### PR TITLE
[XML] Tests cases with multiple test ids present gets copied

### DIFF
--- a/trcli/readers/junit_xml.py
+++ b/trcli/readers/junit_xml.py
@@ -95,7 +95,6 @@ class JunitParser(FileParser):
             cases_count = 0
             test_sections = []
             processed_section_properties = []
-            copies = []
             for section in suite:
                 if not len(section):
                     continue
@@ -115,6 +114,7 @@ class JunitParser(FileParser):
                     comments = []
                     result_steps = []
                     sauce_session = None
+                    copies = []
                     automation_id = f"{case.classname}.{case_name}"
                     if self.case_matcher == MatchersParser.NAME:
                         case_id, case_name = MatchersParser.parse_name_with_id(case_name)
@@ -122,10 +122,10 @@ class JunitParser(FileParser):
                         for prop in case_props.iterchildren(Property):
                             if prop.name and self.case_matcher == MatchersParser.PROPERTY and prop.name == "test_id":
                                 parsed_case_id = int(prop.value.lower().replace("c", "")) 
-                                if case_id is not None:
-                                   copies.append(parsed_case_id)
-                                   continue
-                                case_id = parsed_case_id 
+                                if case_id is None:
+                                    case_id = parsed_case_id 
+                                else:
+                                    copies.append(parsed_case_id)
                             if prop.name and prop.name.startswith("testrail_result_step"):
                                 status, step = prop.value.split(':', maxsplit=1)
                                 step = TestRailSeparatedStep(step.strip())


### PR DESCRIPTION
In testcases where multiple properties has the `test_id` name, only the last value is persisted, which results in only one test being submitted and the previous ones being ignored.

A problematic xml file could be structured as such:

```xml
<testcase>
    <!-- other stuff --> 
    <properties>
	<property name="test_id" value="C576" />
	<property name="test_id" value="C577" />
	<property name="test_id" value="C566" />
    </properties>
</testcase>
```

When a JUnit XML file is ingested by the cli, it is parsed by the `parse_file` method found within `readers/junit_xml.py`. During parsing, each element is iterated over. The parser attempt to extract the `test_id` and then and saves it to a global variable `case_id, this has the downside that when the next element containing a `test_id` name is read, it effectively overwrites the current `case_id`.

## Issue being resolved: https://github.com/gurock/trcli/issues/161

### Solution description

To solve this issue, I've introduced a global `copies`  variable that "follows" the current case, such that it is automatically reset each time a new test case is being parsed. During parsing the parser now checks if the `case_id` is not `None` (indicating that the `case_id was set by another `test_id`). In this event, the `test_id` is added to the `copies` array.

When the test case is done being parsed and is added to the list of tests cases (`test_cases` variable), the copies are iterated over and each create a deep copy of the current `test_case` instance, alter with their respective case_id and appends it to the list. 

This results in each test_id becoming an independent test and submitted to TestRail as such.

### Changes
Altered `readers/junit_xml.py`:

During parsing, now checks if the case id is already set:
```python
parsed_case_id = int(prop.value.lower().replace("c", "")) 
if case_id is None:
    case_id = parsed_case_id 
else:
    copies.append(parsed_case_id)
```

Added `copy_coplicate_test_cases method`:
```python
def copy_duplicate_test_cases(self, copies, test_cases):
        """Creates a deep copy of the current test case for each test_id present"""
        for case_id in copies:
            case = copy.deepcopy(test_cases[len(test_cases)-1])
            case.case_id = case_id
            case.result.case_id = case_id
            test_cases.append(case)
```

Which is called when the parser is done parsing the case.

### Potential impacts
The code added  should not have any impact as it does alter the flow under the documented scenarioes (i.e. where one test case has one test_id).

All tests also pass.

### Steps to test
Create an a junit test file where one testcase contains more than one test_id property.

### PR Tasks
- [ ] PR reference added to issue
- [ ] README updated
- [ ] Unit tests added/updated
