### PR TITLE
Add --case-matcher name_skip_unknown option

### DIFF
--- a/trcli/commands/cmd_parse_junit.py
+++ b/trcli/commands/cmd_parse_junit.py
@@ -31,7 +31,7 @@ def print_config(env: Environment):
     "--case-matcher",
     metavar="",
     default="auto",
-    type=click.Choice(["auto", "name", "property"], case_sensitive=False),
+    type=click.Choice(["auto", "name", "property", "name_skip_unknown"], case_sensitive=False),
     help="Mechanism to match cases between the JUnit report and TestRail."
 )
 @click.option(

--- a/trcli/data_classes/data_parsers.py
+++ b/trcli/data_classes/data_parsers.py
@@ -7,6 +7,7 @@ class MatchersParser:
     AUTO = "auto"
     NAME = "name"
     PROPERTY = "property"
+    NAME_SKIP_UNKNOWN = "name_skip_unknown"
 
     @staticmethod
     def parse_name_with_id(case_name: str) -> (int, str):

--- a/trcli/readers/junit_xml.py
+++ b/trcli/readers/junit_xml.py
@@ -95,6 +95,8 @@ class JunitParser(FileParser):
                     automation_id = f"{case.classname}.{case_name}"
                     if self.case_matcher == MatchersParser.NAME:
                         case_id, case_name = MatchersParser.parse_name_with_id(case_name)
+                    elif self.case_matcher == MatchersParser.NAME_SKIP_UNKNOWN:
+                        _, case_name = MatchersParser.parse_name_with_id(case_name)
                     for case_props in case.iterchildren(Properties):
                         for prop in case_props.iterchildren(Property):
                             if prop.name and self.case_matcher == MatchersParser.PROPERTY and prop.name == "test_id":


### PR DESCRIPTION
## Issue being resolved: https://github.com/gurock/trcli/issues/N

### Solution description
How are we solving the problem?
    When attempting to add test results from the junit.xml file, if one of the test names includes an invalid or unknown case ID (CXXX) that is not present in TestRail's test suite under the specified test run, the --case-matcher name command cannot be used. In such a situation, the command will abort and display the message "Case CXXX is unknown or not part of the test run." Therefore, I have created a new case-matcher specifically designed for this situation.

### Changes
What changes were made?
1. in trcli\api\api_request_handler.py, I added new condition `elif self.environment.case_matcher == MatchersParser.NAME_SKIP_UNKNOWN:`
2. in trcli/commands/cmd_parse_junit.py, I added `type=click. Choice(["auto", "name", "property", "name_skip_unknown"], case_sensitive=False),`
3. in trcli/data_classes/data_parsers.py, I added  `NAME_SKIP_UNKNOWN = "name_skip_unknown`"
4. in trcli/readers/junit_xml.py, I added new condition `elif self.case_matcher == MatchersParser.NAME_SKIP_UNKNOWN:`

### Potential impacts
What could potentially be affected by the implemented changes? 

### Steps to test
Happy path to test implemented scenario
1. Create a test run that includes a single test suite.
5. Within the test suite, include two test cases.
6. Update the junit.xml file to include the names of the two tests.
7. Ensure that one of the test names in the junit.xml file matches the test name specified in the test suite.

### PR Tasks
- [ ] PR reference added to issue
- [ ] README updated
- [ ] Unit tests added/updated
