### PR TITLE
Fix pyserde dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,10 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        "click==8.1.*",
+        "click==8.0.3",
         "pyyaml>=6.0.0,<7.0.0",
         "junitparser>=3.1.0,<4.0.0",
-        "pyserde>=0.12.0,<1.0.0",
+        "pyserde==0.12.*",
         "requests>=2.31.0,<3.0.0",
         "tqdm>=4.65.0,<5.0.0",
         "humanfriendly>=10.0.0,<11.0.0",


### PR DESCRIPTION
There is a strict type hints on latter versions of pyserde. We have reverted back to the previous compatible version. We also reverted the click version to 8.0.3.
