### PR TITLE
[XML] Failed test cases now take precedence during submission

### DIFF
--- a/tests/test_api_data_provider.py
+++ b/tests/test_api_data_provider.py
@@ -22,6 +22,10 @@ def post_data_provider_single_result_without_id():
 def post_data_provider_duplicated_case_names():
     yield ApiDataProvider(test_input_duplicated_case_names)
 
+@pytest.fixture(scope="function")
+def post_data_provider_overlapping_case_ids_with_failure():
+    yield ApiDataProvider(test_overlapping_case_ids_with_failure)
+
 
 class TestApiDataProvider:
     @pytest.mark.data_provider
@@ -128,3 +132,12 @@ class TestApiDataProvider:
         assert (
             result == expected_result
         ), f"Expected: {expected_result} but got {result} instead."
+
+
+    @pytest.mark.data_provider
+    def test_failure_takes_precedence_when_case_ids_overlap(self, post_data_provider_overlapping_case_ids_with_failure):
+        result = post_data_provider_overlapping_case_ids_with_failure.add_results_for_cases(bulk_size=10)
+        expected_result_status = result[0]["results"][0]["status_id"]
+        assert (
+            expected_result_status == 5
+        ), f"Expected: status code 5 but got {expected_result_status} instead."

--- a/tests/test_data/api_data_provider_test_data.py
+++ b/tests/test_data/api_data_provider_test_data.py
@@ -23,6 +23,12 @@ file_json = open(
 json_string = json.dumps(json.load(file_json))
 test_input_duplicated_case_names = from_json(TestRailSuite, json_string)
 
+file_json = open(
+    Path(__file__).parent / "json/overlapping_case_ids_with_failure.json"
+)
+json_string = json.dumps(json.load(file_json))
+test_overlapping_case_ids_with_failure = from_json(TestRailSuite, json_string)
+
 
 post_suite_bodies = [{"name": "Suite1"}]
 

--- a/tests/test_data/json/overlapping_case_ids_with_failure.json
+++ b/tests/test_data/json/overlapping_case_ids_with_failure.json
@@ -1,0 +1,55 @@
+{
+    "description": null,
+    "name": "Suite1",
+    "suite_id": null,
+    "testsections": [
+        {
+            "name": "Failed test",
+            "suite_id": null,
+            "section_id": null,
+            "testcases": [
+                {
+                    "section_id": null,
+                    "title": "testCase1",
+                    "case_id": 60,
+                    "result": {
+                        "comment": "Type: pytest.skip\\nMessage: Please skip\\nText: skipped by user",
+                        "status_id": 5,
+                        "case_id": 60
+                    }
+                }
+            ],
+            "properties": [
+                {
+                    "description": "logging: True",
+                    "name": "logging",
+                    "value": "True"
+                },
+                {
+                    "description": "debug: False",
+                    "name": "debug",
+                    "value": "False"
+                }
+            ]
+        },
+        {
+            "name": "Passed test",
+            "suite_id": null,
+            "section_id": null,
+            "testcases": [
+                {
+                    "section_id": null,
+                    "title": "testCase2",
+                    "custom_automation_id": "className.testCase2abc",
+                    "case_id": 60,
+                    "time": 400,
+                    "result": {
+                        "comment": "",
+                        "status_id": 1,
+                        "case_id": null
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
In JUnit XML files where multiple test_case ids overlap, TestRail CLI currently reports both of them. This behavior results in only the last being "persisted" on the platform, which is especially problematic, when the first test_id fails and subsequent ones succeeds, as the platform now reports the test as being successful.

In instances where testcase ids collide, TestRail should opt for a pessimistic approach where the negative outcome takes the highest priority.

## Issue being resolved: https://github.com/gurock/trcli/issues/161

### Solution description

During upload, `data_provider/api_data_provider.py` now checks if another tests case is to be submitted with the same `case_id` , if not the test case is added to the list of `bodies.

If the code encounters the same case id, one of two things happen:

1. The current case has a status 5 (failed), subsequent cases are ignored as the outcome is a failure.
2. The current case is not a status 5, subsequent cases are ignored unless a failure is found in which case it overwrites the request for the case id.

This is a very simplistic approach that only takes the `failure` status code into account.

### Changes
A `takes_priority(self, statusId1, statusId2)` method has been added that returns true or false if the first statusId takes priority (is a failure):

```python
def takes_priority(self, statusId1, statusId2):
        """Determines if the first argument takes precendece in cases where an earlier result has failed (5).
        """
        return (statusId1 is 5 and statusId2 is not 5)
```
This method definitely leaves a lot to be desired, and it could be worth looking into creating a more sophisticated way of ordering the different status codes.

Appending a result body has been refactored and extracted to its own method: `append_result_body(self, bodies, case)`

```python
def append_result_body(self, bodies, case):
        """Appends result to bodies. Overlapping case ids are ignored, unless a case has status of 5, in which case
        it overwrites the body."""
        case.result.add_global_result_fields(self.result_fields)

        overlapping_case_index = next(iter([i for i, body in enumerate(bodies) if body['case_id'] == case.case_id]), None)
        if overlapping_case_index is None:
            bodies.append(case.result.to_dict())
            return;

        if self.takes_priority(case.result.status_id, bodies[overlapping_case_index]['status_id']):
            bodies[overlapping_case_index] = case.result.to_dict();
```

It is probably also worth noting that this implementation also does not take into account overlapping test_ids from different files.

### Potential impacts
This change specifically impacts instances where JUnit xml files have repetitions of the same test_id. However, it should not have any impact on other instances.

All tests pass.

### Steps to test

- Create a JUnit xml file
- Create two test cases, one where the first one fails and the second succeeds

### PR Tasks
- [x] PR reference added to issue
- [x] README updated
- [x] Unit tests added/updated
