### PR TITLE
Fix/e2e test script add run

### DIFF
--- a/tests_e2e/pytest.ini
+++ b/tests_e2e/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 log_cli = true
+#put testing patterns here

--- a/tests_e2e/pytest.ini
+++ b/tests_e2e/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
 log_cli = true
-#put testing patterns here

--- a/tests_e2e/reports_robot/simple_report_rf50.xml
+++ b/tests_e2e/reports_robot/simple_report_rf50.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot generator="Robot 6.1 (Python 3.10.5 on win32)" generated="20230912 10:52:39.727" rpa="false" schemaversion="4">
+  <suite id="s1" name="Tests" source="tests">
+    <suite id="s1-s1" name="Footer-Tests" source="tests\footer-tests.robot">
+      <test id="s1-s1-t1" name="Verify Presence Of Social Links" line="6">
+        (...)
+        <status status="PASS" starttime="20230912 10:52:39.958" endtime="20230912 10:52:47.980"/>
+      </test>
+      <status status="PASS" starttime="20230912 10:52:39.743" endtime="20230912 10:52:47.980"/>
+    </suite>
+    <suite id="s1-s2" name="Homepage-Tests" source="tests\homepage-tests.robot">
+      <test id="s1-s2-t1" name="Verify Presence Of Header Links" line="6">
+        (...)
+        <status status="PASS" starttime="20230912 10:52:47.994" endtime="20230912 10:52:52.521"/>
+      </test>
+      <test id="s1-s2-t2" name="Verify Presence Of Demo Link" line="15">
+        <kw name="Open TestRail Homepage" library="keywords">
+          <status status="PASS" starttime="20230912 10:52:52.521" endtime="20230912 10:52:54.445"/>
+        </kw>
+        <kw name="Verify Header Demo Link" library="keywords">
+          <status status="FAIL" starttime="20230912 10:52:54.446" endtime="20230912 10:52:59.946"/>
+        </kw>
+        <kw name="Click Demo Link" library="keywords">
+          <status status="NOT RUN" starttime="20230912 10:52:59.947" endtime="20230912 10:52:59.947"/>
+        </kw>
+        <kw name="Verify Demo Page URL" library="keywords">
+          <status status="NOT RUN" starttime="20230912 10:52:59.947" endtime="20230912 10:52:59.947"/>
+        </kw>
+        <kw name="Close Test Browser" library="keywords" type="TEARDOWN">
+          <status status="PASS" starttime="20230912 10:52:59.948" endtime="20230912 10:53:03.127"/>
+        </kw>
+        <doc>Verifies header contains link to request a demo - Intentionally failing
+- testrail_case_field: refs:TR-1
+- testrail_case_field: priority_id:2
+- testrail_result_field: custom_environment:qa
+
+- testrail_attachment: C:\Github\gurock\automation-frameworks-integration\samples\robotframework\robotframework-selenium\reports\failure-2.png</doc>
+        <status status="FAIL" starttime="20230912 10:52:52.521" endtime="20230912 10:53:03.127">Element 'css=.breakdance-menu-list [href*='/invalid/']' not visible after 5 seconds.</status>
+      </test>
+    </suite>
+  </suite>
+</robot>

--- a/tests_e2e/test_end2end.py
+++ b/tests_e2e/test_end2end.py
@@ -388,3 +388,40 @@ trcli -y \\
                 "Submitted 22 test cases"
             ]
         )
+
+    def test_cli_add_run(self):
+        output = _run_cmd(f"""
+trcli -y \\
+  -h {self.TR_INSTANCE} \\
+  --project "SA - (DO NOT DELETE) TRCLI-E2E-Tests" \\
+  add_run \\
+  --title "[CLI-E2E-Tests] ADD RUN TEST: Create run_config.yml" \\
+  -f "run_config.yml"
+        """)
+        _assert_contains(
+            output,
+            [
+                "Creating test run.",
+                f"Test run: {self.TR_INSTANCE}index.php?/runs/view",
+                "title: [CLI-E2E-Tests] ADD RUN TEST: Create run_config.yml",
+                "Writing test run data to file (run_config.yml). Done."
+            ]
+        )
+
+    def test_cli_add_run_upload_results(self):
+        output = _run_cmd(f"""
+trcli -y \\
+  -h {self.TR_INSTANCE} \\
+  --project "SA - (DO NOT DELETE) TRCLI-E2E-Tests" \\
+  -c run_config.yml \\
+  parse_junit \\
+  -f "reports_junit/generic_ids_auto.xml"
+        """)
+        _assert_contains(
+            output,
+            [
+                f"Updating test run. Test run: {self.TR_INSTANCE}index.php?/runs/view",
+                "Uploading 1 attachments for 1 test results.",
+                "Submitted 6 test results"
+            ]
+        )

