### PR TITLE
[TRCL-24]: Fix default config file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ run_id - specifies the Run ID for the Test Run to be created under<br>
 Default configuration file
 --------------------------
 Default configuration file should be named config.yaml or config.yml and be stored in the same directory
-as the trcli executable file.
+as the trcli executable file. Where the executable file was placed can be found by executing `which trcli` on Linux-like
+systems or `where trcli` for Windows.
 
 Custom configuration file
 -------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,7 +109,6 @@ class TestCli:
         [("batch_size", 1000), ("timeout", 160)],
         ids=["batch_size", "timeout"],
     )
-    @pytest.mark.test123
     def test_check_custom_config_overrides_defaults(
         self, argument_name, argument_value, mocker, cli_resources
     ):
@@ -124,7 +123,6 @@ class TestCli:
         with cli_runner.isolated_filesystem():
             with open("fake_config_file.yaml", "w+") as f:
                 f.write(f"{argument_name}: {argument_value}")
-            trcli.cli.trcli_folder = Path("fake_config_file.yaml").parent
             setattr_mock = mocker.patch("trcli.cli.setattr")
             _ = cli_runner.invoke(cli, args)
 
@@ -185,13 +183,12 @@ class TestCli:
         parameters"""
         cli_agrs_helper, cli_runner = cli_resources
         args = cli_agrs_helper.get_all_required_parameters()
-
         mocker.patch("sys.argv", ["trcli", *args])
 
         with cli_runner.isolated_filesystem():
             with open("config.yaml", "w+") as f:
                 f.write(f"{argument_name}: {argument_value}")
-            trcli.cli.trcli_folder = Path("config.yaml").parent
+
             setattr_mock = mocker.patch("trcli.cli.setattr")
             _ = cli_runner.invoke(cli, args)
 
@@ -212,7 +209,6 @@ class TestCli:
 
         with cli_runner.isolated_filesystem():
             copyfile(default_config_file, "config.yaml")
-            trcli.cli.trcli_folder = Path("config.yaml").parent
             _ = cli_runner.invoke(
                 cli,
                 args,
@@ -237,7 +233,6 @@ class TestCli:
         setattr_mock = mocker.patch("trcli.cli.setattr")
         with cli_runner.isolated_filesystem():
             copyfile(default_config_file, "config.yaml")
-            trcli.cli.trcli_folder = Path("config.yaml").parent
             _ = cli_runner.invoke(cli, tool_args)
 
         expected = cli_agrs_helper.get_required_parameters_without_command_no_dashes()

--- a/tests/test_load_data_from_config.py
+++ b/tests/test_load_data_from_config.py
@@ -29,6 +29,7 @@ def load_config_resources(mocker):
     environment = Environment()
     environment.verbose = True
     stdout_mock = mocker.patch("sys.stdout", new_callable=io.StringIO)
+    mocker.patch("sys.argv", ["trcli"])
     yield environment, stdout_mock
 
 
@@ -77,7 +78,6 @@ class TestLoadDataFromConfig:
         with runner.isolated_filesystem():
             copyfile(config_file, "config.yaml")
             copyfile(correct_config_file_path, "custom_config.yaml")
-            trcli.cli.trcli_folder = Path("config.yaml").parent
             environment.parse_config_file(context)
         check_parsed_data(correct_yaml_expected_result, environment.params_from_config)
         check_verbose_message(expected_verbose_message, stdout_mock.getvalue())
@@ -102,7 +102,6 @@ class TestLoadDataFromConfig:
         runner = CliRunner()
         with runner.isolated_filesystem():
             copyfile(correct_config_file_path, config_name)
-            trcli.cli.trcli_folder = Path(config_name).parent
             environment.parse_config_file(context)
             expected_verbose_message = ""
         check_parsed_data(correct_yaml_expected_result, environment.params_from_config)
@@ -183,7 +182,6 @@ class TestLoadDataFromConfig:
         with runner.isolated_filesystem():
             copyfile(correct_config_file_path_with_custom_config_path, "config.yaml")
             copyfile(correct_config_file_loop_check_path, "custom_config.yaml")
-            trcli.cli.trcli_folder = Path("config.yaml").parent
             environment.parse_config_file(context)
         check_parsed_data(yaml_expected_results, environment.params_from_config)
         check_verbose_message(expected_verbose_message, stdout_mock.getvalue())

--- a/trcli/cli.py
+++ b/trcli/cli.py
@@ -103,14 +103,16 @@ class Environment:
 
     def parse_config_file(self, context: click.Context):
         """Sets config file path from context and information if default or custom config file should be used."""
+        executable_folder = Path(sys.argv[0]).parent
+
         if context.params["config"]:
             self.config = context.params["config"]
             self.default_config_file = False
         else:
-            if Path(trcli_folder / "config.yml").is_file():
-                self.config = trcli_folder / "config.yml"
-            elif Path(trcli_folder / "config.yaml").is_file():
-                self.config = trcli_folder / "config.yaml"
+            if Path(executable_folder / "config.yml").is_file():
+                self.config = executable_folder / "config.yml"
+            elif Path(executable_folder / "config.yaml").is_file():
+                self.config = executable_folder / "config.yaml"
             else:
                 self.config = None
         if self.config:


### PR DESCRIPTION
Default config file is taken from place where the source file of trcli
is placed. After this commit it would be taken from the same location
the executable file is placed.