### PR TITLE
Add commands to close a test run created with add_run

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Options:
   --run-assigned-to-id   The ID of the user the test run should be assigned
                          to.  [x>=1]
   --run-include-all      Use this option to include all test cases in this test run.
+  --auto-close-run       Use this option to automatically close the created run.
   --run-case-ids         Comma separated list of test case IDs to include in
                          the test run (i.e.: 1,2,3,4).
   --run-refs             A comma-separated list of references/requirements

--- a/tests/test_project_based_client.py
+++ b/tests/test_project_based_client.py
@@ -390,6 +390,7 @@ class TestProjectBasedClient:
             project_based_client,
         ) = project_based_client_data_provider
         environment.run_id = None
+        environment.auto_close_run = False
         api_request_handler.add_run.return_value = (1, "")
         project_based_client.resolve_project()
         run_id, error_message = project_based_client.create_or_update_test_run()
@@ -411,6 +412,7 @@ class TestProjectBasedClient:
             project_based_client,
         ) = project_based_client_data_provider
         environment.run_id = 1
+        environment.auto_close_run = False
         api_request_handler.update_run.return_value = (1, "")
         project_based_client.resolve_project()
         run_id, error_message = project_based_client.create_or_update_test_run()

--- a/tests/test_results_uploader.py
+++ b/tests/test_results_uploader.py
@@ -208,16 +208,14 @@ class TestResultsUploader:
                 2: mocker.call("Removing unnecessary empty sections that may have been created earlier. ", new_line=False),
                 3: mocker.call("Removed 1 unused/empty section(s)."),
                 4: mocker.call("Creating test run. ", new_line=False),
-                5: mocker.call("Test run: https://fake_host.com/index.php?/runs/view/100"),
-                6: mocker.call("Closing test run. ", new_line=False),
+                5: mocker.call("Closing run. ", new_line=False),
             }
         else:
             calls = {
                 2: mocker.call("Removing unnecessary empty sections that may have been created earlier. ", new_line=False),
                 3: mocker.call("Removed 1 unused/empty section(s)."),
                 4: mocker.call("Updating test run. ", new_line=False),
-                5: mocker.call("Test run: https://fake_host.com/index.php?/runs/view/101"),
-                6: mocker.call("Closing test run. ", new_line=False),
+                5: mocker.call("Closing run. ", new_line=False),
             }
 
         results_uploader.upload_results()

--- a/trcli/api/project_based_client.py
+++ b/trcli/api/project_based_client.py
@@ -228,6 +228,13 @@ class ProjectBasedClient:
             run, error_message = self.api_request_handler.update_run(
                 run_id, self.run_name, self.environment.milestone_id
             )
+        if self.environment.auto_close_run:
+            self.environment.log("Closing run. ", new_line=False)
+            close_run, error_message = self.api_request_handler.close_run(run_id)
+            if close_run:
+                self.environment.log("Run closed successfully.")
+            else:
+                self.environment.elog(f"Failed to close run: {error_message}")
         if error_message:
             self.environment.elog("\n" + error_message)
         else:

--- a/trcli/cli.py
+++ b/trcli/cli.py
@@ -65,6 +65,7 @@ class Environment:
         self.run_assigned_to_id = None
         self.run_case_ids = None
         self.run_include_all = None
+        self.auto_close_run = None
         self.run_refs = None
         self.proxy = None  # Add proxy related attributes
         self.noproxy = None

--- a/trcli/commands/cmd_add_run.py
+++ b/trcli/commands/cmd_add_run.py
@@ -67,6 +67,12 @@ def write_run_to_file(environment: Environment, run_id: int):
     help="Use this option to include all test cases in this test run."
 )
 @click.option(
+    "--auto-close-run",
+    is_flag=True,
+    default=False,
+    help="Use this option to automatically close the created run."
+)
+@click.option(
     "--run-case-ids",
     metavar="",
     type=lambda x: [int(i) for i in x.split(",")], 


### PR DESCRIPTION
### Solution description
Added a new option in add_run command that will allow users to automatically close created test runs.

### Changes
We added a new --auto-close-run option under add_run command.

### Potential impacts
None

### Steps to test
1. Create a new run using add_run command
2. Add the option --auto-close-run then submit
3. The test run should be "closed" or "completed" in TestRail

### PR Tasks
- [x] PR reference added to issue
- [x] README updated
- [x] Unit tests added/updated
