### PR TITLE
TRCLI-244: Attachment upload failure when adding results to empty test runs

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -15,7 +15,7 @@ _released 04-01-2026
  - <to_update>
 
 ### Fixed
- - 
+ - Fixed attachment upload failure when adding results to empty test runs (runs created via API with `include_all: false` and no `case_ids`). Attachments now upload correctly by using direct case_id to result_id mapping instead of fetching tests from the run. 
 
 ## [1.13.4]
 

--- a/tests/test_api_request_handler.py
+++ b/tests/test_api_request_handler.py
@@ -1116,18 +1116,6 @@ class TestApiRequestHandler:
     @pytest.mark.api_handler
     def test_upload_attachments_413_error(self, api_request_handler: ApiRequestHandler, requests_mock, tmp_path):
         """Test that 413 errors (file too large) are properly reported."""
-        run_id = 1
-
-        # Mock get_tests endpoint
-        mocked_tests_response = {
-            "offset": 0,
-            "limit": 250,
-            "size": 1,
-            "_links": {"next": None, "prev": None},
-            "tests": [{"id": 1001, "case_id": 100}],
-        }
-        requests_mock.get(create_url(f"get_tests/{run_id}"), json=mocked_tests_response)
-
         # Create a temporary test file
         test_file = tmp_path / "large_attachment.jpg"
         test_file.write_text("test content")
@@ -1141,10 +1129,10 @@ class TestApiRequestHandler:
 
         # Prepare test data
         report_results = [{"case_id": 100, "attachments": [str(test_file)]}]
-        results = [{"id": 2001, "test_id": 1001}]
+        case_id_to_result_id = {100: 2001}
 
         # Call upload_attachments
-        api_request_handler.upload_attachments(report_results, results, run_id)
+        api_request_handler.upload_attachments(report_results, case_id_to_result_id)
 
         # Verify the request was made (case-insensitive comparison)
         assert requests_mock.last_request.url.lower() == create_url("add_attachment_to_result/2001").lower()
@@ -1152,18 +1140,6 @@ class TestApiRequestHandler:
     @pytest.mark.api_handler
     def test_upload_attachments_success(self, api_request_handler: ApiRequestHandler, requests_mock, tmp_path):
         """Test that successful attachment uploads work correctly."""
-        run_id = 1
-
-        # Mock get_tests endpoint
-        mocked_tests_response = {
-            "offset": 0,
-            "limit": 250,
-            "size": 1,
-            "_links": {"next": None, "prev": None},
-            "tests": [{"id": 1001, "case_id": 100}],
-        }
-        requests_mock.get(create_url(f"get_tests/{run_id}"), json=mocked_tests_response)
-
         # Create a temporary test file
         test_file = tmp_path / "test_attachment.jpg"
         test_file.write_text("test content")
@@ -1173,10 +1149,10 @@ class TestApiRequestHandler:
 
         # Prepare test data
         report_results = [{"case_id": 100, "attachments": [str(test_file)]}]
-        results = [{"id": 2001, "test_id": 1001}]
+        case_id_to_result_id = {100: 2001}
 
         # Call upload_attachments
-        api_request_handler.upload_attachments(report_results, results, run_id)
+        api_request_handler.upload_attachments(report_results, case_id_to_result_id)
 
         # Verify the request was made (case-insensitive comparison)
         assert requests_mock.last_request.url.lower() == create_url("add_attachment_to_result/2001").lower()
@@ -1184,24 +1160,55 @@ class TestApiRequestHandler:
     @pytest.mark.api_handler
     def test_upload_attachments_file_not_found(self, api_request_handler: ApiRequestHandler, requests_mock):
         """Test that missing attachment files are properly reported."""
-        run_id = 1
-
-        # Mock get_tests endpoint
-        mocked_tests_response = {
-            "offset": 0,
-            "limit": 250,
-            "size": 1,
-            "_links": {"next": None, "prev": None},
-            "tests": [{"id": 1001, "case_id": 100}],
-        }
-        requests_mock.get(create_url(f"get_tests/{run_id}"), json=mocked_tests_response)
-
         # Prepare test data with non-existent file
         report_results = [{"case_id": 100, "attachments": ["/path/to/nonexistent/file.jpg"]}]
-        results = [{"id": 2001, "test_id": 1001}]
+        case_id_to_result_id = {100: 2001}
 
         # Call upload_attachments - should not raise exception