--- a/tests_e2e/test_end2end.py
+++ b/tests_e2e/test_end2end.py
@@ -58,10 +58,10 @@ trcli -y \\
         _assert_contains(
             output,
             [
-                "Processed 5 test cases in 2 sections.",
+                "Processed 3 test cases in 2 sections.",
                 f"Creating test run. Test run: {self.TR_INSTANCE}index.php?/runs/view",
                 "Uploading 1 attachments for 1 test results.",
-                "Submitted 5 test results in"
+                "Submitted 3 test results in"
             ]
         )
 
@@ -72,15 +72,15 @@ trcli -y \\
   --project "SA - (DO NOT DELETE) TRCLI-E2E-Tests" \\
   parse_robot \\
   --title "[CLI-E2E-Tests] ROBOT FRAMEWORK PARSER" \\
-  -f "reports_robot/simple_report_RF70.xml"
+  -f "reports_robot/simple_report_RF50.xml"
         """)
         _assert_contains(
             output,
             [
-                "Processed 5 test cases in 2 sections.",
+                "Processed 3 test cases in 2 sections.",
                 f"Creating test run. Test run: {self.TR_INSTANCE}index.php?/runs/view",
                 "Uploading 1 attachments for 1 test results.",
-                "Submitted 5 test results in"
+                "Submitted 3 test results in"
             ]
         )
 
@@ -97,8 +97,7 @@ trcli -y \\
         _assert_contains(
             output,
             [
-                "Processed 3 test cases in section [GENERIC-IDS-AUTO] Suite 1",
-                "Processed 3 test cases in section [GENERIC-IDS-AUTO] Suite 2",
+                "Processed 3 test cases in section [GENERIC-IDS-AUTO]",
                 f"Creating test run. Test run: {self.TR_INSTANCE}index.php?/runs/view",
                 "Uploading 1 attachments for 1 test results.",
                 "Submitted 6 test results in"
@@ -119,8 +118,7 @@ trcli -y \\
         _assert_contains(
             output,
             [
-                "Processed 3 test cases in section [GENERIC-IDS-AUTO] Suite 1",
-                "Processed 3 test cases in section [GENERIC-IDS-AUTO] Suite 2",
+                "Processed 3 test cases in section [GENERIC-IDS-AUTO]",
                 f"Creating test run. Test run: {self.TR_INSTANCE}index.php?/runs/view",
                 "Uploading 1 attachments for 1 test results.",
                 "Submitted 6 test results in"
@@ -140,14 +138,13 @@ trcli -y \\
         _assert_contains(
             output,
             [
-                "Processed 3 test cases in section [GENERIC-IDS-AUTO] Suite 1.",
-                "Processed 3 test cases in section [GENERIC-IDS-AUTO] Suite 2.",
+                "Processed 3 test cases in section [GENERIC-IDS-AUTO]",
                 f"Updating test run. Test run: {self.TR_INSTANCE}index.php?/runs/view",
                 "Uploading 1 attachments for 1 test results.",
                 "Submitted 6 test results in"
             ]
         )
-
+    
     def test_cli_update_run_in_plan_with_configs(self):
         output = _run_cmd(f"""
 trcli -y \\
