### PR TITLE
Add missing test marker project_based_client

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -10,3 +10,5 @@ markers =
     dataclass: tests for dataclass
     api_handler: tests for api handler
     data_provider: tests for data provider
+    project_based_client: mark a test as a project-based client test.
+    


### PR DESCRIPTION
We have added a missing test marker used for pytest unit testing.
