### PR TITLE
Fix/request dependency update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "pyyaml==6.0.*",
         "junitparser==3.1.*",
         "pyserde==0.12.*",
-        "requests==2.31.*",
+        "requests>=2.31.0,<3.0.0",
         "tqdm==4.65.*",
         "humanfriendly==10.0.*",
         "openapi-spec-validator==0.5.*",

--- a/tests_e2e/pytest.ini
+++ b/tests_e2e/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 log_cli = true
+#put testing patterns here

--- a/tests_e2e/pytest.ini
+++ b/tests_e2e/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
 log_cli = true
-#put testing patterns here


### PR DESCRIPTION
## Issue being resolved: https://github.com/gurock/trcli/issues/234

### Solution description
How are we solving the problem?
Allow TRCLI required request version to support newer versions.

### Changes
What changes where made?
We changed the dependency management for the requests library to support minor versions (non-breaking versions)

### Potential impacts
What could potentially be affected by the implemented changes? 
No impact.

### Steps to test
Happy path to test implemented scenario
You can install a newer version of the Requests library >= 2.31.* but below 3.x.x

### PR Tasks
- [x] PR reference added to issue
- [] README updated
- [x] Unit tests added/updated
