### PR TITLE
Fix: Support JUnit 5 default generated test case names ending in parentheses

### DIFF
--- a/tests/test_data/XML/junit5_parentheses_test.xml
+++ b/tests/test_data/XML/junit5_parentheses_test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="JUnit 5 Test Suite with Parentheses">
+    <testsuite failures="0" errors="0" skipped="1" tests="4" time="0.05" name="JUnit5ParenthesesTests">
+        <!-- JUnit 5 style test names with parentheses that should now work -->
+        <testcase classname="com.example.MyTests" name="test_name_C120013()" time="1.5"/>
+        <testcase classname="com.example.MyTests" name="testMethod_C123()" time="2.1"/>
+        <testcase classname="com.example.MyTests" name="complexTest_C456(String param, int value)" time="0.8"/>
+        
+        <!-- Test case that should still work (at beginning) -->
+        <testcase classname="com.example.MyTests" name="C789_test_name()" time="1.2"/>
+        
+        <!-- Test case with brackets (should still work) -->
+        <testcase classname="com.example.MyTests" name="[C999] test_with_brackets()" time="0.9"/>
+        
+        <!-- Test case without parentheses (regression test) -->
+        <testcase classname="com.example.MyTests" name="test_name_C555" time="1.0"/>
+    </testsuite>
+</testsuites>

--- a/tests/test_data/json/junit5_parentheses_test.json
+++ b/tests/test_data/json/junit5_parentheses_test.json
@@ -1,0 +1,101 @@
+{
+  "name": "JUnit 5 Test Suite with Parentheses",
+  "testsections": [
+    {
+      "name": "JUnit5ParenthesesTests",
+      "testcases": [
+        {
+          "title": "test_name",
+          "case_id": 120013,
+          "result": {
+            "case_id": 120013,
+            "elapsed": 1.5,
+            "attachments": [],
+            "result_fields": {},
+            "custom_step_results": [],
+            "status_id": 1,
+            "comment": ""
+          },
+          "custom_automation_id": "com.example.MyTests.test_name_C120013()",
+          "case_fields": {}
+        },
+        {
+          "title": "testMethod",
+          "case_id": 123,
+          "result": {
+            "case_id": 123,
+            "elapsed": 2.1,
+            "attachments": [],
+            "result_fields": {},
+            "custom_step_results": [],
+            "status_id": 1,
+            "comment": ""
+          },
+          "custom_automation_id": "com.example.MyTests.testMethod_C123()",
+          "case_fields": {}
+        },
+        {
+          "title": "complexTest",
+          "case_id": 456,
+          "result": {
+            "case_id": 456,
+            "elapsed": 0.8,
+            "attachments": [],
+            "result_fields": {},
+            "custom_step_results": [],
+            "status_id": 1,
+            "comment": ""
+          },
+          "custom_automation_id": "com.example.MyTests.complexTest_C456(String param, int value)",
+          "case_fields": {}
+        },
+        {
+          "title": "test_name()",
+          "case_id": 789,
+          "result": {
+            "case_id": 789,
+            "elapsed": 1.2,
+            "attachments": [],
+            "result_fields": {},
+            "custom_step_results": [],
+            "status_id": 1,
+            "comment": ""
+          },
+          "custom_automation_id": "com.example.MyTests.C789_test_name()",
+          "case_fields": {}
+        },
+        {
+          "title": "test_with_brackets()",
+          "case_id": 999,
+          "result": {
+            "case_id": 999,
+            "elapsed": 0.9,
+            "attachments": [],
+            "result_fields": {},
+            "custom_step_results": [],
+            "status_id": 1,
+            "comment": ""
+          },
+          "custom_automation_id": "com.example.MyTests.[C999] test_with_brackets()",
+          "case_fields": {}
+        },
+        {
+          "title": "test_name",
+          "case_id": 555,
+          "result": {
+            "case_id": 555,
+            "elapsed": 1.0,
+            "attachments": [],
+            "result_fields": {},
+            "custom_step_results": [],
+            "status_id": 1,
+            "comment": ""
+          },
+          "custom_automation_id": "com.example.MyTests.test_name_C555",
+          "case_fields": {}
+        }
+      ]
+    }
+  ],
+  "source": null
+}

