### PR TITLE
TR-14146: Revised help output for --key parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Options:
                      be duplicated in TestRail  [x>=1]
   -u, --username     Username.
   -p, --password     Password.
-  -k, --key          API key.
+  -k, --key          API key used for authenticating with TestRail.
+                     This must be used in conjunction with --username.
+                     If provided, --password is not required.
   -v, --verbose      Output all API calls and their results.
   --verify           Verify the data was added correctly.
   --insecure         Allow insecure requests.
@@ -78,10 +80,10 @@ Options:
   --help             Show this message and exit.
 
 Commands:
+  add_run        Add a new test run in TestRail
   parse_junit    Parse JUnit report and upload results to TestRail
   parse_openapi  Parse OpenAPI spec and create cases in TestRail
   parse_robot    Parse Robot Framework report and upload results to TestRail
-  add_run        Create a new test run (useful for CI/CD flows prior to parsing results)
 ```
 
 Uploading automated test results

--- a/trcli/cli.py
+++ b/trcli/cli.py
@@ -272,7 +272,7 @@ class TRCLI(click.MultiCommand):
 )
 @click.option("-u", "--username", type=click.STRING, metavar="", help="Username.")
 @click.option("-p", "--password", type=click.STRING, metavar="", help="Password.")
-@click.option("-k", "--key", metavar="", help="API key.")
+@click.option("-k", "--key", metavar="", help="API key used for authenticating with TestRail. This must be used in conjunction with --username. If provided, --password is not required.")
 @click.option(
     "-v", "--verbose", is_flag=True, help="Output all API calls and their results."
 )


### PR DESCRIPTION
### Solution description
- To avoid confusion in using --key (instead of --password) we added more context to help output.

### Changes
- Revised help description for --key (trcli --help)

### Potential impacts
None

### Steps to test
Happy path to test implemented scenario

### PR Tasks
- [x] PR reference added to issue
- [x] README updated
- [ ] Unit tests added/updated
