### PR TITLE
Add add_run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The TestRail CLI currently supports:
 - **Uploading automated test results from JUnit reports**
 - **Uploading automated test results from Robot Framework reports**
 - **Auto-generating test cases from OpenAPI specifications**
+- **Creating new test runs for results to be uploaded to.**
 
 To see further documentation about the TestRail CLI, please refer to the 
 [TestRail CLI documentation pages](https://support.gurock.com/hc/en-us/articles/7146548750868-TestRail-CLI)
@@ -73,6 +74,7 @@ Commands:
   parse_junit    Parse JUnit report and upload results to TestRail
   parse_openapi  Parse OpenAPI spec and create cases in TestRail
   parse_robot    Parse Robot Framework report and upload results to TestRail
+  add_run        Create a new test run (useful for CI/CD flows prior to parsing results)
 ```
 
 Uploading automated test results
@@ -244,6 +246,43 @@ the `--special-parser saucectl` command line option.
 
 Please refer to the [SauceLabs and saucectl reports](https://support.gurock.com/hc/en-us/articles/12719558686484)
 documentation for further information.
+
+#### Creating new test runs
+
+When a test run MUST created before using one of the parse commands, use the `add_run` command. For example, if
+tests are run across parallel, independent test nodes, all nodes should report their results into the same test run.
+Use the `add_run` command to create a new run. Then pass the run title and id to each of the test nodes, which can then
+be used to upload all results into the same test run.
+
+### Reference
+```shell
+$ trcli add_run --help
+TestRail CLI v1.9.5
+Copyright 2024 Gurock Software GmbH - www.gurock.com
+Usage: trcli add_run [OPTIONS]
+
+Options:
+  --title                Title of Test Run to be created or updated in
+                         TestRail.
+  --suite-id             Suite ID to submit results to.  [x>=1]
+  --run-description      Summary text to be added to the test run.
+  --milestone-id         Milestone ID to which the Test Run should be
+                         associated to.  [x>=1]
+  --run-assigned-to-id   The ID of the user the test run should be assigned
+                         to.  [x>=1]
+  --include-all
+  --case-ids             Comma separated list of test case IDs to include in
+                         the test run.
+  --run-refs             A comma-separated list of references/requirements
+  -f, --file             Filename and path.
+  --help                 Show this message and exit.
+```
+
+If the file parameter is used, the run title and id are written to the file each on their own line. Example:
+```text
+Run Title
+1
+```
 
 Generating test cases from OpenAPI specs
 -----------------

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Supported and loaded modules:
     - parse_junit: JUnit XML Files (& Similar)
     - parse_robot: Robot Framework XML Files
     - parse_openapi: OpenAPI YML Files
+    - add_run: Create a new empty test run
 ```
 
 CLI general reference
@@ -251,8 +252,8 @@ documentation for further information.
 
 When a test run MUST created before using one of the parse commands, use the `add_run` command. For example, if
 tests are run across parallel, independent test nodes, all nodes should report their results into the same test run.
-Use the `add_run` command to create a new run. Then pass the run title and id to each of the test nodes, which can then
-be used to upload all results into the same test run.
+First, use the `add_run` command to create a new run; then, pass the run title and id to each of the test nodes, which
+will be used to upload all results into the same test run.
 
 ### Reference
 ```shell
@@ -274,15 +275,17 @@ Options:
   --case-ids             Comma separated list of test case IDs to include in
                          the test run.
   --run-refs             A comma-separated list of references/requirements
-  -f, --file             Filename and path.
+  -f, --file             Write run title and id to file.
   --help                 Show this message and exit.
 ```
 
-If the file parameter is used, the run title and id are written to the file each on their own line. Example:
+If the file parameter is used, the run title and id are written to the file in yaml format. Example:
 ```text
-Run Title
-1
+title: Run Title
+run_id: 1
 ```
+
+This file can be used as the config file (or appended to an existing config file) in a later run.
 
 Generating test cases from OpenAPI specs
 -----------------

--- a/tests/test_api_data_provider.py
+++ b/tests/test_api_data_provider.py
@@ -83,6 +83,24 @@ class TestApiDataProvider:
         ), "Adding run data doesn't match expected body"
 
     @pytest.mark.data_provider
