### PR TITLE
fixed the character limit issue for custom_automation_id

### DIFF
--- a/trcli/data_classes/dataclass_testrail.py
+++ b/trcli/data_classes/dataclass_testrail.py
@@ -153,6 +153,7 @@ class TestRailCase:
             )
         if self.custom_automation_id:
             self.custom_automation_id = self.custom_automation_id.strip()
+            self.custom_automation_id = self.custom_automation_id[:128]
 
     def add_global_case_fields(self, case_fields: dict) -> None:
         """Add global case fields without overriding the existing case-specific fields


### PR DESCRIPTION
<!-- 
Thanks for contributing!
PLEASE:
- Read our contributing guidelines: https://github.com/gurock/trcli/blob/main/CONTRIBUTING.md
- Mark this PR as "Draft" if it is not ready for review.
-->

## Issue being resolved: 
Testrail String data type doesn't accept more than 250 characters so trimmed the custom_automation_id to 128 chars

### Solution description
By trimming the value to 128 characters

### Changes
What changes where made?
Just added a line to trim the custom_automation_id to 128 characters

### Potential impacts
What could potentially be affected by the implemented changes? 

### Steps to test
Happy path to test implemented scenario

### PR Tasks
- [ ] PR reference added to issue
- [ ] README updated
- [ ] Unit tests added/updated
