### PR TITLE
Multiple report files support

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -6,9 +6,11 @@ name: build
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
-    branches: [ main ]
+    branches:
+      - '*'
 
 permissions:
   contents: read
@@ -30,4 +32,21 @@ jobs:
         pip install -r tests/requirements.txt
     - name: Test with pytest
       run: |
-        pytest -c ./tests/pytest.ini -W ignore::pytest.PytestCollectionWarning
+        coverage run -m pytest \
+          -c ./tests/pytest.ini \
+          -W ignore::pytest.PytestCollectionWarning \
+          --md-report --md-report-output=report.md --md-report-color=never \
+          tests || pytest_exit_code=$?
+        echo "## :clipboard: Test Results" >> $GITHUB_STEP_SUMMARY
+        cat report.md >> $GITHUB_STEP_SUMMARY
+        echo "## :bar_chart: Code coverage" >> $GITHUB_STEP_SUMMARY
+        coverage report --format markdown >> $GITHUB_STEP_SUMMARY
+        if [[ "$(coverage report --format total)" -lt 80 ]]
+        then
+          echo "::error::Code coverage is less than 80%" && exit_code=1
+        fi
+        if [[ $pytest_exit_code -gt 0 ]]
+        then
+          echo "::error::Unit tests failed" && exit_code=1
+        fi
+        exit $exit_code

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,6 @@
 pytest
+pytest-md-report
+coverage
 allure-pytest
 pytest-freezegun
 pytest-mock

--- a/trcli/cli.py
+++ b/trcli/cli.py
@@ -230,6 +230,10 @@ class TRCLI(click.MultiCommand):
             return
         return mod.cli
 
+    def main(self, *args, **kwargs):
+        """Overriding to disable automatic glob patterns expansion"""
+        return super().main(windows_expand_args=False, *args, **kwargs)
+
 
 @click.command(cls=TRCLI, context_settings=CONTEXT_SETTINGS)
 @click.pass_context

--- a/trcli/readers/file_parser.py
+++ b/trcli/readers/file_parser.py
@@ -12,16 +12,16 @@ class FileParser:
     """
 
     def __init__(self, environment: Environment):
-        filepath = environment.file
-        self.filepath = filepath
-        self.check_file(filepath)
-        self.filename = Path(filepath).name
+        self.filepath = self.check_file(environment.file)
+        self.filename = self.filepath.name
         self.env = environment
 
     @staticmethod
-    def check_file(filepath: Union[str, Path]):
-        if not Path(filepath).is_file():
+    def check_file(filepath: Union[str, Path]) -> Path:
+        filepath = Path(filepath)
+        if not filepath.is_file():
             raise FileNotFoundError("File not found.")
+        return filepath
 
     @abstractmethod
     def parse_file(self) -> list[TestRailSuite]:

--- a/trcli/readers/junit_xml.py
+++ b/trcli/readers/junit_xml.py
@@ -1,3 +1,4 @@
+import glob
 from pathlib import Path
 from typing import Union
 from unittest import TestCase, TestSuite
@@ -54,6 +55,25 @@ class JunitParser(FileParser):
             return etree.ElementTree(new_root)
         else:
             raise JUnitXmlError("Invalid format.")
+
+    @staticmethod
+    def check_file(filepath: Union[str, Path]) -> Path:
+        filepath = Path(filepath)
+        files = glob.glob(str(filepath))
+        if not files:
+            raise FileNotFoundError("File not found.")
+        elif len(files) == 1:
+            return filepath
+        sub_suites = []
+        for file in files:
+            suite = JUnitXml.fromfile(file)
+            sub_suites.append(suite)
+        suite = sub_suites.pop(0)
+        for sub_suite in sub_suites:
+            suite += sub_suite
+        merged_report_path = Path().cwd().joinpath("Merged-JUnit-report.xml")
+        suite.write(merged_report_path)
+        return merged_report_path
 
     def parse_file(self) -> list[TestRailSuite]:
         self.env.log(f"Parsing JUnit report.")

--- a/trcli/readers/openapi_yml.py
+++ b/trcli/readers/openapi_yml.py
@@ -190,7 +190,7 @@ class OpenApiParser(FileParser):
         return [test_suite]
 
     def resolve_openapi_spec(self) -> dict:
-        spec_path = Path(self.filepath)
+        spec_path = self.filepath
         unresolved_spec_dict, spec_url = read_from_filename(str(spec_path.absolute()))
         parser = ResolvingParser(spec_string=json.dumps(unresolved_spec_dict), backend='openapi-spec-validator')
         spec_dictionary = parser.specification


### PR DESCRIPTION
<!-- 
Thanks for contributing!
PLEASE:
- Read our contributing guidelines: https://github.com/gurock/trcli/blob/main/CONTRIBUTING.md
- Mark this PR as "Draft" if it is not ready for review.
-->

## Implement glob support for multiple report files

### Solution description
Using glob expressions such as `*/**.xml` will make the CLI merge all matching JUnit files
