### PR TITLE
Added handling for elapsed time in milliseconds

### DIFF
--- a/tests/test_data/json/no_root.json
+++ b/tests/test_data/json/no_root.json
@@ -16,7 +16,7 @@
                                   "result": {"assignedto_id": null,
                                              "comment": "",
                                              "defects": null,
-                                             "elapsed": null,
+                                             "elapsed": "50ms",
                                              "junit_result_unparsed": [],
                                              "status_id": 1,
                                              "case_id": null,

--- a/tests/test_junit_parser.py
+++ b/tests/test_junit_parser.py
@@ -29,11 +29,16 @@ class TestJunitParser:
                 Path(__file__).parent / "test_data/XML/required_only.xml",
                 Path(__file__).parent / "test_data/json/required_only.json",
             ),
+            (
+                Path(__file__).parent / "test_data/XML/elapsed.xml",
+                Path(__file__).parent / "test_data/json/elapsed.json",
+            ),
         ],
         ids=[
             "XML without testsuites root",
             "XML with testsuites root",
             "XML with no data",
+            "XML with different time units",
         ],
     )
     @pytest.mark.parse_junit

--- a/trcli/data_classes/dataclass_testrail.py
+++ b/trcli/data_classes/dataclass_testrail.py
@@ -66,12 +66,13 @@ class TestRailResult:
         try:
             # If elapsed is less than 1 convert it to milliseconds
             # Anything lower than 1 millisecond will be omitted
-            if float(elapsed) < 1:
-                rounded_ms = round(float(elapsed) * 1000)
-                return f"{rounded_ms}ms" if rounded_ms > 0 else None
+            elapsed = float(elapsed)
+            if elapsed >= 1:
+                return f"{round(elapsed)}s"
+            elif elapsed >= 0.001:
+                return f"{round(elapsed * 1000)}ms"
             else:
-                rounded_secs = round(float(elapsed))
-                return f"{rounded_secs}s" if rounded_secs > 0 else None
+                return None
 
         except ValueError:
             # unable to parse time format

--- a/trcli/data_classes/dataclass_testrail.py
+++ b/trcli/data_classes/dataclass_testrail.py
@@ -5,6 +5,7 @@ from time import gmtime, strftime
 from trcli.data_classes.validation_exception import ValidationException
 
 
+
 @serialize
 @deserialize
 @dataclass
@@ -63,8 +64,15 @@ class TestRailResult:
     @staticmethod
     def proper_format_for_elapsed(elapsed):
         try:
-            rounded_secs = round(float(elapsed))
-            return f"{rounded_secs}s" if rounded_secs > 0 else None
+            # If elapsed is less than 1 convert it to milliseconds
+            # Anything lower than 1 millisecond will be omitted
+            if float(elapsed) < 1:
+                rounded_ms = round(float(elapsed) * 1000)
+                return f"{rounded_ms}ms" if rounded_ms > 0 else None
+            else:
+                rounded_secs = round(float(elapsed))
+                return f"{rounded_secs}s" if rounded_secs > 0 else None
+
         except ValueError:
             # unable to parse time format
             return None


### PR DESCRIPTION
<!-- 
Thanks for contributing!
PLEASE:
- Read our contributing guidelines: https://github.com/gurock/trcli/blob/main/CONTRIBUTING.md
- Mark this PR as "Draft" if it is not ready for review.
-->

## Issue being resolved: https://github.com/gurock/trcli/issues/95

### Solution description

If a test time is less than 1 second it is rounded to the nearest millisecond. Anything less than 1 millisecond is still omitted.


### Changes

test estimates will now be in `s` or `ms` based on the time provided in the junit xml.

### Potential impacts

Any existing tests reporting time under 1 second will start to see times posted in testrail. While I see this as a bug, others may have usecases where this is unexpected as they have worked with the current behavior.

### Steps to test

Upload any junit with a time < ".5" and confirm the test is uploaded with the estimate in `ms`

### PR Tasks
- [x] PR reference added to issue
- [x] README updated (nothing to update)
- [x] Unit tests added/updated
