### PR TITLE
fixes #177, adding workaround for buggy legacy server response

### DIFF
--- a/tests/test_api_request_handler.py
+++ b/tests/test_api_request_handler.py
@@ -122,6 +122,21 @@ class TestApiRequestHandler:
         ), "Get project should return proper project data object"
 
     @pytest.mark.api_handler
+    def test_return_project_legacy_response_with_buggy_authentication_prefix(
+        self, api_request_handler: ApiRequestHandler, requests_mock
+    ):
+        mocked_response = [
+            {"id": 1, "name": "DataHub", "suite_mode": 1},
+            {"id": 2, "name": "Test Project", "suite_mode": 1},
+            {"id": 3, "name": "DataHub", "suite_mode": 1},
+        ]
+
+        requests_mock.get(create_url("get_projects"), text=f"USER AUTHENTICATION SUCCESSFUL!\n"+json.dumps(mocked_response))
+        assert api_request_handler.get_project_data("Test Project") == ProjectData(
+            project_id=2, suite_mode=1, error_message=""
+        ), "Get project should return proper project data object"
+
+    @pytest.mark.api_handler
     def test_check_suite_exists(
         self, api_request_handler: ApiRequestHandler, requests_mock
     ):

--- a/trcli/api/api_client.py
+++ b/trcli/api/api_client.py
@@ -132,7 +132,12 @@ class APIClient:
                     retry_time = float(response.headers["Retry-After"])
                     sleep(retry_time)
                 try:
-                    response_text = response.json()
+                    # workaround for buggy legacy TR server version response
+                    if response.content.startswith(b"USER AUTHENTICATION SUCCESSFUL!\n"):
+                        response_text = response.content.replace(b"USER AUTHENTICATION SUCCESSFUL!\n", b"", 1)
+                        response_text = json.loads(response_text)
+                    else:
+                        response_text = response.json()
                     error_message = response_text.get("error", "")
                 except (JSONDecodeError, ValueError):
                     response_text = str(response.content)


### PR DESCRIPTION
<!-- 
Thanks for contributing!
PLEASE:
- Read our contributing guidelines: https://github.com/gurock/trcli/blob/main/CONTRIBUTING.md
- Mark this PR as "Draft" if it is not ready for review.
-->

## Issue being resolved: https://github.com/gurock/trcli/issues/177

### Solution description
remove auth string from content, if exists, and then parse the JSON content afterwards

### Changes
added workaround to remove buggy auth string on the body of legacy TR server versions.

### Potential impacts
N/A

### Steps to test
Happy path to test implemented scenario

### PR Tasks
- [x] PR reference added to issue
- [x] README updated
- [x] Unit tests added/updated
