### PR TITLE
Replace limit=0 query parameter to avoid 400 Bad Request responses

### DIFF
--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -13,7 +13,7 @@ from trcli.data_classes.data_parsers import MatchersParser
 from trcli.data_classes.dataclass_testrail import TestRailSuite, TestRailCase, ProjectData
 from trcli.data_providers.api_data_provider import ApiDataProvider
 from trcli.settings import MAX_WORKERS_ADD_RESULTS, MAX_WORKERS_ADD_CASE
-from urllib.parse import urlparse
+
 
 class ApiRequestHandler:
     """Sends requests based on DataProvider bodies"""

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -13,7 +13,7 @@ from trcli.data_classes.data_parsers import MatchersParser
 from trcli.data_classes.dataclass_testrail import TestRailSuite, TestRailCase, ProjectData
 from trcli.data_providers.api_data_provider import ApiDataProvider
 from trcli.settings import MAX_WORKERS_ADD_RESULTS, MAX_WORKERS_ADD_CASE
-
+from urllib.parse import urlparse
 
 class ApiRequestHandler:
     """Sends requests based on DataProvider bodies"""
@@ -691,7 +691,8 @@ class ApiRequestHandler:
             # Endpoints with pagination
             entities = entities + response.response_text[entity]
             if response.response_text["_links"]["next"] is not None:
-                return self.__get_all_entities(entity, link=response.response_text["_links"]["next"], entities=entities)
+                next_link = response.response_text["_links"]["next"].replace("limit=0", "limit=250")
+                return self.__get_all_entities(entity, link=next_link, entities=entities)
             else:
                 return entities, response.error_message
         else:


### PR DESCRIPTION
## Issue being resolved: https://github.com/gurock/trcli/issues/301

### Solution description
How are we solving the problem?
__get_all_entities() method needs more work than this easy fix.
1. The API of TestRail 8.0.6 `response.response_text["_links"]["next"]` and the link inside does not contain `?` marking the start of query parameters so it is not easy to parse with built-in libraries (e.g. `urllib.parse.urlparse()`)
2. One of the requests mentioned in #301 has query-param-like entity appended and set to 0, which causes the server to respond with 400 Bad Request.
Pay attention to this URL
`url: https://<redacted>/api/v2/get_sections/<project_id>&suite_id=<suite_id>&limit=0&offset=0`
There is no `?` so technically (based on `urllib.parse.urlparse`) there are no query parameters at all.
3. Having this in mind, we only check whether the `limit=0` string exists in `response.response_text["_links"]["next"]` and if that's true, we replace it with `limit=250`

### Changes
Explained above

### Potential impacts
Don't see. Ideally it should not be a hardcoded value. Maybe it should be investigated further why TestRail API returns such link in `response.response_text["_links"]["next"]` bodies.

### Steps to test
Follow reproduction steps from #301 

### PR Tasks
- [x] PR reference added to issue
- [ ] README updated
- [ ] Unit tests added/updated