-        api_request_handler.upload_attachments(report_results, results, run_id)
+        api_request_handler.upload_attachments(report_results, case_id_to_result_id)
+
+    @pytest.mark.api_handler
+    def test_upload_attachments_empty_run_scenario(
+        self, api_request_handler: ApiRequestHandler, requests_mock, tmp_path
+    ):
+        """Test that attachments work correctly when results are added to an empty run.
+
+        This test covers the bug fix for issue where TRCLI failed to upload attachments
+        when using --run-id with an empty run (created via API with include_all: false
+        and no case_ids). The fix uses case_id to result_id mapping instead of fetching
+        tests from the run.
+        """
+        # Create test attachment files
+        attachment1 = tmp_path / "screenshot1.png"
+        attachment1.write_text("screenshot content 1")
+        attachment2 = tmp_path / "screenshot2.png"
+        attachment2.write_text("screenshot content 2")
+
+        # Mock successful attachment uploads
+        requests_mock.post(create_url("add_attachment_to_result/5001"), status_code=200, json={"attachment_id": 9001})
+        requests_mock.post(create_url("add_attachment_to_result/5002"), status_code=200, json={"attachment_id": 9002})
+
+        # Prepare test data - two cases with attachments
+        report_results = [
+            {"case_id": 100, "attachments": [str(attachment1)]},
+            {"case_id": 101, "attachments": [str(attachment2)]},
+        ]
+
+        # Case ID to result ID mapping (this is built from add_results_for_cases response)
+        case_id_to_result_id = {100: 5001, 101: 5002}
+
+        # Call upload_attachments
+        api_request_handler.upload_attachments(report_results, case_id_to_result_id)
+
+        # Verify both attachments were uploaded correctly
+        history = requests_mock.request_history
+        upload_requests = [req for req in history if "add_attachment_to_result" in req.url]
+        assert len(upload_requests) == 2, "Should have uploaded 2 attachments"
+
+        # Verify correct result IDs were used
+        urls = [req.url.lower() for req in upload_requests]
+        assert any("add_attachment_to_result/5001" in url for url in urls), "Should upload to result 5001"
+        assert any("add_attachment_to_result/5002" in url for url in urls), "Should upload to result 5002"
 
     @pytest.mark.api_handler
     def test_caching_reduces_api_calls(self, api_request_handler: ApiRequestHandler, requests_mock):

--- a/tests/test_cmd_add_run.py
+++ b/tests/test_cmd_add_run.py
@@ -147,6 +147,19 @@ class TestCmdAddRun:
         assert result.exit_code == 1
         assert "cannot be used together" in result.output
 
+    @mock.patch("trcli.cli.Environment.check_for_required_parameters")
+    def test_run_case_ids_mutually_exclusive_with_run_include_all(self, mock_check):
+        """Test that --run-case-ids and --run-include-all are mutually exclusive"""
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cmd_add_run.cli,
+            ["--title", "Test Run", "--run-case-ids", "1,2,3", "--run-include-all"],
+        )
+
+        assert result.exit_code == 1
+        assert "cannot be used together" in result.output
+
 
 class TestApiRequestHandlerReferences:
     """Test class for reference management functionality"""

--- a/tests/test_data/XML/multiple_case_ids_with_attachments.xml
+++ b/tests/test_data/XML/multiple_case_ids_with_attachments.xml
@@ -27,7 +27,7 @@
       <properties>
         <property name="test_id" value="C1050420, C1050421"/>
         <property name="testrail_case_field" value="custom_preconds:Setup database and test users"/>
-        <property name="testrail_case_field" value="custom_automation_type:e2e"/>
+        <property name="testrail_case_field" value="custom_automation_type:1"/>
         <property name="testrail_case_field"><![CDATA[custom_steps:1. Login to application
 2. Navigate to dashboard
 3. Verify data loaded]]>
@@ -53,7 +53,7 @@
         <property name="testrail_attachment" value="/evidence/debug.log"/>
         <property name="testrail_result_field" value="version:2.0.0"/>
         <property name="testrail_result_field" value="browser:firefox"/>
-        <property name="testrail_case_field" value="custom_automation_type:integration"/>
+        <property name="testrail_case_field" value="custom_automation_type:1"/>
         <property name="testrail_result_comment" value="Full integration test executed successfully"/>
         <property name="testrail_result_step" value="passed:Setup complete"/>
         <property name="testrail_result_step" value="passed:Execution complete"/>

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -284,8 +284,8 @@ class ApiRequestHandler:
     ) -> Tuple[bool, str, List[str], List[str], List[str]]:
         return self.case_handler.update_existing_case_references(case_id, junit_refs, case_fields, strategy)
 
