### PR TITLE
[XML] Fix parsing of testrail_case_field with empty xml but value present

### DIFF
--- a/tests/test_data/XML/root.xml
+++ b/tests/test_data/XML/root.xml
@@ -19,6 +19,8 @@
 2. Second step
 3. Third step]]>
     </property>
+    <property name="testrail_case_field" value="test_empty_value:another_case_val">
+    </property>
 </properties>
 <skipped type="pytest.skip" message="Please skip">skipped by user</skipped>
 </testcase>

--- a/tests/test_data/json/root.json
+++ b/tests/test_data/json/root.json
@@ -57,7 +57,8 @@
                     "title": "test_testrail_test_suite",
                     "case_fields": {
                         "custom_case_field": "custom_case_val",
-                        "custom_steps": "1. First step\n2. Second step\n3. Third step"
+                        "custom_steps": "1. First step\n2. Second step\n3. Third step",
+                        "test_empty_value": "another_case_val"
                     },
                     "type_id": null
                 },

--- a/trcli/readers/junit_xml.py
+++ b/trcli/readers/junit_xml.py
@@ -138,7 +138,7 @@ class JunitParser(FileParser):
                             if prop.name and prop.name.startswith("testrail_result_comment"):
                                 comments.append(prop.value)
                             if prop.name and prop.name.startswith("testrail_case_field"):
-                                if prop._elem.text is not None:
+                                if prop._elem.text is not None and prop._elem.text.strip() != "":
                                     case_fields.append(prop._elem.text.strip())
                                 else:
                                     case_fields.append(prop.value)


### PR DESCRIPTION
## Issue being resolved: https://github.com/gurock/trcli/issues/217

### Solution description
When the property named `testrail_case_field` has a text node but it's empty just use the value.

### Changes
- Added a new test case
- Added a new check to decide to use the XML node's text or the value.

### Potential impacts
If some XML is providing values on both text and value, the text will be used first.

### Steps to test
Already added to fixtures.

Failing tests before fix: https://github.com/gurock/trcli/actions/runs/8205303102

### PR Tasks
- [x] PR reference added to issue
- [ ] README updated
- [x] Unit tests added/updated
