### PR TITLE
Fix legacy projects response

### DIFF
--- a/tests/test_api_request_handler.py
+++ b/tests/test_api_request_handler.py
@@ -96,6 +96,21 @@ class TestApiRequestHandler:
         ), "Get project should return proper project data object"
 
     @pytest.mark.api_handler
+    def test_return_project_legacy_response(
+        self, api_request_handler: ApiRequestHandler, requests_mock
+    ):
+        mocked_response = [
+            {"id": 1, "name": "DataHub", "suite_mode": 1},
+            {"id": 2, "name": "Test Project", "suite_mode": 1},
+            {"id": 3, "name": "DataHub", "suite_mode": 1},
+        ]
+
+        requests_mock.get(create_url("get_projects"), json=mocked_response)
+        assert api_request_handler.get_project_id("Test Project") == ProjectData(
+            project_id=2, suite_mode=1, error_message=""
+        ), "Get project should return proper project data object"
+
+    @pytest.mark.api_handler
     def test_check_suite_exists(
         self, api_request_handler: ApiRequestHandler, requests_mock
     ):

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -70,11 +70,17 @@ class ApiRequestHandler:
         """
         response = self.client.send_get("get_projects")
         if not response.error_message:
+            if isinstance(response.response_text, dict):
+                projects_data = response.response_text["projects"]
+            else:
+                projects_data = response.response_text
+
             available_projects = [
                 project
-                for project in response.response_text["projects"]
+                for project in projects_data
                 if project["name"] == project_name
             ]
+
             if len(available_projects) == 1:
                 return ProjectData(
                     project_id=int(available_projects[0]["id"]),

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -70,9 +70,9 @@ class ApiRequestHandler:
         """
         response = self.client.send_get("get_projects")
         if not response.error_message:
-            if isinstance(response.response_text, dict):
+            if isinstance(response.response_text, dict):  # Endpoints with pagination
                 projects_data = response.response_text["projects"]
-            else:
+            else:  # Endpoints without pagination (legacy)
                 projects_data = response.response_text
 
             available_projects = [
@@ -557,6 +557,10 @@ class ApiRequestHandler:
         else:
             response = self.client.send_get(link.replace(self.suffix, ""))
         if not response.error_message:
+            # Endpoints without pagination (legacy)
+            if isinstance(response.response_text, list):
+                return response.response_text, response.error_message
+            # Endpoints with pagination
             entities = entities + response.response_text[entity]
             if response.response_text["_links"]["next"] is not None:
                 return self.__get_all_entities(entity, link=response.response_text["_links"]["next"], entities=entities)


### PR DESCRIPTION
<!-- 
Thanks for contributing!
PLEASE:
- Read our contributing guidelines: https://github.com/gurock/trcli/blob/main/CONTRIBUTING.md
- Mark this PR as "Draft" if it is not ready for review.
-->

## Issue being resolved: https://github.com/gurock/trcli/issues/76

### Solution description
How are we solving the problem?
- Checking whether the responses return a list or a dictionary

### Changes
What changes where made?
- Support for legacy list responses for
  - `get_project_id`
  - `__get_all_entities`

### Potential impacts
What could potentially be affected by the implemented changes? 
- None

### Steps to test
- Import any results file on latest TestRail version
- Import any result file on legacy TestRail version (tested on 7.0.2.1016)

### PR Tasks
- [x] PR reference added to issue
- [x] README updated
- [x] Unit tests added/updated