-    def upload_attachments(self, report_results: List[Dict], results: List[Dict], run_id: int):
-        return self.result_handler.upload_attachments(report_results, results, run_id)
+    def upload_attachments(self, report_results: List[Dict], case_id_to_result_id: Dict[int, int]):
+        return self.result_handler.upload_attachments(report_results, case_id_to_result_id)
 
     def add_results(self, run_id: int) -> Tuple[List, str, int]:
         return self.result_handler.add_results(run_id)

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -257,9 +257,20 @@ class ApiRequestHandler:
         refs: str = None,
         refs_action: str = "add",
         assigned_to_id: Union[int, None] = ...,
+        include_all: Union[bool, type(...)] = ...,
+        case_ids: Union[List[int], type(...)] = ...,
     ) -> Tuple[dict, str]:
         return self.run_handler.update_run(
-            run_id, run_name, start_date, end_date, milestone_id, refs, refs_action, assigned_to_id
+            run_id,
+            run_name,
+            start_date,
+            end_date,
+            milestone_id,
+            refs,
+            refs_action,
+            assigned_to_id,
+            include_all,
+            case_ids,
         )
 
     def _manage_references(self, existing_refs: str, new_refs: str, action: str) -> str:

--- a/trcli/api/project_based_client.py
+++ b/trcli/api/project_based_client.py
@@ -222,6 +222,18 @@ class ProjectBasedClient:
             else:
                 assigned_to_id = ...  # Don't change (sentinel value)
 
+            # Determine include_all and case_ids based on user input
+            if self.environment.run_include_all:
+                include_all = True
+                case_ids = ...  # Ignore case_ids when include_all is True
+            elif self.environment.run_case_ids:
+                include_all = False
+                case_ids = self.environment.run_case_ids
+            else:
+                # Neither provided - preserve existing settings
+                include_all = ...
+                case_ids = ...
+
             run, error_message = self.api_request_handler.update_run(
                 run_id,
                 self.run_name,
@@ -231,6 +243,8 @@ class ProjectBasedClient:
                 refs=self.environment.run_refs,
                 refs_action=getattr(self.environment, "run_refs_action", "add"),
                 assigned_to_id=assigned_to_id,
+                include_all=include_all,
+                case_ids=case_ids,
             )
         if self.environment.auto_close_run:
             self.environment.log("Closing run. ", new_line=False)

--- a/trcli/api/result_handler.py
+++ b/trcli/api/result_handler.py
@@ -44,61 +44,60 @@ class ResultHandler:
         self.__get_all_tests_in_run = get_all_tests_in_run_callback
         self.handle_futures = handle_futures_callback
 
-    def upload_attachments(self, report_results: List[Dict], results: List[Dict], run_id: int):
+    def upload_attachments(self, report_results: List[Dict], case_id_to_result_id: Dict[int, int]):
         """
-        Getting test result id and upload attachments for it.
+        Upload attachments to test results.
 
         :param report_results: List of test results with attachments from report
-        :param results: List of created results from TestRail
-        :param run_id: Run ID
+        :param case_id_to_result_id: Mapping from case_id to result_id
         """
-        tests_in_run, error = self.__get_all_tests_in_run(run_id)
-        if not error:
-            failed_uploads = []
-            for report_result in report_results:
-                case_id = report_result["case_id"]
-                test_id = next((test["id"] for test in tests_in_run if test["case_id"] == case_id), None)
-                result_id = next((result["id"] for result in results if result["test_id"] == test_id), None)
-                for file_path in report_result.get("attachments"):
-                    try:
-                        with open(file_path, "rb") as file:
-                            response = self.client.send_post(
-                                f"add_attachment_to_result/{result_id}", files={"attachment": file}
-                            )
+        failed_uploads = []
+        for report_result in report_results:
+            case_id = report_result["case_id"]
+            result_id = case_id_to_result_id.get(case_id)
 
-                            # Check if upload was successful
-                            if response.status_code != 200:
-                                file_name = os.path.basename(file_path)
+            if result_id is None:
+                self.environment.elog(f"Unable to find result_id for case {case_id}, skipping attachments.")
+                continue
 
