### PR TITLE
Allow custom result fields - passed up on results for cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Options:
   --case-fields       List of case fields and values for new test cases
                       creation. Usage: --case-fields type_id:1 --case-fields
                       priority_id:3
+  --result-fields     List of result fields and values for test results
+                      creation. Usage: --result-fields custom_environment:2 
   --help              Show this message and exit.
 ```
 
@@ -253,6 +255,7 @@ Possible fields:<br>
 | run_id                 | specifies the Run ID for the Test Run to be created under                                                                                 |
 | close_run              | specifies whether to close the run after adding all the results (false by default)                                                        |
 | case_fields            | dictionary with case fields to be filled on case creation as a key value pair                                                             |
+| result_fields          | dictionary with result fields to be filled on results creation as a key value pair                                                        |
 | run_description        | text to be added to the run description (for example, if you want to add the link to your CI job)                                         |
 
 Below is an example of a sample configuration file for the TestRail CLI.

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -38,7 +38,7 @@ class ApiRequestHandler:
         self.environment = environment
         self.client = api_client
         self.suffix = api_client.VERSION
-        self.data_provider = ApiDataProvider(suites_data, environment.case_fields, environment.run_description)
+        self.data_provider = ApiDataProvider(suites_data, environment.case_fields, environment.run_description, environment.result_fields)
         self.suites_data_from_provider = self.data_provider.suites_input
         self.response_verifier = ApiResponseVerify(verify)
 

--- a/trcli/cli.py
+++ b/trcli/cli.py
@@ -51,6 +51,7 @@ class Environment:
         self.run_description = None
         self.case_matcher = None
         self._case_fields = None
+        self._result_fields = None
 
     @property
     def case_fields(self):
@@ -69,6 +70,24 @@ class Environment:
             self.elog(f"Invalid case fields type ({type(case_fields)}), supported types are tuple/list/dictionary.")
             exit(1)
         self._case_fields = fields_dictionary
+
+    @property 
+    def result_fields(self):
+        return self._result_fields
+
+    @result_fields.setter
+    def result_fields(self, result_fields: Union[List[str], dict]):
+        fields_dictionary = {}
+        if isinstance(result_fields, list) or isinstance(result_fields, tuple):
+            for result_field in result_fields:
+                field, value = result_field.split(":", maxsplit=1)
+                fields_dictionary[field] = value
+        elif isinstance(result_fields, dict):
+            fields_dictionary = result_fields
+        else:
+            self.elog(f"Invalid result fields type ({type(result_fields)}), supported types are tuple/list/dictionary.")
+            exit(1)
+        self._result_fields = fields_dictionary
 
     def log(self, msg: str, new_line=True, *args):
         """Logs a message to stdout only is silent mode is disabled."""

--- a/trcli/commands/cmd_parse_junit.py
+++ b/trcli/commands/cmd_parse_junit.py
@@ -50,6 +50,14 @@ def print_config(env: Environment):
     help="List of case fields and values for new test cases creation. "
          "Usage: --case-fields type_id:1 --case-fields priority_id:3",
 )
+@click.option(
+    "--result-fields",
+    multiple=True,
+    metavar="",
+    default=[],
+    help="List of result fields and values for test results creation. "
+         "Usage: --result-fields custom_type_id:1 --result-fields custom_priority_id:3",
+)
 @click.pass_context
 @pass_environment
 def cli(environment: Environment, context: click.Context, *args, **kwargs):


### PR DESCRIPTION
<!-- 
Thanks for contributing!
PLEASE:
- Read our contributing guidelines: https://github.com/gurock/trcli/blob/main/CONTRIBUTING.md
- Mark this PR as "Draft" if it is not ready for review.
-->

## Issue being resolved: https://github.com/gurock/trcli/issues/106

### Solution description
When posting test case results back to TestRail there are often times where we want to pass up custom fields to populate. This adds the ability to set those custom results

### Changes
Adds a new `--result-fields` property to the `parse_junit` command similar to how `--case-fields` works. If added, these will get applied to the `add_results_for_cases` api call.

In the below example 
```
trcli -y -v \
...
parse_junit \
--run-id 146 \
--suite-id 33 \
--result-fields custom_env:1 \
--file report.junit
```
adds in the `custom_env` property to the call: 

```
url: https://xxx/index.php?/api/v2/add_results_for_cases/146
payload: {'results': [{'case_id': 61, 'status_id': 1, 'comment': '', 'elapsed': '1s', 'attachments': [], 'custom_env': '1'}, {'case_id': 147, 'status_id': 5, 'comment': 'Type: \nMessage: failed - Error starting virtual visit invalidRequest(message: "Invalid data sent")\nText: \n        baseIntegrationTests.swift:412\n      ', 'attachments': [], 'custom_env': '1'}, {'case_id': 142, 'status_id': 1, 'comment': '', 'elapsed': '6s', 'attachments': [], 'custom_env': '1'}]}
response status code: 200
```

### Steps to test
Add a `--result-fields custom_env:1` to the call including a `-v` to see the new property being added to the `add_results_for_cases` api call.

### PR Tasks
- [x] PR reference added to issue
- [x] README updated
- [ ] Unit tests added/updated
