### PR TITLE
Smart Automated Failed tests Assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Options:
   --allow-ms          Allows using milliseconds for elapsed times.
   --special-parser    Optional special parser option for specialized JUnit
                       reports.
+  -a, --assign        Comma-separated list of user emails to assign failed test 
+                      results to.
   --help              Show this message and exit.
 ```
 
@@ -266,6 +268,50 @@ case_result_statuses:
 ```
 You can find statuses ids for your project using following endpoint:
  ```/api/v2/get_statuses```
+
+### Auto-Assigning Failed Tests
+
+The `--assign` (or `-a`) option allows you to automatically assign failed test results to specific TestRail users. This feature is particularly useful in CI/CD environments where you want to automatically assign failures to responsible team members for investigation.
+
+#### Usage
+
+```shell
+# Assign failed tests to a single user
+$ trcli parse_junit -f results.xml --assign user@example.com \
+  --host https://yourinstance.testrail.io --username <your_username> --password <your_password> \
+  --project "Your Project"
+
+# Assign failed tests to multiple users (round-robin distribution)
+$ trcli parse_junit -f results.xml --assign "user1@example.com,user2@example.com,user3@example.com" \
+  --host https://yourinstance.testrail.io --username <your_username> --password <your_password> \
+  --project "Your Project"
+
+# Short form using -a
+$ trcli parse_junit -f results.xml -a user@example.com \
+  --host https://yourinstance.testrail.io --username <your_username> --password <your_password> \
+  --project "Your Project"
+```
+
+#### Example Output
+
+```shell
+Parser Results Execution Parameters
+> Report file: results.xml
+> Config file: /path/to/config.yml
+> TestRail instance: https://yourinstance.testrail.io (user: your@email.com)
+> Project: Your Project
+> Run title: Automated Test Run
+> Update run: No
+> Add to milestone: No
+> Auto-assign failures: Yes (user1@example.com,user2@example.com)
+> Auto-create entities: True
+
+Creating test run. Done.
+Adding results: 100%|████████████| 25/25 [00:02<00:00, 12.5results/s]
+Assigning failed results: 3/3, Done.
+Submitted 25 test results in 2.1 secs.
+```
+
 ### Exploring other features
 
 #### General features

--- a/tests/test_results_uploader.py
+++ b/tests/test_results_uploader.py
@@ -36,6 +36,9 @@ class TestResultsUploader:
         environment.run_id = None
         environment.file = "results.xml"
         environment.case_matcher = MatchersParser.AUTO
+        environment.assign_failed_to = None
+        environment._has_invalid_users = False
+        environment._validated_user_ids = []
 
         junit_file_parser = mocker.patch.object(JunitParser, "parse_file")
         api_request_handler = mocker.patch(

--- a/tests_e2e/reports_junit/assign_test_failures.xml
+++ b/tests_e2e/reports_junit/assign_test_failures.xml
@@ -1,0 +1,39 @@
+<testsuites>
+    <testsuite failures="3" errors="1" skipped="1" tests="6" time="15.5" name="[ASSIGNTESTSUITE] Suite">
+        <!-- Passed test -->
+        <testcase classname="[ASSIGNTESTSUITE] Suite" name="[C101] test successful operation" time="2.1"/>
+        
+        <!-- Failed test 1 -->
+        <testcase classname="[ASSIGNTESTSUITE] Suite" name="[C102] test failed validation" time="1.5">
+            <failure type="AssertionError" message="Validation failed">
+                Expected validation to pass, but it failed with error: Invalid input
+            </failure>
+        </testcase>
+        
+        <!-- Failed test 2 -->
+        <testcase classname="[ASSIGNTESTSUITE] Suite" name="[C103] test failed network call" time="3.2">
+            <failure type="NetworkError" message="Connection timeout">
+                Network call failed after 30 seconds timeout
+            </failure>
+        </testcase>
+        
+        <!-- Error test -->
+        <testcase classname="[ASSIGNTESTSUITE] Suite" name="[C104] test error exception" time="0.8">
+            <error type="RuntimeError" message="Unexpected runtime error">
+                An unexpected runtime error occurred during test execution
+            </error>
+        </testcase>
+        
+        <!-- Failed test 3 -->
+        <testcase classname="[ASSIGNTESTSUITE] Suite" name="[C105] test failed assertion" time="1.9">
+            <failure type="AssertionError" message="Assertion failed">
+                Expected value 'expected' but got 'actual'
+            </failure>
+        </testcase>
+        
+        <!-- Skipped test -->
+        <testcase classname="[ASSIGNTESTSUITE] Suite" name="[C106] test skipped feature" time="0.0">
+            <skipped type="pytest.skip" message="Feature not implemented"/>
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/trcli/cli.py
+++ b/trcli/cli.py
@@ -69,7 +69,8 @@ class Environment:
         self.run_include_all = None
         self.auto_close_run = None
         self.run_refs = None
-        self.proxy = None  # Add proxy related attributes
+        self.proxy = None
+        self.assign_failed_to = None  # Add proxy related attributes
         self.noproxy = None
         self.proxy_user = None
 

--- a/trcli/commands/cmd_parse_junit.py
+++ b/trcli/commands/cmd_parse_junit.py
@@ -21,6 +21,12 @@ from trcli.readers.junit_xml import JunitParser
     type=click.Choice(["junit", "saucectl"], case_sensitive=False),
     help="Optional special parser option for specialized JUnit reports."
 )
+@click.option(
+    "-a", "--assign",
+    "assign_failed_to",
+    metavar="",
+    help="Comma-separated list of user emails to assign failed test results to."
+)
 @click.pass_context
 @pass_environment
 def cli(environment: Environment, context: click.Context, *args, **kwargs):

--- a/trcli/commands/results_parser_helpers.py
+++ b/trcli/commands/results_parser_helpers.py
@@ -7,6 +7,7 @@ from trcli.cli import Environment
 
 
 def print_config(env: Environment):
+    assign_info = f"Yes ({env.assign_failed_to})" if hasattr(env, 'assign_failed_to') and env.assign_failed_to and env.assign_failed_to.strip() else "No"
     env.log(f"Parser Results Execution Parameters"
             f"\n> Report file: {env.file}"
             f"\n> Config file: {env.config}"
@@ -15,6 +16,7 @@ def print_config(env: Environment):
             f"\n> Run title: {env.title}"
             f"\n> Update run: {env.run_id if env.run_id else 'No'}"
             f"\n> Add to milestone: {env.milestone_id if env.milestone_id else 'No'}"
+            f"\n> Auto-assign failures: {assign_info}"
             f"\n> Auto-create entities: {env.auto_creation_response}")
 
 


### PR DESCRIPTION
### Solution description
This feature enables teams to automatically assign failed automated tests to a responsible engineer or owner during result upload, ensuring clear accountability and reducing the overhead of manual triage.

### Changes
Added a new --assign, -a option under parse_junit command that allows users to automatically assigned failed tests to users.

### Potential impacts
None.

### Steps to test
Upload a test result file with failed tests and use the --assign option together with a valid user email when using parse_junit. Once the results are uploaded they should automatically be assigned to the specified user.

### PR Tasks
- [ ] PR reference added to issue
- [x] README updated
- [x] Unit tests added/updated