-                                # Handle 413 Request Entity Too Large specifically
-                                if response.status_code == 413:
-                                    error_msg = FAULT_MAPPING["attachment_too_large"].format(
-                                        file_name=file_name, case_id=case_id
-                                    )
-                                    self.environment.elog(error_msg)
-                                    failed_uploads.append(f"{file_name} (case {case_id})")
-                                else:
-                                    # Handle other HTTP errors
-                                    error_msg = FAULT_MAPPING["attachment_upload_failed"].format(
-                                        file_path=file_name,
-                                        case_id=case_id,
-                                        error_message=response.error_message or f"HTTP {response.status_code}",
-                                    )
-                                    self.environment.elog(error_msg)
-                                    failed_uploads.append(f"{file_name} (case {case_id})")
-                    except FileNotFoundError:
-                        self.environment.elog(f"Attachment file not found: {file_path} (case {case_id})")
-                        failed_uploads.append(f"{file_path} (case {case_id})")
-                    except Exception as ex:
-                        file_name = os.path.basename(file_path) if os.path.exists(file_path) else file_path
-                        self.environment.elog(f"Error uploading attachment '{file_name}' for case {case_id}: {ex}")
-                        failed_uploads.append(f"{file_name} (case {case_id})")
+            for file_path in report_result.get("attachments"):
+                try:
+                    with open(file_path, "rb") as file:
+                        response = self.client.send_post(
+                            f"add_attachment_to_result/{result_id}", files={"attachment": file}
+                        )
 
-            # Provide a summary if there were failed uploads
-            if failed_uploads:
-                self.environment.log(f"\nWarning: {len(failed_uploads)} attachment(s) failed to upload.")
-        else:
-            self.environment.elog(f"Unable to upload attachments due to API request error: {error}")
+                        # Check if upload was successful
+                        if response.status_code != 200:
+                            file_name = os.path.basename(file_path)
+
+                            # Handle 413 Request Entity Too Large specifically
+                            if response.status_code == 413:
+                                error_msg = FAULT_MAPPING["attachment_too_large"].format(
+                                    file_name=file_name, case_id=case_id
+                                )
+                                self.environment.elog(error_msg)
+                                failed_uploads.append(f"{file_name} (case {case_id})")
+                            else:
+                                # Handle other HTTP errors
+                                error_msg = FAULT_MAPPING["attachment_upload_failed"].format(
+                                    file_path=file_name,
+                                    case_id=case_id,
+                                    error_message=response.error_message or f"HTTP {response.status_code}",
+                                )
+                                self.environment.elog(error_msg)
+                                failed_uploads.append(f"{file_name} (case {case_id})")
+                except FileNotFoundError:
+                    self.environment.elog(f"Attachment file not found: {file_path} (case {case_id})")
+                    failed_uploads.append(f"{file_path} (case {case_id})")
+                except Exception as ex:
+                    file_name = os.path.basename(file_path) if os.path.exists(file_path) else file_path
+                    self.environment.elog(f"Error uploading attachment '{file_name}' for case {case_id}: {ex}")
+                    failed_uploads.append(f"{file_name} (case {case_id})")
+
+        # Provide a summary if there were failed uploads
+        if failed_uploads:
+            self.environment.log(f"\nWarning: {len(failed_uploads)} attachment(s) failed to upload.")
 
     def add_results(self, run_id: int) -> Tuple[List, str, int]:
         """
@@ -135,6 +134,18 @@ class ResultHandler:
                 responses = ResultHandler.retrieve_results_after_cancelling(futures)
         responses = [response.response_text for response in responses]
         results = [result for results_list in responses for result in results_list]
+
+        # Build case_id to result_id mapping based on order correspondence
+        # TestRail API preserves order, so we can match requests to responses
+        case_id_to_result_id = {}
+        for request_body, response_results in zip(add_results_data_chunks, responses):
+            # Match request case_ids to response result_ids by order
+            for request_result, response_result in zip(request_body["results"], response_results):
+                case_id = request_result.get("case_id")
+                result_id = response_result.get("id")
+                if case_id and result_id:
+                    case_id_to_result_id[case_id] = result_id
+
         report_results_w_attachments = []
         for results_data_chunk in add_results_data_chunks:
             for test_result in results_data_chunk["results"]:
@@ -147,7 +158,7 @@ class ResultHandler:
             self.environment.log(
                 f"Uploading {attachments_count} attachments " f"for {len(report_results_w_attachments)} test results."
             )
-            self.upload_attachments(report_results_w_attachments, results, run_id)
+            self.upload_attachments(report_results_w_attachments, case_id_to_result_id)
         else:
             self.environment.log(f"No attachments found to upload.")
 

--- a/trcli/api/run_handler.py
+++ b/trcli/api/run_handler.py
@@ -136,6 +136,8 @@ class RunHandler:
         refs: str = None,
         refs_action: str = "add",
         assigned_to_id: Union[int, None] = ...,
+        include_all: Union[bool, type(...)] = ...,
+        case_ids: Union[List[int], type(...)] = ...,
     ) -> Tuple[dict, str]:
         """
         Updates an existing run
