### PR TITLE
Fix/run description bug

### DIFF
--- a/tests_e2e/test_end2end.py
+++ b/tests_e2e/test_end2end.py
@@ -425,3 +425,23 @@ trcli -y \\
                 "Submitted 6 test results"
             ]
         )
+
+    def bug_test_cli_robot_description_bug(self):
+        output = _run_cmd(f"""
+trcli -y \\
+  -h {self.TR_INSTANCE} \\
+  --project "SA - (DO NOT DELETE) TRCLI-E2E-Tests" \\
+  parse_robot \\
+  --title "[CLI-E2E-Tests] RUN DESCRIPTION BUG" \\
+  -f "reports_robot/simple_report_RF50.xml" \\
+  --run-id 2332
+        """)
+        _assert_contains(
+            output,
+            [
+                "Processed 3 test cases in 2 sections.",
+                "Uploading 1 attachments for 1 test results.",
+                "Submitted 3 test results in"
+            ]
+        )
+    

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -416,13 +416,18 @@ class ApiRequestHandler:
         :run_name: run name
         :returns: Tuple with run and error string.
         """
+        run_response = self.client.send_get(f"get_run/{run_id}")
+        existing_description = run_response.response_text.get("description", "")
+
         add_run_data = self.data_provider.add_run(run_name, milestone_id=milestone_id)
+        add_run_data["description"] = existing_description  # Retain the current description
+
         run_tests, error_message = self.__get_all_tests_in_run(run_id)
         run_case_ids = [test["case_id"] for test in run_tests]
         report_case_ids = add_run_data["case_ids"]
         joint_case_ids = list(set(report_case_ids + run_case_ids))
         add_run_data["case_ids"] = joint_case_ids
-        run_response = self.client.send_get(f"get_run/{run_id}")
+        
         plan_id = run_response.response_text["plan_id"]
         config_ids = run_response.response_text["config_ids"]
         if not plan_id:


### PR DESCRIPTION
## Issue being resolved: https://github.com/gurock/trcli/issues/250

### Solution description
The existing description is now fetched before the update and added to add_run_data, ensuring it doesn’t get overwritten or wiped out during the update process. The rest of the update logic remains unchanged, but now the description is always preserved unless explicitly changed. This approach ensures that the test run description will not be wiped during updates.

### Changes
We updated the api handler class to preserve the run description.

### Potential impacts
None

### PR Tasks
- [x] PR reference added to issue
- [ ] README updated
- [x] Unit tests added/updated
