### PR TITLE
Support Start and End Dates changes in the API for Test Runs and Test Plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ Options:
   --run-description      Summary text to be added to the test run.
   --milestone-id         Milestone ID to which the Test Run should be
                          associated to.  [x>=1]
+  --run-start-date       The expected or scheduled start date of this test run in MM/DD/YYYY format
+  --run-end-date         The expected or scheduled end date of this test run in MM/DD/YYYY format
   --run-assigned-to-id   The ID of the user the test run should be assigned
                          to.  [x>=1]
   --run-include-all      Use this option to include all test cases in this test run.

--- a/tests_e2e/test_end2end.py
+++ b/tests_e2e/test_end2end.py
@@ -444,6 +444,25 @@ trcli -y \\
                 "Submitted 6 test results"
             ]
         )
+    
+    def test_cli_add_run_and_plan_with_due_date(self):
+        output = _run_cmd(f"""
+trcli -y \\
+  -h {self.TR_INSTANCE} \\
+  --project "SA - (DO NOT DELETE) TRCLI-E2E-Tests" \\
+  add_run --run-include-all \\
+  --title "[CLI-E2E-Tests] ADD RUN TEST: Test Run with Due Date" \\
+  --run-start-date "03/01/2030" --run-end-date "03/12/2030"
+        """)
+        _assert_contains(
+            output,
+            [
+                "Creating test run.",
+                f"Test run: {self.TR_INSTANCE}index.php?/runs/view",
+                "title: [CLI-E2E-Tests] ADD RUN TEST: Test Run with Due Date"
+            ]
+        )
+
 
     def bug_test_cli_robot_description_bug(self):
         output = _run_cmd(f"""

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -404,6 +404,8 @@ class ApiRequestHandler:
             project_id: int,
             run_name: str,
             milestone_id: int = None,
+            start_date: str = None,
+            end_date: str = None,
             plan_id: int = None,
             config_ids: List[int] = None,
             assigned_to_id: int = None,
@@ -420,6 +422,8 @@ class ApiRequestHandler:
         add_run_data = self.data_provider.add_run(
             run_name,
             case_ids=case_ids,
+            start_date=start_date,
+            end_date=end_date,
             milestone_id=milestone_id,
             assigned_to_id=assigned_to_id,
             include_all=include_all,
@@ -443,7 +447,8 @@ class ApiRequestHandler:
             run_id = response.response_text["runs"][0]["id"]
         return run_id, response.error_message
 
-    def update_run(self, run_id: int, run_name: str, milestone_id: int = None) -> Tuple[dict, str]:
+    def update_run(self, run_id: int, run_name: str, start_date: str = None,
+            end_date: str = None, milestone_id: int = None) -> Tuple[dict, str]:
         """
         Updates an existing run
         :run_id: run id
@@ -453,7 +458,8 @@ class ApiRequestHandler:
         run_response = self.client.send_get(f"get_run/{run_id}")
         existing_description = run_response.response_text.get("description", "")
 
-        add_run_data = self.data_provider.add_run(run_name, milestone_id=milestone_id)
+        add_run_data = self.data_provider.add_run(run_name, start_date=start_date,
+            end_date=end_date, milestone_id=milestone_id)
         add_run_data["description"] = existing_description  # Retain the current description
 
         run_tests, error_message = self.__get_all_tests_in_run(run_id)

--- a/trcli/api/project_based_client.py
+++ b/trcli/api/project_based_client.py
@@ -214,6 +214,8 @@ class ProjectBasedClient:
                 project_id=self.project.project_id,
                 run_name=self.run_name,
                 milestone_id=self.environment.milestone_id,
+                start_date=self.environment.run_start_date,
+                end_date=self.environment.run_end_date,
                 plan_id=self.environment.plan_id,
                 config_ids=self.environment.config_ids,
                 assigned_to_id=self.environment.run_assigned_to_id,

--- a/trcli/cli.py
+++ b/trcli/cli.py
@@ -51,6 +51,8 @@ class Environment:
         self.plan_id = None
         self.config_ids = None
         self.milestone_id = None
+        self.run_start_date = None
+        self.run_end_date = None
         self.section_id = None
         self.auto_creation_response = None
         self.silent = None

--- a/trcli/commands/cmd_add_run.py
+++ b/trcli/commands/cmd_add_run.py
@@ -14,6 +14,8 @@ def print_config(env: Environment):
             f"\n> Suite ID: {env.suite_id}"
             f"\n> Description: {env.run_description}"
             f"\n> Milestone ID: {env.milestone_id}"
+            f"\n> Start Date: {env.run_start_date}"
+            f"\n> End Date: {env.run_end_date}"
             f"\n> Assigned To ID: {env.run_assigned_to_id}"
             f"\n> Include All: {env.run_include_all}"
             f"\n> Case IDs: {env.run_case_ids}"
@@ -53,6 +55,20 @@ def write_run_to_file(environment: Environment, run_id: int):
     type=click.IntRange(min=1),
     metavar="",
     help="Milestone ID to which the Test Run should be associated to.",
+)
+@click.option(
+    "--run-start-date",
+    metavar="",
+    default=None,
+    type=lambda x: [int(i) for i in x.split("/") if len(x.split("/")) == 3], 
+    help="The expected or scheduled start date of this test run in MM/DD/YYYY format"
+)
+@click.option(
+    "--run-end-date",
+    metavar="",
+    default=None,
+    type=lambda x: [int(i) for i in x.split("/") if len(x.split("/")) == 3], 
+    help="The expected or scheduled end date of this test run in MM/DD/YYYY format"
 )
 @click.option(
     "--run-assigned-to-id",

--- a/trcli/data_providers/api_data_provider.py
+++ b/trcli/data_providers/api_data_provider.py
@@ -1,6 +1,7 @@
 from beartype.typing import List, Dict, Optional
 
 from serde.json import to_dict
+from datetime import datetime, timezone
 
 from trcli.constants import OLD_SYSTEM_NAME_AUTOMATION_ID, UPDATED_SYSTEM_NAME_AUTOMATION_ID
 from trcli.data_classes.dataclass_testrail import TestRailSuite
@@ -66,6 +67,8 @@ class ApiDataProvider:
             self,
             run_name: Optional[str],
             case_ids=None,
+            start_date=None,
+            end_date=None,
             milestone_id=None,
             assigned_to_id=None,
             include_all=None,
@@ -93,6 +96,18 @@ class ApiDataProvider:
             "milestone_id": milestone_id,
             "case_ids": case_ids
         }