+    def test_post_run_all_args(self, post_data_provider):
+        """Check body for adding run"""
+        suite_updater = [
+            {
+                "suite_id": 123,
+            }
+        ]
+        post_data_provider.update_data(suite_data=suite_updater)
+        assert (
+                post_data_provider.add_run(
+                    "test run",
+                    assigned_to_id=1,
+                    include_all=True,
+                    refs="SAN-1, SAN-2"
+                ) == post_run_full_body
+        ), "Adding run full data doesn't match expected body"
+
+    @pytest.mark.data_provider
     def test_post_results_for_cases(self, post_data_provider):
         """Check body for adding results"""
         case_updater = [

--- a/tests/test_cmd_add_run.py
+++ b/tests/test_cmd_add_run.py
@@ -1,0 +1,22 @@
+from unittest import mock
+
+from trcli.cli import Environment
+from trcli.commands import cmd_add_run
+
+
+class TestCmdAddRun:
+    @mock.patch("builtins.open", new_callable=mock.mock_open)
+    def test_write_run_to_file(self, mock_open_file):
+        """The purpose of this test is to check that calling the write_run_to_file method
+        writes the correct yaml file."""
+        title = "Test run 1"
+        run_id = 1
+        file = "/fake/path/out.yaml"
+        environment = Environment(cmd="add_run")
+        environment.title = title
+        environment.file = file
+        expected_string = f"run_id: {run_id}\ntitle: {title}\n"
+
+        cmd_add_run.write_run_to_file(environment, run_id)
+        mock_open_file.assert_called_with(file, "w")
+        mock_open_file.return_value.__enter__().write.assert_called_once_with(expected_string)

--- a/tests/test_data/api_data_provider_test_data.py
+++ b/tests/test_data/api_data_provider_test_data.py
@@ -40,8 +40,18 @@ post_run_bodies = {
     "name": "test run",
     "suite_id": 123,
     "case_ids": [60, 4],
-    "include_all": False,
     "milestone_id": None
+}
+
+post_run_full_body = {
+    "description": "logging: True\ndebug: False",
+    "name": "test run",
+    "suite_id": 123,
+    "case_ids": [60, 4],
+    "milestone_id": None,
+    "assignedto_id": 1,
+    "include_all": True,
+    "refs": "SAN-1, SAN-2"
 }
 
 post_results_for_cases_body = [

--- a/tests/test_data/cli_test_data.py
+++ b/tests/test_data/cli_test_data.py
@@ -65,6 +65,7 @@ RETURN_VALUE_FROM_CUSTOM_CONFIG_FILE = {
 trcli_description = ('Supported and loaded modules:\n'
                      '    - parse_junit: JUnit XML Files (& Similar)\n'
                      '    - parse_robot: Robot Framework XML Files\n'
-                     '    - parse_openapi: OpenAPI YML Files\n')
+                     '    - parse_openapi: OpenAPI YML Files\n'
+                     '    - add_run: Create a new test run\n')
 
 trcli_help_description = "TestRail CLI"

--- a/tests/test_data/project_based_client_test_data.py
+++ b/tests/test_data/project_based_client_test_data.py
@@ -1,0 +1,32 @@
+from trcli.constants import FAULT_MAPPING
+
+TEST_GET_SUITE_ID_PROMPTS_USER_TEST_DATA = [
+    (True, 10, 1, "Adding missing suites to project Fake project name.", False),
+    (True, 10, -1, "Adding missing suites to project Fake project name.", True),
+    (False, -1, -1, FAULT_MAPPING["no_user_agreement"].format(type="suite"), False),
+]
+
+TEST_GET_SUITE_ID_PROMPTS_USER_IDS = [
+    "user agrees",
+    "user agrees, fail to add suite",
+    "used does not agree",
+]
+
+TEST_GET_SUITE_ID_SINGLE_SUITE_MODE_BASELINES_TEST_DATA = [
+    (([], "Could not get suites"), -1, -1, "Could not get suites"),
+    (([10], ""), -1, 1, ""),
+    (
+        ([10, 11, 12], ""),
+        -1,
+        -1,
+        FAULT_MAPPING["not_unique_suite_id_single_suite_baselines"].format(
+            project_name="Fake project name"
+        ),
+    ),
+]
+
+TEST_GET_SUITE_ID_SINGLE_SUITE_MODE_BASELINES_IDS = [
+    "get_suite_ids fails",
+    "get_suite_ids returns one ID",
+    "get_suite_ids returns more than one ID",
+]

--- a/tests/test_data/results_provider_test_data.py
+++ b/tests/test_data/results_provider_test_data.py
@@ -16,16 +16,6 @@ TEST_UPLOAD_RESULTS_FLOW_IDS = [
     "add_results_failed",
     "close_run_failed",
 ]
-TEST_GET_SUITE_ID_PROMPTS_USER_TEST_DATA = [
-    (True, 10, 1, "Adding missing suites to project Fake project name.", False),
-    (True, 10, -1, "Adding missing suites to project Fake project name.", True),
-    (False, -1, -1, FAULT_MAPPING["no_user_agreement"].format(type="suite"), False),
-]
-TEST_GET_SUITE_ID_PROMPTS_USER_IDS = [
-    "user agrees",
-    "user agrees, fail to add suite",
-    "used does not agree",
-]
 TEST_ADD_MISSING_SECTIONS_PROMPTS_USER_TEST_DATA = [
     (
         True,
@@ -87,24 +77,6 @@ TEST_ADD_MISSING_TEST_CASES_PROMPTS_USER_IDS = [
     "user agrees, test cases added",
     "user agrees, test cases not added",
     "used does not agree",
-]
-TEST_GET_SUITE_ID_SINGLE_SUITE_MODE_BASELINES_TEST_DATA = [
-    (([], "Could not get suites"), -1, -1, "Could not get suites"),
-    (([10], ""), -1, 1, ""),
-    (
-        ([10, 11, 12], ""),
-        -1,
-        -1,
-        FAULT_MAPPING["not_unique_suite_id_single_suite_baselines"].format(
-            project_name="Fake project name"
-        ),
-    ),
-]
-
-TEST_GET_SUITE_ID_SINGLE_SUITE_MODE_BASELINES_IDS = [
-    "get_suite_ids fails",
-    "get_suite_ids returns one ID",
-    "get_suite_ids returns more than one ID",
 ]
 
 TEST_REVERT_FUNCTIONS_AND_EXPECTED = [

--- a/tests/test_project_based_client.py
+++ b/tests/test_project_based_client.py
@@ -1,0 +1,438 @@
+import pytest
+
+from tests.test_data.project_based_client_test_data import (
+    TEST_GET_SUITE_ID_PROMPTS_USER_IDS,
+    TEST_GET_SUITE_ID_PROMPTS_USER_TEST_DATA,
+    TEST_GET_SUITE_ID_SINGLE_SUITE_MODE_BASELINES_TEST_DATA,
+    TEST_GET_SUITE_ID_SINGLE_SUITE_MODE_BASELINES_IDS,
+)
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import Environment
+from trcli.constants import FAULT_MAPPING, SuiteModes, PROMPT_MESSAGES
+from trcli.data_classes.data_parsers import MatchersParser
+from trcli.data_classes.dataclass_testrail import TestRailSuite, ProjectData
+from trcli.readers.junit_xml import JunitParser
+
+
+class TestProjectBasedClient:
+    @pytest.fixture(scope="function")
+    def project_based_client_data_provider(self, mocker):
+        environment = mocker.patch("trcli.api.project_based_client.Environment")
+        environment.host = "https://fake_host.com/"
+        environment.project = "Fake project name"
+        environment.project_id = 1
+        environment.case_id = None
+        environment.run_id = None
+        environment.file = "results.xml"
+        environment.case_matcher = MatchersParser.AUTO
+
+        api_request_handler = mocker.patch(
+            "trcli.api.project_based_client.ApiRequestHandler"
+        )
+        api_request_handler.get_project_data.return_value = ProjectData(
+            project_id=environment.project_id, suite_mode=1, error_message=""
+        )
+        api_request_handler.check_automation_id_field.return_value = None
+        project_based_client = ProjectBasedClient(
+            environment=environment, suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+        )
+        project_based_client.api_request_handler = api_request_handler
+        yield environment, api_request_handler, project_based_client
+
+    @pytest.mark.project_based_client
+    @pytest.mark.parametrize(
+        "timeout", [40, None], ids=["with_timeout", "without_timeout"]
+    )
+    def test_instantiate_api_client(
+            self, timeout, project_based_client_data_provider, mocker
+    ):
+        """The purpose of this test is to check that APIClient was instantiated properly and credential fields
+        were set es expected."""
+        (_, api_request_handler, _) = project_based_client_data_provider
+        junit_file_parser = mocker.patch.object(JunitParser, "parse_file")
+        environment = Environment()
+        environment.host = "https://fake_host.com"
+        environment.username = "usermane@host.com"
+        environment.password = "test_password"
+        environment.key = "test_api_key"
+        if timeout:
+            environment.timeout = timeout
+        timeout_expected_result = 30 if not timeout else timeout
+        project_based_client = ProjectBasedClient(
+            environment=environment, suite=junit_file_parser
+        )
+
+        api_client = project_based_client.instantiate_api_client()
+
+        assert (
+                api_client.username == environment.username
+        ), f"Expected username to be set to: {environment.username}, but got: {api_client.username} instead."
+        assert (
+                api_client.password == environment.password
+        ), f"Expected password  to be set to: {environment.password}, but got: {api_client.password} instead."
+        assert (
+                api_client.api_key == environment.key
+        ), f"Expected api_key to be set to: {environment.key}, but got: {api_client.api_key} instead."
+        assert (
+                api_client.timeout == timeout_expected_result
+        ), f"Expected timeout to be set to: {timeout_expected_result}, but got: {api_client.timeout} instead."
+
+    def test_resolve_project(self, project_based_client_data_provider):
+        """The purpose of this test is to check that a project can be resolved properly and set on the environment.
+        Resolving a project includes retrieving the project data and validating the project id."""
+        (
+            environment,
+            api_request_handler,
+            project_based_client,
+        ) = project_based_client_data_provider
+
+        project_based_client.resolve_project()
+        assert (
+                project_based_client.project.project_id == environment.project_id
+        ), (f"Expected project_based_client.project to have {environment.project_id},"
+            f" but had {project_based_client.project.project_id}")
+
+    @pytest.mark.project_based_client
+    def test_get_suite_id_returns_valid_id(self, project_based_client_data_provider):
+        """The purpose of this test is to check that get_suite_id function will
+        return suite_id if it exists in TestRail"""
+        (
+            environment,
+            api_request_handler,
+            project_based_client,
+        ) = project_based_client_data_provider
+        suite_id = 1
+        result_code = 1
+        project_based_client.api_request_handler.suites_data_from_provider.suite_id = suite_id
+        project_based_client.api_request_handler.check_suite_id.return_value = (True, "")
+        (result_suite_id, result_return_code, suite_added) = project_based_client.get_suite_id(
+            suite_mode=SuiteModes.single_suite
+        )
+
+        assert (
+                result_suite_id == suite_id
+        ), f"Expected suite_id: {suite_id} but got {result_suite_id} instead."
+        assert (
+                suite_added is False
+        ), f"Expected suite_added: {False} but got {suite_added} instead."
+        assert (
+                result_return_code == result_code
+        ), f"Expected suite_id: {result_code} but got {result_return_code} instead."
+
+    @pytest.mark.project_based_client
+    @pytest.mark.parametrize(
+        "user_response, expected_suite_id, expected_result_code, expected_message, suite_add_error",
+        TEST_GET_SUITE_ID_PROMPTS_USER_TEST_DATA,
+        ids=TEST_GET_SUITE_ID_PROMPTS_USER_IDS,
+    )
+    def test_get_suite_id_multiple_suites_mode(
+            self,
+            user_response,
+            expected_suite_id,
+            expected_result_code,
+            expected_message,
+            suite_add_error,
+            project_based_client_data_provider,
+            mocker,
+    ):
+        """The purpose of this test is to check that user will be prompted to add suite is one is missing
+        in TestRail. Depending on user response either information about addition of missing suite or error message
+        should be printed."""
+        (
+            environment,
+            api_request_handler,
+            project_based_client,
+        ) = project_based_client_data_provider
+        project_id = 1
+        suite_name = "Fake suite name"
+        suite_mode = SuiteModes.multiple_suites
+        project_based_client.api_request_handler.resolve_suite_id_using_name.return_value = (-1, "Any Error")
+        if not suite_add_error:
+            project_based_client.api_request_handler.add_suites.return_value = (
+                [
+                    {
+                        "suite_id": expected_suite_id,
+                        "name": suite_name,
+                    }
+                ],
+                "",
+            )
+        else:
+            project_based_client.api_request_handler.add_suites.return_value = (
+                [{"suite_id": expected_suite_id, "name": suite_name}],
+                FAULT_MAPPING["error_while_adding_suite"].format(
+                    error_message="Failed to add suite."
+                ),
+            )
+        project_based_client.api_request_handler.suites_data_from_provider.suite_id = None
+        project_based_client.api_request_handler.suites_data_from_provider.name = suite_name
+        environment.get_prompt_response_for_auto_creation.return_value = user_response
+        result_suite_id, result_code, suite_added = project_based_client.get_suite_id(suite_mode)
+        expected_elog_calls = []
+        expected_log_calls = []
+        if "User did not agree to create" not in expected_message:
+            expected_log_calls = [mocker.call(expected_message)]
+        else:
+            expected_elog_calls.append(mocker.call(expected_message))
+
+        if suite_add_error:
+            expected_elog_calls.append(
+                mocker.call(
+                    FAULT_MAPPING["error_while_adding_suite"].format(
+                        error_message="Failed to add suite."
+                    )
+                )
+            )
+
+        assert (
+                expected_suite_id == result_suite_id
+        ), f"Expected suite_id: {expected_suite_id} but got {result_suite_id} instead."
+        assert (
+                expected_result_code == result_code
+        ), f"Expected suite_id: {expected_result_code} but got {result_code} instead."
+        environment.get_prompt_response_for_auto_creation.assert_called_with(
+            PROMPT_MESSAGES["create_new_suite"].format(
+                suite_name=suite_name,
+                project_name=environment.project,
+            )
+        )
+        if user_response:
+            project_based_client.api_request_handler.add_suites.assert_called_with(
+                project_id=project_id
+            )
+        environment.log.assert_has_calls(expected_log_calls)
+        environment.elog.assert_has_calls(expected_elog_calls)
+
+    @pytest.mark.project_based_client
+    @pytest.mark.parametrize(
+        "suite_ids, error_message, expected_suite_id, expected_result_code",
+        [([10], "", 10, 1), ([], "Could not get suites", -1, -1)],
+        ids=["get_suite_ids succeeds", "get_suite_ids fails"],
+    )
+    def test_get_suite_id_single_suite_mode(
+            self,
+            suite_ids,
+            error_message,
+            expected_suite_id,
+            expected_result_code,
+            project_based_client_data_provider,
+            mocker,
+    ):
+        """The purpose of this test is to check flow of get_suite_id_log_error function for single
+        suite mode."""
+        (
+            environment,
+            api_request_handler,
+            project_based_client,
+        ) = project_based_client_data_provider
+        project_id = 1
+        suite_mode = SuiteModes.single_suite
+        project_based_client.api_request_handler.suites_data_from_provider.suite_id = None
+        project_based_client.api_request_handler.get_suite_ids.return_value = (
+            suite_ids,
+            error_message,
+        )
+        expected_elog_calls = []
+        if error_message:
+            expected_elog_calls = [mocker.call(error_message)]
+        result_suite_id, result_code, suite_added = project_based_client.get_suite_id(suite_mode)
+
+        assert (
+                result_suite_id == expected_suite_id
+        ), f"Expected suite id: {expected_suite_id} but got {result_suite_id} instead."
+        assert (
+                result_code == expected_result_code
+        ), f"Expected result code: {expected_result_code} but got {result_code} instead."
+        if error_message:
+            environment.elog.assert_has_calls(expected_elog_calls)
+
+    @pytest.mark.project_based_client
+    @pytest.mark.parametrize(
+        "get_suite_ids_result, expected_suite_id, expected_result_code, expected_error_message",
+        TEST_GET_SUITE_ID_SINGLE_SUITE_MODE_BASELINES_TEST_DATA,
+        ids=TEST_GET_SUITE_ID_SINGLE_SUITE_MODE_BASELINES_IDS,
+    )
+    def test_get_suite_id_single_suite_mode_baselines(
+            self,
+            get_suite_ids_result,
+            expected_suite_id,
+            expected_result_code,
+            expected_error_message,
+            project_based_client_data_provider,
+            mocker,
+    ):
+        """The purpose of this test is to check flow of get_suite_id_log_error function for single
+        suite with baselines mode."""
+        (
+            environment,
+            api_request_handler,
+            project_based_client,
+        ) = project_based_client_data_provider
+        suite_mode = SuiteModes.single_suite_baselines
+        project_based_client.api_request_handler.resolve_suite_id_using_name.return_value = (-1, "Any Error")
+        project_based_client.api_request_handler.suites_data_from_provider.suite_id = None
+        project_based_client.api_request_handler.get_suite_ids.return_value = (
+            get_suite_ids_result
+        )
+        expected_elog_calls = []
+        if expected_error_message:
+            expected_elog_calls = [mocker.call(expected_error_message)]
+        result_suite_id, result_code, suite_added = project_based_client.get_suite_id(suite_mode)
+
+        assert (
+                result_suite_id == expected_suite_id
+        ), f"Expected suite id: {expected_suite_id} but got {result_suite_id} instead."
+        assert (
+                result_code == expected_result_code
+        ), f"Expected result code: {expected_result_code} but got {result_code} instead."
+        environment.elog.assert_has_calls(expected_elog_calls)
+
+    @pytest.mark.project_based_client
+    def test_get_suite_id_unknown_suite_mode(
+            self, project_based_client_data_provider, mocker
+    ):
+        """The purpose of this test is to check that get_suite_id will return -1 and print
+        proper message when unknown suite mode will be returned during execution."""
+        (
+            environment,
+            api_request_handler,
+            project_based_client,
+        ) = project_based_client_data_provider
+        suite_mode = 4
+        expected_result_code = -1
+        expected_suite_id = -1
+        project_based_client.api_request_handler.suites_data_from_provider.suite_id = None
+        expected_elog_calls = [
+            mocker.call(
+                FAULT_MAPPING["unknown_suite_mode"].format(suite_mode=suite_mode)
+            )
+        ]
+        result_suite_id, result_code, suite_added = project_based_client.get_suite_id(suite_mode)
+
+        assert (
+                result_suite_id == expected_suite_id
+        ), f"Expected suite id: {expected_suite_id} but got {result_suite_id} instead."
+        assert (
+                result_code == expected_result_code
+        ), f"Expected result code: {expected_result_code} but got {result_code} instead."
+        environment.elog.assert_has_calls(expected_elog_calls)
+
+    @pytest.mark.project_based_client
+    def test_check_suite_id_returns_id(self, project_based_client_data_provider):
+        """The purpose of this test is to check that check_suite_id function will success,
+        when suite ID exists under specified project."""
+        (
+            environment,
+            api_request_handler,
+            project_based_client,
+        ) = project_based_client_data_provider
+        expected_result_code = 1
+        project_id = 2
+        project_based_client.api_request_handler.check_suite_id.return_value = (True, "")
+
+        result_code = project_based_client.check_suite_id(project_id=project_id)
+
+        assert (
+                result_code == expected_result_code
+        ), f"Expected to get {result_code} as result code, but got {expected_result_code} instead."
+
+    @pytest.mark.project_based_client
+    def test_check_suite_id_prints_error_message(
+            self, project_based_client_data_provider, mocker
+    ):
+        """The purpose of this test is to check that proper message would be printed to the user
+        and program will quit when suite ID is not present in TestRail."""
+        (
+            environment,
+            api_request_handler,
+            project_based_client,
+        ) = project_based_client_data_provider
+        suite_id = 1
+        expected_result_code = -1
+        project_id = 2
+        project_based_client.api_request_handler.check_suite_id.return_value = (
+            False,
+            FAULT_MAPPING["missing_suite"].format(suite_id=suite_id),
+        )
+
+        result_code = project_based_client.check_suite_id(project_id=project_id)
+        expected_elog_calls = [
+            mocker.call(FAULT_MAPPING["missing_suite"].format(suite_id=suite_id))
+        ]
+
+        environment.elog.assert_has_calls(expected_elog_calls)
+        assert (
+                result_code == expected_result_code
+        ), f"Expected to get {expected_result_code} as result code, but got {result_code} instead."
+
+    def test_resolve_suite_returns_valid_id(self, project_based_client_data_provider):
+        """The purpose of this test is to check that resolve_suite returns a valid suite id."""
+        (
+            environment,
+            api_request_handler,
+            project_based_client,
+        ) = project_based_client_data_provider
+        api_request_handler.suites_data_from_provider.suite_id = 1
+        api_request_handler.check_suite_id.return_value = (True, "")
+
+        project_based_client.resolve_project()
+        suite_id, suite_added = project_based_client.resolve_suite()
+        assert (
+                suite_id == 1
+        ), f"Expected suite id 1 but got {suite_id} instead."
+
+    def test_create_or_update_test_run_calls_add_run(self, project_based_client_data_provider):
+        """The purpose of this test is to check that calling the method without a run_id in the environment causes
+        the add_run method of the request handler to be called."""
+        (
+            environment,
+            api_request_handler,
+            project_based_client,
+        ) = project_based_client_data_provider
+        environment.run_id = None
+        api_request_handler.add_run.return_value = (1, "")
+        project_based_client.resolve_project()
+        run_id, error_message = project_based_client.create_or_update_test_run()
+
+        project_based_client.api_request_handler.add_run.assert_called_once()
+        assert (
+                run_id == 1
+        ), f"Expected run_id to be 1 but got {run_id} instead."
+        assert (
+                error_message == ""
+        ), f"Expected error message to be None but got {error_message} instead."
+
+    def test_create_or_update_test_run_calls_update_run(self, project_based_client_data_provider):
+        """The purpose of this test is to check that calling the method with a run_id in the environment causes
+        the update_run method of the request handler to be called."""
+        (
+            environment,
+            api_request_handler,
+            project_based_client,
+        ) = project_based_client_data_provider
+        environment.run_id = 1
+        api_request_handler.update_run.return_value = (1, "")
+        project_based_client.resolve_project()
+        run_id, error_message = project_based_client.create_or_update_test_run()
+
+        api_request_handler.update_run.assert_called_once()
+        assert (
+                run_id == 1
+        ), f"Expected run_id to be 1 but got {run_id} instead."
+        assert (
+                error_message == ""
+        ), f"Expected error message to be None but got {error_message} instead."
+
+    def test_get_project_id(self, project_based_client_data_provider):
+        """The purpose of this test is to check that the _get_project_id() will fall back to the environment.project_id
+        when environment.project does not contain the project_id."""
+        (
+            environment,
+            _,
+            project_based_client,
+        ) = project_based_client_data_provider
+
+        assert (
+                project_based_client._get_project_id() == environment.project_id
+        ), (f"Expected to get {environment.project_id} from project_based_client.get_project_id but got"
+            f" {project_based_client._get_project_id()} instead.")

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -373,7 +373,10 @@ class ApiRequestHandler:
             run_name: str,
             milestone_id: int = None,
             plan_id: int = None,
-            config_ids: List[int] = None
+            config_ids: List[int] = None,
+            assigned_to_id=None,
+            include_all=False,
+            refs=None,
     ) -> Tuple[int, str]:
         """
         Creates a new test run.
@@ -381,7 +384,13 @@ class ApiRequestHandler:
         :run_name: run name
         :returns: Tuple with run id and error string.
         """
-        add_run_data = self.data_provider.add_run(run_name, milestone_id=milestone_id)
+        add_run_data = self.data_provider.add_run(
+            run_name,
+            milestone_id=milestone_id,
+            assigned_to_id=assigned_to_id,
+            include_all=include_all,
+            refs=refs,
+        )
         if not plan_id:
             response = self.client.send_post(f"add_run/{project_id}", add_run_data)
             run_id = response.response_text.get("id")

--- a/trcli/api/project_based_client.py
+++ b/trcli/api/project_based_client.py
@@ -1,0 +1,242 @@
+from beartype.typing import Callable, Optional, Tuple
+
+from trcli.api.api_client import APIClient
+from trcli.api.api_request_handler import ApiRequestHandler
+from trcli.cli import Environment
+from trcli.constants import ProjectErrors, FAULT_MAPPING, SuiteModes, PROMPT_MESSAGES
+from trcli.data_classes.data_parsers import MatchersParser
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+class ProjectBasedClient:
+    """
+    Class to be used to interact with the TestRail Api at a project level.
+    Initialized with environment object and result file parser object (any parser derived from FileParser).
+    """
+
+    def __init__(self, environment: Environment, suite: TestRailSuite):
+        self.project = None
+        self.environment = environment
+        self.run_name = self.environment.title
+        if self.environment.suite_id:
+            suite.suite_id = self.environment.suite_id
+        self.api_request_handler = ApiRequestHandler(
+            environment=self.environment,
+            api_client=self.instantiate_api_client(),
+            suites_data=suite,
+            verify=self.environment.verify,
+        )
+
+    def instantiate_api_client(self) -> APIClient:
+        """
+        Instantiate api client with needed attributes taken from environment.
+        """
+        verbose_logging_function = self.environment.vlog
+        logging_function = self.environment.log
+        if self.environment.timeout:
+            api_client = APIClient(
+                self.environment.host,
+                verbose_logging_function=verbose_logging_function,
+                logging_function=logging_function,
+                timeout=self.environment.timeout,
+                verify=not self.environment.insecure,
+            )
+        else:
+            api_client = APIClient(
+                self.environment.host,
+                logging_function=logging_function,
+                verbose_logging_function=verbose_logging_function,
+                verify=not self.environment.insecure,
+            )
+        api_client.username = self.environment.username
+        api_client.password = self.environment.password
+        api_client.api_key = self.environment.key
+        return api_client
+
+    def resolve_project(self):
+        """
+        Gets and checks project settings.
+        """
+        self.environment.log("Checking project. ", new_line=False)
+        self.project = self.api_request_handler.get_project_data(
+            self.environment.project, self.environment.project_id
+        )
+        self._validate_project_id()
+        if self.environment.auto_creation_response:
+            if self.environment.case_matcher == MatchersParser.AUTO:
+                automation_id_error = self.api_request_handler.check_automation_id_field(self.project.project_id)
+                if automation_id_error:
+                    self.environment.elog(automation_id_error)
+                    exit(1)
+        self.environment.log("Done.")
+
+    def _validate_project_id(self):
+        if self.project.project_id == ProjectErrors.not_existing_project:
+            self.environment.elog("\n" + self.project.error_message)
+            exit(1)
+        elif self.project.project_id == ProjectErrors.other_error:
+            self.environment.elog(
+                "\n"
+                + FAULT_MAPPING["error_checking_project"].format(
+                    error_message=self.project.error_message
+                )
+            )
+            exit(1)
+        elif self.project.project_id == ProjectErrors.multiple_project_same_name:
+            self.environment.elog(
+                "\n"
+                + FAULT_MAPPING["error_checking_project"].format(
+                    error_message=self.project.error_message
+                )
+            )
+            exit(1)
+
+    def get_suite_id(self, suite_mode: int) -> Tuple[int, int, bool]:
+        """
+        Gets and checks suite ID for specified project.
+        Project id should already be resolved as self.project.project_id or self.environment.project_id (as a backup).
+        Depending on the entry conditions (suite ID provided or not, suite mode, project ID)
+        it will:
+            * check if specified suite ID exists and is correct
+            * try to create missing suite ID
+            * try to fetch suite ID from TestRail
+        Returns the suite ID if added/found or -1 in any other case, along with a return code, and a boolean
+        to identify is suite was created or not. Proper information is printed on failure.
+        """
+        suite_id = -1
+        result_code = -1
+        suite_added = False
+
+        project_id = self._get_project_id()
+
+        if not self.api_request_handler.suites_data_from_provider.suite_id:
+            if suite_mode in [SuiteModes.multiple_suites, SuiteModes.single_suite_baselines]:
+                suite_id, error_msg = self.api_request_handler.resolve_suite_id_using_name(project_id)
+                if suite_id != -1:
+                    self.api_request_handler.suites_data_from_provider.suite_id = suite_id
+                    return suite_id, 1, False
+            if suite_mode == SuiteModes.multiple_suites:
+                prompt_message = PROMPT_MESSAGES["create_new_suite"].format(
+                    suite_name=self.api_request_handler.suites_data_from_provider.name,
+                    project_name=self.environment.project,
+                )
+                adding_message = (
+                    f"Adding missing suites to project {self.environment.project}."
+                )
+                fault_message = FAULT_MAPPING["no_user_agreement"].format(type="suite")
+                added_suites, result_code = self.prompt_user_and_add_items(
+                    prompt_message=prompt_message,
+                    adding_message=adding_message,
+                    fault_message=fault_message,
+                    add_function=self.api_request_handler.add_suites,
+                    project_id=project_id,
+                )
+                if added_suites:
+                    suite_id = added_suites[0]["suite_id"]
+                    suite_added = True
+            elif suite_mode == SuiteModes.single_suite_baselines:
+                suite_ids, error_message = self.api_request_handler.get_suite_ids(
+                    project_id=project_id
+                )
+                if error_message:
+                    self.environment.elog(error_message)
+                else:
+                    if len(suite_ids) > 1:
+                        self.environment.elog(
+                            FAULT_MAPPING[
+                                "not_unique_suite_id_single_suite_baselines"
+                            ].format(project_name=self.environment.project)
+                        )
+                    else:
+                        result_code = 1
+            elif suite_mode == SuiteModes.single_suite:
+                suite_ids, error_message = self.api_request_handler.get_suite_ids(
+                    project_id=project_id
+                )
+                if error_message:
+                    self.environment.elog(error_message)
+                else:
+                    suite_id = suite_ids[0]
+                    result_code = 1
+            else:
+                self.environment.elog(
+                    FAULT_MAPPING["unknown_suite_mode"].format(suite_mode=suite_mode)
+                )
+        else:
+            suite_id = self.api_request_handler.suites_data_from_provider.suite_id
+            result_code = self.check_suite_id(project_id)
+        return suite_id, result_code, suite_added
+
+    def check_suite_id(self, project_id: Optional[int]) -> int:
+        """
+        Checks that suite ID is correct.
+        Returns suite ID is succeeds or -1 on failure. Proper information will be printed
+        on failure.
+        """
+        result_code = -1
+        if project_id is None:
+            project_id = self._get_project_id()
+        suite_exists, error_message = self.api_request_handler.check_suite_id(
+            project_id
+        )
+        if suite_exists:
+            result_code = 1
+        else:
+            self.environment.elog(error_message)
+        return result_code
+
+    def resolve_suite(self) -> Tuple[int, bool]:
+        suite_id, result_code, suite_added = self.get_suite_id(suite_mode=self.project.suite_mode)
+        if result_code == -1:
+            exit(1)
+        return suite_id, suite_added
+
+    def create_or_update_test_run(self) -> Tuple[int, str]:
+        """
+        If a run_id is provided, update the test run; otherwise, add a new test run.
+        """
+        if not self.environment.run_id:
+            self.environment.log(f"Creating test run. ", new_line=False)
+            added_run, error_message = self.api_request_handler.add_run(
+                self.project.project_id, self.run_name, self.environment.milestone_id, self.environment.plan_id,
+                self.environment.config_ids
+            )
+            run_id = added_run
+        else:
+            self.environment.log(f"Updating test run. ", new_line=False)
+            run_id = self.environment.run_id
+            run, error_message = self.api_request_handler.update_run(
+                run_id, self.run_name, self.environment.milestone_id
+            )
+        if error_message:
+            self.environment.elog("\n" + error_message)
+        else:
+            self.environment.log(f"Test run: {self.environment.host.rstrip('/')}/index.php?/runs/view/{run_id}")
+        return run_id, error_message
+
+    def prompt_user_and_add_items(
+        self,
+        prompt_message,
+        adding_message,
+        fault_message,
+        add_function: Callable,
+        project_id: int = None,
+    ):
+        added_items = []
+        result_code = -1
+        if self.environment.get_prompt_response_for_auto_creation(prompt_message):
+            self.environment.log(adding_message)
+            if project_id:
+                added_items, error_message = add_function(project_id=project_id)
+            else:
+                added_items, error_message = add_function()
+            if error_message:
+                self.environment.elog(error_message)
+            else:
+                result_code = 1
+        else:
+            self.environment.elog(fault_message)
+        return added_items, result_code
+
+    def _get_project_id(self) -> int:
+        return getattr(self.project, "project_id", self.environment.project_id)

--- a/trcli/api/results_uploader.py
+++ b/trcli/api/results_uploader.py
@@ -1,36 +1,24 @@
 import time
 from beartype.typing import Tuple, Callable, List
 
-from trcli.api.api_client import APIClient
-from trcli.api.api_request_handler import ApiRequestHandler
+from trcli.api.project_based_client import ProjectBasedClient
 from trcli.cli import Environment
 from trcli.constants import PROMPT_MESSAGES, FAULT_MAPPING, SuiteModes
-from trcli.constants import ProjectErrors, RevertMessages
+from trcli.constants import RevertMessages
 from trcli.data_classes.dataclass_testrail import TestRailSuite
-from trcli.data_classes.data_parsers import MatchersParser
 
 
-class ResultsUploader:
+class ResultsUploader(ProjectBasedClient):
     """
     Class to be used to upload the results to TestRail.
     Initialized with environment object and result file parser object (any parser derived from FileParser).
     """
 
     def __init__(self, environment: Environment, suite: TestRailSuite, skip_run: bool = False):
-        self.project = None
-        self.environment = environment
+        super().__init__(environment, suite)
         self.skip_run = skip_run
-        self.run_name = self.environment.title
         if self.environment.special_parser == "saucectl":
             self.run_name += f" ({suite.name})"
-        if self.environment.suite_id:
-            suite.suite_id = self.environment.suite_id
-        self.api_request_handler = ApiRequestHandler(
-            api_client=self.instantiate_api_client(),
-            environment=self.environment,
-            suites_data=suite,
-            verify=self.environment.verify,
-        )
 
     def upload_results(self):
         """
@@ -42,26 +30,8 @@ class ResultsUploader:
         start = time.time()
         results_amount = None
 
-        # Validate project settings
-        self.environment.log("Checking project. ", new_line=False)
-        self.project = self.api_request_handler.get_project_data(
-            self.environment.project, self.environment.project_id
-        )
-        self._validate_project_id()
-        if self.environment.auto_creation_response:
-            if self.environment.case_matcher == MatchersParser.AUTO:
-                automation_id_error = self.api_request_handler.check_automation_id_field(self.project.project_id)
-                if automation_id_error:
-                    self.environment.elog(automation_id_error)
-                    exit(1)
-        self.environment.log("Done.")
-
-        # Resolve test suite
-        suite_id, result_code, suite_added = self.get_suite_id(
-            project_id=self.project.project_id, suite_mode=self.project.suite_mode
-        )
-        if result_code == -1:
-            exit(1)
+        self.resolve_project()
+        suite_id, suite_added = self.resolve_suite()
 
         # Resolve missing test cases and sections
         missing_test_cases, error_message = self.api_request_handler.check_missing_test_cases_ids(
@@ -124,21 +94,8 @@ class ResultsUploader:
                     self.environment.log(f"Removed {len(empty_sections)} unused/empty section(s).")
 
         # Create/update test run
-        if not self.environment.run_id:
-            self.environment.log(f"Creating test run. ", new_line=False)
-            added_run, error_message = self.api_request_handler.add_run(
-                self.project.project_id, self.run_name, self.environment.milestone_id, self.environment.plan_id,
-                self.environment.config_ids
-            )
-            run_id = added_run
-        else:
-            self.environment.log(f"Updating test run. ", new_line=False)
-            run_id = self.environment.run_id
-            run, error_message = self.api_request_handler.update_run(
-                run_id, self.run_name, self.environment.milestone_id
-            )
+        run_id, error_message = self.create_or_update_test_run()
         if error_message:
-            self.environment.elog("\n" + error_message)
             revert_logs = self.rollback_changes(
                 suite_id=suite_id,
                 suite_added=suite_added,
@@ -147,8 +104,6 @@ class ResultsUploader:
             )
             self.environment.log("\n".join(revert_logs))
             exit(1)
-        else:
-            self.environment.log(f"Test run: {self.environment.host.rstrip('/')}/index.php?/runs/view/{run_id}")
 
         added_results, error_message, results_amount = self.api_request_handler.add_results(run_id)
         if error_message:
@@ -173,94 +128,6 @@ class ResultsUploader:
         stop = time.time()
         if results_amount:
             self.environment.log(f"Submitted {results_amount} test results in {stop - start:.1f} secs.")
-
-    def get_suite_id(self, project_id: int, suite_mode: int) -> Tuple[int, int, bool]:
-        """
-        Gets and checks suite ID for specified project_id.
-        Depending on the entry conditions (suite ID provided or not, suite mode, project ID)
-        it will:
-            * check if specified suite ID exists and is correct
-            * try to create missing suite ID
-            * try to fetch suite ID from TestRail
-        Returns the suite ID if added/found or -1 in any other case, along with a return code, and a boolean
-        to identify is suite was created or not. Proper information is printed on failure.
-        """
-        suite_id = -1
-        result_code = -1
-        suite_added = False
-
-        if not self.api_request_handler.suites_data_from_provider.suite_id:
-            if suite_mode in [SuiteModes.multiple_suites, SuiteModes.single_suite_baselines]:
-                suite_id, error_msg = self.api_request_handler.resolve_suite_id_using_name(project_id)
-                if suite_id != -1:
-                    self.api_request_handler.suites_data_from_provider.suite_id = suite_id
-                    return suite_id, 1, False
-            if suite_mode == SuiteModes.multiple_suites:
-                prompt_message = PROMPT_MESSAGES["create_new_suite"].format(
-                    suite_name=self.api_request_handler.suites_data_from_provider.name,
-                    project_name=self.environment.project,
-                )
-                adding_message = (
-                    f"Adding missing suites to project {self.environment.project}."
-                )
-                fault_message = FAULT_MAPPING["no_user_agreement"].format(type="suite")
-                added_suites, result_code = self.prompt_user_and_add_items(
-                    prompt_message=prompt_message,
-                    adding_message=adding_message,
-                    fault_message=fault_message,
-                    add_function=self.api_request_handler.add_suites,
-                    project_id=project_id,
-                )
-                if added_suites:
-                    suite_id = added_suites[0]["suite_id"]
-                    suite_added = True
-            elif suite_mode == SuiteModes.single_suite_baselines:
-                suite_ids, error_message = self.api_request_handler.get_suite_ids(
-                    project_id=project_id
-                )
-                if error_message:
-                    self.environment.elog(error_message)
-                else:
-                    if len(suite_ids) > 1:
-                        self.environment.elog(
-                            FAULT_MAPPING[
-                                "not_unique_suite_id_single_suite_baselines"
-                            ].format(project_name=self.environment.project)
-                        )
-                    else:
-                        result_code = 1
-            elif suite_mode == SuiteModes.single_suite:
-                suite_ids, error_message = self.api_request_handler.get_suite_ids(
-                    project_id=project_id
-                )
-                if error_message:
-                    self.environment.elog(error_message)
-                else:
-                    suite_id = suite_ids[0]
-                    result_code = 1
-            else:
-                self.environment.elog(
-                    FAULT_MAPPING["unknown_suite_mode"].format(suite_mode=suite_mode)
-                )
-        else:
-            result_code = self.check_suite_id(project_id)
-        return suite_id, result_code, suite_added
-
-    def check_suite_id(self, project_id: int) -> int:
-        """
-        Checks that suite ID is correct.
-        Returns suite ID is succeeds or -1 on failure. Proper information will be printed
-        on failure.
-        """
-        result_code = -1
-        suite_exists, error_message = self.api_request_handler.check_suite_id(
-            project_id
-        )
-        if suite_exists:
-            result_code = 1
-        else:
-            self.environment.elog(error_message)
-        return result_code
 
     def add_missing_sections(self, project_id: int) -> Tuple[List, int]:
         """
@@ -324,56 +191,6 @@ class ResultsUploader:
 
         return added_cases, result_code
 
-    def prompt_user_and_add_items(
-        self,
-        prompt_message,
-        adding_message,
-        fault_message,
-        add_function: Callable,
-        project_id: int = None,
-    ):
-        added_items = []
-        result_code = -1
-        if self.environment.get_prompt_response_for_auto_creation(prompt_message):
-            self.environment.log(adding_message)
-            if project_id:
-                added_items, error_message = add_function(project_id=project_id)
-            else:
-                added_items, error_message = add_function()
-            if error_message:
-                self.environment.elog(error_message)
-            else:
-                result_code = 1
-        else:
-            self.environment.elog(fault_message)
-        return added_items, result_code
-
-    def instantiate_api_client(self) -> APIClient:
-        """
-        Instantiate api client with needed attributes taken from environment.
-        """
-        verbose_logging_function = self.environment.vlog
-        logging_function = self.environment.log
-        if self.environment.timeout:
-            api_client = APIClient(
-                self.environment.host,
-                verbose_logging_function=verbose_logging_function,
-                logging_function=logging_function,
-                timeout=self.environment.timeout,
-                verify=not self.environment.insecure,
-            )
-        else:
-            api_client = APIClient(
-                self.environment.host,
-                logging_function=logging_function,
-                verbose_logging_function=verbose_logging_function,
-                verify=not self.environment.insecure,
-            )
-        api_client.username = self.environment.username
-        api_client.password = self.environment.password
-        api_client.api_key = self.environment.key
-        return api_client
-
     def rollback_changes(
         self, suite_id=0, suite_added=False, added_sections=None, added_test_cases=None, run_id=0
     ) -> List[str]:
@@ -421,25 +238,3 @@ class ResultsUploader:
             else:
                 returned_log.append(RevertMessages.suite_deleted)
         return returned_log
-
-
-    def _validate_project_id(self):
-        if self.project.project_id == ProjectErrors.not_existing_project:
-            self.environment.elog("\n" + self.project.error_message)
-            exit(1)
-        elif self.project.project_id == ProjectErrors.other_error:
-            self.environment.elog(
-                "\n"
-                + FAULT_MAPPING["error_checking_project"].format(
-                    error_message=self.project.error_message
-                )
-            )
-            exit(1)
-        elif self.project.project_id == ProjectErrors.multiple_project_same_name:
-            self.environment.elog(
-                "\n"
-                + FAULT_MAPPING["error_checking_project"].format(
-                    error_message=self.project.error_message
-                )
-            )
-            exit(1)

--- a/trcli/commands/cmd_add_run.py
+++ b/trcli/commands/cmd_add_run.py
@@ -1,4 +1,5 @@
 import click
+import yaml
 
 from trcli.api.project_based_client import ProjectBasedClient
 from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
@@ -17,6 +18,15 @@ def print_config(env: Environment):
             f"\n> Include All: {env.run_include_all}"
             f"\n> Case IDs: {env.run_case_ids}"
             f"\n> Refs: {env.run_refs}")
+
+
+def write_run_to_file(environment: Environment, run_id: int):
+    """Write the created run id and title to a yaml file that can be included in the configuration of later runs."""
+    environment.log(f"Writing test run name and id to file ({environment.file}). ", new_line=False)
+    data = dict(title=environment.title, run_id=run_id)
+    with open(environment.file, "w") as f:
+        f.write(yaml.dump(data, default_flow_style=False))
+    environment.log("Done.")
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
@@ -55,7 +65,7 @@ def print_config(env: Environment):
     metavar="",
     help="A comma-separated list of references/requirements"
 )
-@click.option("-f", "--file", type=click.Path(), metavar="", help="Filename and path.")
+@click.option("-f", "--file", type=click.Path(), metavar="", help="Write run title and id to file.")
 @click.pass_context
 @pass_environment
 def cli(environment: Environment, context: click.Context, *args, **kwargs):
@@ -74,9 +84,8 @@ def cli(environment: Environment, context: click.Context, *args, **kwargs):
     if error_message:
         exit(1)
 
-    environment.log(f"Run id: {run_id}")
+    environment.run_id = run_id
+    environment.log(f"title: {environment.title}")
+    environment.log(f"run_id: {run_id}")
     if environment.file is not None:
-        environment.log(f"Writing test run name and id to file ({environment.file}). ", new_line=False)
-        with open(environment.file, "w") as f:
-            f.write(f"{environment.title}\n{run_id}\n")
-        environment.log("Done.")
+        write_run_to_file(environment, run_id)

--- a/trcli/commands/cmd_add_run.py
+++ b/trcli/commands/cmd_add_run.py
@@ -1,0 +1,82 @@
+import click
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def print_config(env: Environment):
+    env.log(f"Parser Results Execution Parameters"
+            f"\n> TestRail instance: {env.host} (user: {env.username})"
+            f"\n> Project: {env.project if env.project else env.project_id}"
+            f"\n> Run title: {env.title}"
+            f"\n> Suite ID: {env.suite_id}"
+            f"\n> Description: {env.run_description}"
+            f"\n> Milestone ID: {env.milestone_id}"
+            f"\n> Assigned To ID: {env.run_assigned_to_id}"
+            f"\n> Include All: {env.run_include_all}"
+            f"\n> Case IDs: {env.run_case_ids}"
+            f"\n> Refs: {env.run_refs}")
+
+
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.option("--title", metavar="", help="Title of Test Run to be created or updated in TestRail.")
+@click.option(
+    "--suite-id",
+    type=click.IntRange(min=1),
+    metavar="",
+    help="Suite ID to submit results to.",
+)
+@click.option("--run-description", metavar="", default="", help="Summary text to be added to the test run.")
+@click.option(
+    "--milestone-id",
+    type=click.IntRange(min=1),
+    metavar="",
+    help="Milestone ID to which the Test Run should be associated to.",
+)
+@click.option(
+    "--run-assigned-to-id",
+    type=click.IntRange(min=1),
+    metavar="",
+    help="The ID of the user the test run should be assigned to."
+)
+@click.option(
+    "--include-all",
+    is_flag=True,
+    default=False,
+)
+@click.option(
+    "--case-ids",
+    metavar="",
+    help="Comma separated list of test case IDs to include in the test run."
+)
+@click.option(
+    "--run-refs",
+    metavar="",
+    help="A comma-separated list of references/requirements"
+)
+@click.option("-f", "--file", type=click.Path(), metavar="", help="Filename and path.")
+@click.pass_context
+@pass_environment
+def cli(environment: Environment, context: click.Context, *args, **kwargs):
+    environment.cmd = "add_run"
+    environment.set_parameters(context)
+    environment.check_for_required_parameters()
+    print_config(environment)
+
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+    project_client.resolve_project()
+    project_client.resolve_suite()
+    run_id, error_message = project_client.create_or_update_test_run()
+    if error_message:
+        exit(1)
+
+    environment.log(f"Run id: {run_id}")
+    if environment.file is not None:
+        environment.log(f"Writing test run name and id to file ({environment.file}). ", new_line=False)
+        with open(environment.file, "w") as f:
+            f.write(f"{environment.title}\n{run_id}\n")
+        environment.log("Done.")

--- a/trcli/commands/cmd_parse_junit.py
+++ b/trcli/commands/cmd_parse_junit.py
@@ -25,6 +25,7 @@ from trcli.readers.junit_xml import JunitParser
 @pass_environment
 def cli(environment: Environment, context: click.Context, *args, **kwargs):
     """Parse JUnit report and upload results to TestRail"""
+    environment.cmd = "parse_junit"
     environment.set_parameters(context)
     environment.check_for_required_parameters()
     settings.ALLOW_ELAPSED_MS = environment.allow_ms

--- a/trcli/commands/cmd_parse_robot.py
+++ b/trcli/commands/cmd_parse_robot.py
@@ -17,6 +17,7 @@ from trcli.readers.robot_xml import RobotParser
 @pass_environment
 def cli(environment: Environment, context: click.Context, *args, **kwargs):
     """Parse Robot Framework report and upload results to TestRail"""
+    environment.cmd = "parse_robot"
     environment.set_parameters(context)
     environment.check_for_required_parameters()
     settings.ALLOW_ELAPSED_MS = environment.allow_ms

--- a/trcli/constants.py
+++ b/trcli/constants.py
@@ -1,12 +1,19 @@
 import trcli
 import enum
 
+PARSE_COMMON_FAULT_MAPPING = dict(
+    missing_file="Please provide a valid path to your results file with the -f argument.",
+)
+
 PARSE_JUNIT_OR_ROBOT_FAULT_MAPPING = dict(
     missing_title="Please give your Test Run a title using the --title argument."
 )
 
+ADD_RUN_FAULT_MAPPING = dict(
+    missing_title="Please give your Test Run a title using the --title argument.",
+)
+
 FAULT_MAPPING = dict(
-    missing_file="Please provide a valid path to your results file with the -f argument.",
     invalid_file="Provided file is not a valid file.",
     missing_host="Please provide a TestRail server address with the -h argument.",
     missing_project="Please specify the project name using the --project argument.",
@@ -52,6 +59,13 @@ FAULT_MAPPING = dict(
     f"  - Is Active: True"
 )
 
+COMMAND_FAULT_MAPPING = dict(
+    add_run=dict(**FAULT_MAPPING, **ADD_RUN_FAULT_MAPPING),
+    parse_junit=dict(**FAULT_MAPPING, **PARSE_COMMON_FAULT_MAPPING, **PARSE_JUNIT_OR_ROBOT_FAULT_MAPPING),
+    parse_openapi=dict(**FAULT_MAPPING, **PARSE_COMMON_FAULT_MAPPING),
+    parse_robot=dict(**FAULT_MAPPING, **PARSE_COMMON_FAULT_MAPPING, **PARSE_JUNIT_OR_ROBOT_FAULT_MAPPING),
+)
+
 PROMPT_MESSAGES = dict(
     create_new_suite="Suite ID was not provided in either the result file or the command line.\n"
     "Would you like to create suite with name '{suite_name}' under project: "
@@ -69,7 +83,8 @@ Copyright 2024 Gurock Software GmbH - www.gurock.com"""
 TOOL_USAGE = f"""Supported and loaded modules:
     - parse_junit: JUnit XML Files (& Similar)
     - parse_robot: Robot Framework XML Files
-    - parse_openapi: OpenAPI YML Files"""
+    - parse_openapi: OpenAPI YML Files
+    - add_run: Create a new test run"""
 
 MISSING_COMMAND_SLOGAN = """Usage: trcli [OPTIONS] COMMAND [ARGS]...\nTry 'trcli --help' for help.
 \nError: Missing command."""

--- a/trcli/data_providers/api_data_provider.py
+++ b/trcli/data_providers/api_data_provider.py
@@ -1,4 +1,4 @@
-from beartype.typing import List, Dict
+from beartype.typing import List, Dict, Optional
 
 from serde.json import to_dict
 
@@ -61,7 +61,15 @@ class ApiDataProvider:
                     bodies.append(case)
         return bodies
 
-    def add_run(self, run_name: None, case_ids=None, milestone_id=None):
+    def add_run(
+            self,
+            run_name: Optional[str],
+            case_ids=None,
+            milestone_id=None,
+            assigned_to_id=None,
+            include_all=None,
+            refs=None,
+    ):
         """Return body for adding or updating a run."""
         if case_ids is None:
             case_ids = [
@@ -82,9 +90,14 @@ class ApiDataProvider:
             "suite_id": self.suites_input.suite_id,
             "description": "\n".join(properties),
             "milestone_id": milestone_id,
-            "include_all": False,
             "case_ids": case_ids
         }
+        if include_all is not None:
+            body["include_all"] = include_all
+        if assigned_to_id is not None:
+            body["assignedto_id"] = assigned_to_id
+        if refs is not None:
+            body["refs"] = refs
         if run_name is not None:
             body["name"] = run_name
         return body


### PR DESCRIPTION
<!-- 
Thanks for contributing!
PLEASE:
- Read our contributing guidelines: https://github.com/gurock/trcli/blob/main/CONTRIBUTING.md
- Mark this PR as "Draft" if it is not ready for review.
-->

## Issue being resolved: https://github.com/gurock/trcli/issues/236

### Solution description
How are we solving the problem?
Adding the add_run command exposes the API's add_run route to trcli users. This command can be used to create the target test run prior to uploading results - a required step when uploading results that are generated in CI/CD environments that use parallel execution nodes, such as circleCi.

The command follows the same usage pattern as trcli's other commands. The output of the command is the test run id, which is sent to STDOUT and optionally to a yaml file that can be used as a config for `parse_***` command that may be executed next.

### Changes
What changes where made?

* The README was updated to include the usage of the `add_run` command.
* API request handler was updated to support all inputs for add_run route.
* A ProjectBasedClient class was added to encapsulate shared API request methods that function based on the presence of a project id.
* Existing class TestResultsUploader was refactored to extend the shared logic in the ProjectBasedClient.
* CLI class was updated to accept the new add_run command.
* Add_run command was added.
* Tests were updated to exercise the refactored classes: ProjectBasedClient, TestResultsUploader
* Tests were added for the `add_run` command.

### Potential impacts
What could potentially be affected by the implemented changes?

The implemented changes should have no impact on existing usage. These changes do not alter the current behavior of the application.

### Steps to test
Happy path to test implemented scenario:

- having installed the trcli
1. Use the add_run command to create a new test run:
```
trcli -h "<host>" -p "project" -u "<un>" -p "<pw>" add_run --title "Run Title" -f run_config.yml
```
2. Observe the run id in the standard output of the command.
3. Observe the newly created run_config.yml file contains the test run title and run id.
4. Observe the newly created run in TestRail.
5. Use the newly created run_config.yml to upload results to the test run:
```
trcli -h "<host>" -p "project" -u "<un>" -p "<pw>" -c run_config.yml parse_junit -f results.xml
```
6. Observe the test results uploaded to the test run.

### PR Tasks
- [x] PR reference added to issue
- [x] README updated
- [x] Unit tests added/updated
