### PR TITLE
update check_suite_id to handle paginated results

### DIFF
--- a/tests/test_api_request_handler.py
+++ b/tests/test_api_request_handler.py
@@ -163,6 +163,7 @@ class TestApiRequestHandler:
             "offset": 0,
             "limit": 250,
             "size": 2,
+            "_links": {"next": None, "prev": None},
             "suites": [
                 {"id": 4, "name": "Suite1", "description": "Test1", "project_id": 3},
                 {"id": 5, "name": "Suite2", "description": "Test2", "project_id": 3},


### PR DESCRIPTION
<!-- 
Thanks for contributing!
PLEASE:
- Read our contributing guidelines: https://github.com/gurock/trcli/blob/main/CONTRIBUTING.md
- Mark this PR as "Draft" if it is not ready for review.
-->

## Issue being resolved: https://github.com/gurock/trcli/issues/332

### Solution description
How are we solving the problem?

Updating check_suite_id to use __get_all_entities instead of __send_request to get paginated results. This PR creates a new method __get_all_suites following the pattern used by __get_all_projects and others.

### Changes
What changes where made?

check_suite_id now uses __get_all_suites, which wraps __get_all_entities to get paginated results. The API for check_suite_id does not change.

### Potential impacts
What could potentially be affected by the implemented changes? 

Any area of the cli where check_suite_id is called, it could add latency to the call. It should not otherwise impact anything, since it is still returning a boolean if the suite id is returned. 

### Steps to test
Happy path to test implemented scenario

Create a project with more than a single page of suites (ie >250). Use the add_run trcli command with --suite-id for a suite in the second page of results and observe that before this is merged, the call will fail with the error "Suite with ID (some id) does not exist in TestRail."

### PR Tasks
- [ ] PR reference added to issue
- [ ] README updated
- [ x] Unit tests added/updated