+        if isinstance(start_date, list) and start_date is not None:
+            try:
+                dt = datetime(start_date[2], start_date[0], start_date[1], tzinfo=timezone.utc)
+                body["start_on"] = int(dt.timestamp())
+            except ValueError:
+                body["start_on"] = None
+        if isinstance(end_date, list) and end_date is not None:
+            try:
+                dt = datetime(end_date[2], end_date[0], end_date[1], tzinfo=timezone.utc)
+                body["due_on"] = int(dt.timestamp())
+            except ValueError:
+                body["due_on"] = None
         if include_all is not None:
             body["include_all"] = include_all
         if assigned_to_id is not None:


### PR DESCRIPTION
### Solution description
There are new due date fields in TestRail for Test Runs and Test Plans that can now be passed as a parameter when creating or updating Test Runs/Plans in entry.

### Changes
Added new options to include start and end dates.

### Potential impacts
None since these fields are optional.

### Steps to test
1. Create a new run using add_run command
2. Add the parameter --run-start-date followed by  a date in MM/DD/YYYY format
3. Add the parameter --run-start-date followed by  a date in MM/DD/YYYY format
4. Once submitted, the due date for this run should be updated in TestRail.

### PR Tasks
- [x] PR reference added to issue
- [x] README updated
- [x] Unit tests added/updated