@@ -161,8 +158,7 @@ trcli -y \\
         _assert_contains(
             output,
             [
-                "Processed 3 test cases in section [GENERIC-IDS-AUTO] Suite 1.",
-                "Processed 3 test cases in section [GENERIC-IDS-AUTO] Suite 2.",
+                "Processed 3 test cases in section [GENERIC-IDS-AUTO]",
                 f"Updating test run. Test run: {self.TR_INSTANCE}index.php?/runs/view",
                 "Uploading 1 attachments for 1 test results.",
                 "Submitted 6 test results in"
@@ -181,8 +177,7 @@ trcli -y \\
         _assert_contains(
             output,
             [
-                "Processed 3 test cases in section [GENERIC-IDS-AUTO] Suite 1.",
-                "Processed 3 test cases in section [GENERIC-IDS-AUTO] Suite 2.",
+                "Processed 3 test cases in section [GENERIC-IDS-AUTO]",
                 f"Creating test run. Test run: {self.TR_INSTANCE}index.php?/runs/view",
                 "Uploading 1 attachments for 1 test results.",
                 "Submitted 6 test results in"
@@ -203,8 +198,7 @@ trcli -y \\
         _assert_contains(
             output,
             [
-                "Processed 3 test cases in section [GENERIC-IDS-AUTO] Suite 1.",
-                "Processed 3 test cases in section [GENERIC-IDS-AUTO] Suite 2.",
+                "Processed 3 test cases in section [GENERIC-IDS-AUTO]",
                 f"Updating test run. Test run: {self.TR_INSTANCE}index.php?/runs/view",
                 "Uploading 1 attachments for 1 test results.",
                 "Submitted 6 test results in"
@@ -223,14 +217,13 @@ trcli -y \\
         _assert_contains(
             output,
             [
-                "Processed 3 test cases in section [MULTIPART-REPORT-2] testsuite element 2B (with tests).",
-                "Processed 1 test cases in section [MULTIPART-REPORT-1] testsuite element 1B (with tests).",
+                "Processed 3 test cases in section [MULTIPART-REPORT-2]",
                 f"Creating test run. Test run: {self.TR_INSTANCE}index.php?/runs/view",
                 "No attachments found to upload.",
                 "Submitted 4 test results in"
             ]
         )
-
+    
     def test_cli_matchers_name(self):
         output = _run_cmd(f"""
 trcli -n \\
@@ -244,15 +237,14 @@ trcli -n \\
         _assert_contains(
             output,
             [
-                "Processed 3 test cases in section [GENERIC-IDS-NAME] Suite 1.",
-                "Processed 3 test cases in section [GENERIC-IDS-NAME] Suite 2.",
+                "Processed 3 test cases in section [GENERIC-IDS-NAME]",
                 "Found 3 test cases without case ID in the report file.",
                 f"Creating test run. Test run: {self.TR_INSTANCE}index.php?/runs/view",
                 "Uploading 1 attachments for 1 test results.",
                 "Submitted 3 test results in"
             ]
         )
-
+    
     def test_cli_matchers_property(self):
         output = _run_cmd(f"""
 trcli -n \\
@@ -266,15 +258,14 @@ trcli -n \\
         _assert_contains(
             output,
             [
-                "Processed 3 test cases in section [GENERIC-IDS-PROP] Suite 1.",
-                "Processed 3 test cases in section [GENERIC-IDS-PROP] Suite 2.",
+                "Processed 3 test cases in section [GENERIC-IDS-PROP]",
                 "Found 3 test cases without case ID in the report file.",
                 f"Creating test run. Test run: {self.TR_INSTANCE}index.php?/runs/view",
                 "Uploading 1 attachments for 1 test results.",
                 "Submitted 3 test results in"
             ]
         )
-
+    
     def test_cli_attachments(self):
         output = _run_cmd(f"""
 trcli -y \\
@@ -287,13 +278,12 @@ trcli -y \\
         _assert_contains(
             output,
             [
-                "Processed 3 test cases in section [ATTACHMENTS] tests.LoginTests.",
+                "Processed 3 test cases in section [ATTACHMENTS]",
                 f"Creating test run. Test run: {self.TR_INSTANCE}index.php?/runs/view",
                 "Uploading 4 attachments for 2 test results.",
                 "Submitted 3 test results in"
             ]
         )
-
     def test_cli_multisuite_with_suite_id(self):
         output = _run_cmd(f"""
 trcli -y \\
@@ -307,10 +297,10 @@ trcli -y \\
         _assert_contains(
             output,
             [
-                "Processed 1 test cases in section [DUPLICATES] NewTest.",
-                "Processed 3 test cases in section [DUPLICATES] Professional.",
-                "Processed 3 test cases in section [DUPLICATES] Enterprise.",
-                "Processed 3 test cases in section [DUPLICATES] Basic.",
+                "Processed 1 test cases in section [DUPLICATES] NewTest",
+                "Processed 3 test cases in section [DUPLICATES] Professional",
+                "Processed 3 test cases in section [DUPLICATES] Enterprise",
+                "Processed 3 test cases in section [DUPLICATES] Basic",
                 f"Creating test run. Test run: {self.TR_INSTANCE}index.php?/runs/view",
                 "No attachments found to upload.",
                 "Submitted 10 test results in"
@@ -330,10 +320,10 @@ trcli -y \\
         _assert_contains(
             output,
             [
-                "Processed 1 test cases in section [DUPLICATES] NewTest.",
-                "Processed 3 test cases in section [DUPLICATES] Professional.",
-                "Processed 3 test cases in section [DUPLICATES] Enterprise.",
-                "Processed 3 test cases in section [DUPLICATES] Basic.",
+                "Processed 1 test cases in section [DUPLICATES] NewTest",
+                "Processed 3 test cases in section [DUPLICATES] Professional",
+                "Processed 3 test cases in section [DUPLICATES] Enterprise",
+                "Processed 3 test cases in section [DUPLICATES] Basic",
                 f"Creating test run. Test run: {self.TR_INSTANCE}index.php?/runs/view",
                 "No attachments found to upload.",
                 "Submitted 10 test results in"
@@ -352,16 +342,16 @@ trcli -y \\
         _assert_contains(
             output,
             [
-                "Processed 1 test cases in section [DUPLICATES] NewTest.",
-                "Processed 3 test cases in section [DUPLICATES] Professional.",
-                "Processed 3 test cases in section [DUPLICATES] Enterprise.",
-                "Processed 3 test cases in section [DUPLICATES] Basic.",
+                "Processed 1 test cases in section [DUPLICATES] NewTest",
+                "Processed 3 test cases in section [DUPLICATES] Professional",
+                "Processed 3 test cases in section [DUPLICATES] Enterprise",
+                "Processed 3 test cases in section [DUPLICATES] Basic",
                 f"Creating test run. Test run: {self.TR_INSTANCE}index.php?/runs/view",
                 "No attachments found to upload.",
                 "Submitted 10 test results in"
             ]
         )
-
+    
     def test_cli_saucelabs(self):
         output = _run_cmd(f"""
 trcli -y \\
@@ -378,12 +368,11 @@ trcli -y \\
                 "Found 2 SauceLabs suites.",
                 "Processing JUnit suite - Firefox",
                 "Processing JUnit suite - Chrome",
-                "Processed 1 test cases in section [SAUCELABS] test_suite_1.cy.js.",
-                "Processed 1 test cases in section [SAUCELABS] test_suite_2.cy.js.",
+                "Processed 1 test cases in section [SAUCELABS]",
                 f"Creating test run. Test run: {self.TR_INSTANCE}index.php?/runs/view"
             ]
         )
-
+    
     def test_cli_openapi(self):
         output = _run_cmd(f"""
 trcli -y \\


### PR DESCRIPTION
## Issue being resolved: Additional script for add run command used for end to end tests

### Solution description


### Changes
We updated the test_end2end.py under tests_e2e to include the necessary tests/assertions.

### Potential impacts
What could potentially be affected by the implemented changes? 

### Steps to test
You may uncomment the line from tox.ini for end to end functional test or do:

1. Create a virtual environment then activate it.
2. Change directory to tests_e2e
3. Install the requirements using PIP: pip install -r requirements.txt
4. Export your credentials in TR_CLI_USERNAME=<your username>, and TR_CLI_PASSWORD=<your api key>
5. Change the Testrail host in Line 41 of test_end2end.py to point to your Testrail host.
6. Execute test: `pytest -c ./pytest.ini -W ignore::pytest.PytestCollectionWarning  .`

### PR Tasks
- [x] PR reference added to issue
- [ ] README updated
- [x] Unit tests added/updated