@@ -148,6 +150,8 @@ class RunHandler:
         :param refs: references to manage
         :param refs_action: action to perform ('add', 'update', 'delete')
         :param assigned_to_id: user ID to assign (int), None to clear, or ... to leave unchanged
+        :param include_all: include all cases (bool) or ... to leave unchanged
+        :param case_ids: specific case IDs (List[int]) or ... to leave unchanged
         :returns: Tuple with run and error string.
         """
         run_response = self.client.send_get(f"get_run/{run_id}")
@@ -174,22 +178,36 @@ class RunHandler:
             add_run_data["assignedto_id"] = assigned_to_id  # Can be None (clears) or int (sets)
         # else: Don't include assignedto_id in payload (no change to existing assignee)
 
-        existing_include_all = run_response.response_text.get("include_all", False)
-        add_run_data["include_all"] = existing_include_all
-
-        if not existing_include_all:
-            # Only manage explicit case_ids when include_all=False
-            run_tests, error_message = self.__get_all_tests_in_run(run_id)
-            if error_message:
-                return None, f"Failed to get tests in run: {error_message}"
-            run_case_ids = [test["case_id"] for test in run_tests]
-            report_case_ids = add_run_data["case_ids"]
-            joint_case_ids = list(set(report_case_ids + run_case_ids))
-            add_run_data["case_ids"] = joint_case_ids
+        # Handle include_all - only change if explicitly provided
+        if include_all is not ...:
+            add_run_data["include_all"] = include_all
         else:
-            # include_all=True: TestRail includes all suite cases automatically
-            # Do NOT send case_ids array (TestRail ignores it anyway)
+            # Preserve existing value
+            existing_include_all = run_response.response_text.get("include_all", False)
+            add_run_data["include_all"] = existing_include_all
+
+        # Handle case_ids based on include_all state
+        if add_run_data["include_all"]:
+            # include_all=True: Remove case_ids (TestRail includes all suite cases automatically)
             add_run_data.pop("case_ids", None)
+        else:
+            # include_all=False: Handle case_ids
+            if case_ids is not ...:
+                # User explicitly provided case_ids - use them
+                add_run_data["case_ids"] = case_ids
+            else:
+                # Preserve existing case_ids
+                run_tests, error_message = self.__get_all_tests_in_run(run_id)
+                if error_message:
+                    return None, f"Failed to get tests in run: {error_message}"
+                run_case_ids = [test["case_id"] for test in run_tests]
+                # Merge with any case_ids from data provider (from report files)
+                report_case_ids = add_run_data.get("case_ids", [])
+                if report_case_ids:
+                    joint_case_ids = list(set(report_case_ids + run_case_ids))
+                    add_run_data["case_ids"] = joint_case_ids
+                else:
+                    add_run_data["case_ids"] = run_case_ids
 
         plan_id = run_response.response_text["plan_id"]
         config_ids = run_response.response_text["config_ids"]

--- a/trcli/commands/cmd_add_run.py
+++ b/trcli/commands/cmd_add_run.py
@@ -145,6 +145,10 @@ def cli(environment: Environment, context: click.Context, *args, **kwargs):
     if environment.run_refs_action == "delete" and not environment.run_refs and environment.run_id:
         environment.run_refs = ""
 
+    if environment.run_case_ids and environment.run_include_all:
+        environment.elog("Error: --run-case-ids and --run-include-all cannot be used together.")
+        exit(1)
+
     print_config(environment)
 
     project_client = ProjectBasedClient(


### PR DESCRIPTION
## Issue being resolved: https://github.com/gurock/trcli/issues/404

### Solution description
Fixed attachment upload failure when adding results to empty test runs (runs created via API with include_all: false and no case_ids).

### Changes
Changed mapping case_id directly to result_id instead of fetching tests from the run.

### Potential impacts
None.

### Steps to test

1. Create an empty test run using add_run with include all = false (take note of the run id)
2. Upload an xml junnit file using parse_junit  (must be referencing attachments).

### PR Tasks
- [x] PR reference added to issue
- [ ] README updated
- [x] Unit tests added/updated
