### PR TITLE
TRCLI-236: Fixed an issue where empty case validation is not skipped for add_run

### DIFF
--- a/trcli/api/run_handler.py
+++ b/trcli/api/run_handler.py
@@ -89,8 +89,14 @@ class RunHandler:
         )
 
         # Validate that we have test cases to include in the run
-        # Empty runs are not allowed unless include_all is True
-        if not include_all and (not add_run_data.get("case_ids") or len(add_run_data["case_ids"]) == 0):
+        # Empty runs are not allowed for parse commands unless include_all is True
+        # However, add_run command explicitly allows empty runs for later result uploads
+        is_add_run_command = self.environment.cmd == "add_run"
+        if (
+            not is_add_run_command
+            and not include_all
+            and (not add_run_data.get("case_ids") or len(add_run_data["case_ids"]) == 0)
+        ):
             error_msg = (
                 "Cannot create test run: No test cases were matched.\n"
                 "  - For parse_junit: Ensure tests have automation_id/test ids that matches existing cases in TestRail\n"


### PR DESCRIPTION

### Solution description
Allow empty runs to be added to add_run command (skip validation)

### Changes
Updated validation to exclude empty runs added via add_run command in run_handler.py

### Potential impacts
What could potentially be affected by the implemented changes?

### Steps to test
Execute command to add an empty run: trcli -c config.yml add_run --title Add empty run

### PR Tasks
- [x] PR reference added to issue
- [x] README updated
- [x] Unit tests added/updated
