### PR TITLE
Fix parsing for glob, when only one file is returned.

### DIFF
--- a/tests/test_junit_parser.py
+++ b/tests/test_junit_parser.py
@@ -30,6 +30,10 @@ class TestJunitParser:
                 Path(__file__).parent / "test_data/json/root.json",
             ),
             (
+                    Path(__file__).parent / "test_data/XML/ro*t.xml",
+                    Path(__file__).parent / "test_data/json/root.json",
+            ),
+            (
                 Path(__file__).parent / "test_data/XML/required_only.xml",
                 Path(__file__).parent / "test_data/json/required_only.json",
             )
@@ -37,6 +41,7 @@ class TestJunitParser:
         ids=[
             "XML without testsuites root",
             "XML with testsuites root",
+            "XML with testsuites root, using a glob pattern",
             "XML with no data",
         ],
     )

--- a/trcli/readers/junit_xml.py
+++ b/trcli/readers/junit_xml.py
@@ -63,7 +63,7 @@ class JunitParser(FileParser):
         if not files:
             raise FileNotFoundError("File not found.")
         elif len(files) == 1:
-            return filepath
+            return Path().cwd().joinpath(files[0])
         sub_suites = []
         for file in files:
             suite = JUnitXml.fromfile(file)


### PR DESCRIPTION
## Issue being resolved: https://github.com/gurock/trcli/issues/241

### Solution description
Return the Path of the file found instead of returning the file pattern.

### Potential impacts
I have run the test without failures, but I don't see any tests about the glob feature. I tried to add one.

### Steps to test
Happy path to test implemented scenario

### PR Tasks
- [x] PR reference added to issue
- [ ] README updated
- [x] Unit tests added/updated