--- a/tests/test_matchers_parser.py
+++ b/tests/test_matchers_parser.py
@@ -1,0 +1,101 @@
+import pytest
+from trcli.data_classes.data_parsers import MatchersParser
+
+
+class TestMatchersParser:
+    """Test cases for MatchersParser.parse_name_with_id method"""
+
+    @pytest.mark.parametrize(
+        "test_input, expected_id, expected_name",
+        [
+            # Basic patterns (existing functionality)
+            ("C123 my test case", 123, "my test case"),
+            ("my test case C123", 123, "my test case"),
+            ("C123_my_test_case", 123, "my_test_case"),
+            ("my_test_case_C123", 123, "my_test_case"),
+            ("module_1_C123_my_test_case", 123, "module_1_my_test_case"),
+            ("[C123] my test case", 123, "my test case"),
+            ("my test case [C123]", 123, "my test case"),
+            ("module 1 [C123] my test case", 123, "module 1 my test case"),
+            
+            # JUnit 5 patterns with parentheses (new functionality)
+            ("test_name_C120013()", 120013, "test_name"),
+            ("testMethod_C123()", 123, "testMethod"),
+            ("my_test_C456()", 456, "my_test"),
+            ("C789_test_name()", 789, "test_name()"),
+            ("C100 test_name()", 100, "test_name()"),
+            
+            # JUnit 5 patterns with parameters
+            ("test_name_C120013(TestParam)", 120013, "test_name"),
+            ("test_C456(param1, param2)", 456, "test"),
+            ("complexTest_C999(String param, int value)", 999, "complexTest"),
+            
+            # Edge cases with parentheses
+            ("myTest_C789()", 789, "myTest"),
+            ("C200_method()", 200, "method()"),
+            ("[C300] test_case()", 300, "test_case()"),
+            ("test [C400] method()", 400, "test method()"),
+            
+            # Cases that should not match
+            ("test_name_C()", None, "test_name_C()"),
+            ("test_name_123()", None, "test_name_123()"),
+            ("test_name", None, "test_name"),
+            ("C_test_name", None, "C_test_name"),
+            ("test_Cabc_name", None, "test_Cabc_name"),
+            
+            # Case sensitivity
+            ("c123_test_name", 123, "test_name"),
+            ("test_name_c456", 456, "test_name"),
+            ("[c789] test_name", 789, "test_name"),
+        ]
+    )
+    def test_parse_name_with_id_patterns(self, test_input, expected_id, expected_name):
+        """Test various patterns of test name parsing including JUnit 5 parentheses support"""
+        case_id, case_name = MatchersParser.parse_name_with_id(test_input)
+        assert case_id == expected_id, f"Expected ID {expected_id}, got {case_id} for input '{test_input}'"
+        assert case_name == expected_name, f"Expected name '{expected_name}', got '{case_name}' for input '{test_input}'"
+
+    def test_parse_name_with_id_junit5_specific(self):
+        """Specific test cases for JUnit 5 parentheses issue reported by user"""
+        # The exact examples from the user's issue
+        junit5_cases = [
+            ("test_name_C120013()", 120013, "test_name"),  # Should work now
+            ("test_name_C120013", 120013, "test_name"),    # Should still work
+            ("C120013_test_name()", 120013, "test_name()"), # Should work
+        ]
+        
+        for test_case, expected_id, expected_name in junit5_cases:
+            case_id, case_name = MatchersParser.parse_name_with_id(test_case)
+            assert case_id == expected_id, f"JUnit 5 case failed: {test_case}"
+            assert case_name == expected_name, f"JUnit 5 name failed: {test_case}"
+
+    def test_parse_name_with_id_regression(self):
+        """Ensure existing functionality still works (regression test)"""
+        # Test all the patterns mentioned in the docstring
+        existing_patterns = [
+            ("C123 my test case", 123, "my test case"),
+            ("my test case C123", 123, "my test case"),  
+            ("C123_my_test_case", 123, "my_test_case"),
+            ("my_test_case_C123", 123, "my_test_case"),
+            ("module_1_C123_my_test_case", 123, "module_1_my_test_case"),
+            ("[C123] my test case", 123, "my test case"),
+            ("my test case [C123]", 123, "my test case"),
+            ("module 1 [C123] my test case", 123, "module 1 my test case"),
+        ]
+        
+        for test_case, expected_id, expected_name in existing_patterns:
+            case_id, case_name = MatchersParser.parse_name_with_id(test_case)
+            assert case_id == expected_id, f"Regression failed for: {test_case}"
+            assert case_name == expected_name, f"Regression name failed for: {test_case}"
+
+    def test_parse_name_with_id_empty_and_none(self):
+        """Test edge cases with empty or None inputs"""
+        # Empty string
+        case_id, case_name = MatchersParser.parse_name_with_id("")
+        assert case_id is None
+        assert case_name == ""
+        
+        # String with just spaces
+        case_id, case_name = MatchersParser.parse_name_with_id("   ")
+        assert case_id is None
+        assert case_name == "   "

--- a/trcli/data_classes/data_parsers.py
+++ b/trcli/data_classes/data_parsers.py
@@ -19,6 +19,7 @@ class MatchersParser:
         - "[C123] my test case"
         - "my test case [C123]"
         - "module 1 [C123] my test case"
+        - "my_test_case_C123()" (JUnit 5 support)
 
         :param case_name: Name of the test case
         :return: Tuple with test case ID and test case name without the ID
@@ -29,9 +30,10 @@ class MatchersParser:
             for idx, part in enumerate(parts):
                 if part.lower().startswith("c") and len(part) > 1:
                     id_part = part[1:]
-                    if id_part.isnumeric():
+                    id_part_clean = re.sub(r'\(.*\)$', '', id_part)
+                    if id_part_clean.isnumeric():
                         parts_copy.pop(idx)
-                        return int(id_part), char.join(parts_copy)
+                        return int(id_part_clean), char.join(parts_copy)
 
         results = re.findall(r"\[(.*?)\]", case_name)
         for result in results:


### PR DESCRIPTION

## Issue being resolved: https://github.com/gurock/trcli/issues/350

### Solution description
Updated matcher parser to account for JUnit 5 default format for test names which includes parentheses

### Changes
Updated the data_parsers.py class logic to strip trailing parentheses and cleans up ID part for numeric validity.

### Potential impacts
None. Maintains backward compatibility with existing patterns.

### Steps to test
Upload a test result file with test names ending in parentheses.

### PR Tasks
- [x] PR reference added to issue
- [ ] README updated
- [x] Unit tests added/updated
