### PR TITLE
TRCLI-12: Added updates to fix issue when specifying case-ids in add_run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,8 +280,8 @@ Options:
   --run-assigned-to-id   The ID of the user the test run should be assigned
                          to.  [x>=1]
   --run-include-all      Use this option to include all test cases in this test run.
-  --case-ids             Comma separated list of test case IDs to include in
-                         the test run.
+  --run-case-ids         Comma separated list of test case IDs to include in
+                         the test run (i.e.: 1,2,3,4).
   --run-refs             A comma-separated list of references/requirements
   -f, --file             Write run title and id to file.
   --help                 Show this message and exit.

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -384,6 +384,7 @@ class ApiRequestHandler:
             assigned_to_id: int = None,
             include_all: bool = False,
             refs: str = None,
+            case_ids: List[int] = None,
     ) -> Tuple[int, str]:
         """
         Creates a new test run.
@@ -393,6 +394,7 @@ class ApiRequestHandler:
         """
         add_run_data = self.data_provider.add_run(
             run_name,
+            case_ids=case_ids,
             milestone_id=milestone_id,
             assigned_to_id=assigned_to_id,
             include_all=include_all,

--- a/trcli/api/project_based_client.py
+++ b/trcli/api/project_based_client.py
@@ -219,6 +219,7 @@ class ProjectBasedClient:
                 assigned_to_id=self.environment.run_assigned_to_id,
                 include_all=bool(self.environment.run_include_all),
                 refs=self.environment.run_refs,
+                case_ids=self.environment.run_case_ids,
             )
             run_id = added_run
         else:

--- a/trcli/commands/cmd_add_run.py
+++ b/trcli/commands/cmd_add_run.py
@@ -67,9 +67,10 @@ def write_run_to_file(environment: Environment, run_id: int):
     help="Use this option to include all test cases in this test run."
 )
 @click.option(
-    "--case-ids",
+    "--run-case-ids",
     metavar="",
-    help="Comma separated list of test case IDs to include in the test run."
+    type=lambda x: [int(i) for i in x.split(",")], 
+    help="Comma separated list of test case IDs to include in the test run (i.e.: 1,2,3,4)."
 )
 @click.option(
     "--run-refs",


### PR DESCRIPTION
## Issue being resolved: https://github.com/gurock/trcli/issues/284

### Solution description
include the parameter contents of case-ids when specified in add_run command.

### Changes
Updated the api handler class to properly include the case ids

### Potential impacts
None

### Steps to test
When using add_run command, specify the case ids using --run-case-ids and include valid case ids in comma separated format.

### PR Tasks
- [x] PR reference added to issue
- [x] README updated
- [x] Unit tests added/updated
