### PR TITLE
TRCLI-246: Attachments are all uploaded to the last result when multiple results are added to case while parsing several reports via glob support

### DIFF
--- a/tests/test_api_request_handler.py
+++ b/tests/test_api_request_handler.py
@@ -1377,10 +1377,10 @@ class TestApiRequestHandler:
 
         # Prepare test data
         report_results = [{"case_id": 100, "attachments": [str(test_file)]}]
-        case_id_to_result_id = {100: 2001}
+        request_id_to_result_id = {id(report_results[0]): 2001}
 
         # Call upload_attachments
-        api_request_handler.upload_attachments(report_results, case_id_to_result_id)
+        api_request_handler.upload_attachments(report_results, request_id_to_result_id)
 
         # Verify the request was made (case-insensitive comparison)
         assert requests_mock.last_request.url.lower() == create_url("add_attachment_to_result/2001").lower()
@@ -1397,10 +1397,10 @@ class TestApiRequestHandler:
 
         # Prepare test data
         report_results = [{"case_id": 100, "attachments": [str(test_file)]}]
-        case_id_to_result_id = {100: 2001}
+        request_id_to_result_id = {id(report_results[0]): 2001}
 
         # Call upload_attachments
-        api_request_handler.upload_attachments(report_results, case_id_to_result_id)
+        api_request_handler.upload_attachments(report_results, request_id_to_result_id)
 
         # Verify the request was made (case-insensitive comparison)
         assert requests_mock.last_request.url.lower() == create_url("add_attachment_to_result/2001").lower()
@@ -1410,10 +1410,10 @@ class TestApiRequestHandler:
         """Test that missing attachment files are properly reported."""
         # Prepare test data with non-existent file
         report_results = [{"case_id": 100, "attachments": ["/path/to/nonexistent/file.jpg"]}]
-        case_id_to_result_id = {100: 2001}
+        request_id_to_result_id = {id(report_results[0]): 2001}
 
         # Call upload_attachments - should not raise exception
-        api_request_handler.upload_attachments(report_results, case_id_to_result_id)
+        api_request_handler.upload_attachments(report_results, request_id_to_result_id)
 
     @pytest.mark.api_handler
     def test_upload_attachments_empty_run_scenario(
@@ -1423,8 +1423,8 @@ class TestApiRequestHandler:
 
         This test covers the bug fix for issue where TRCLI failed to upload attachments
         when using --run-id with an empty run (created via API with include_all: false
-        and no case_ids). The fix uses case_id to result_id mapping instead of fetching
-        tests from the run.
+        and no case_ids). The fix uses request object identity to result_id mapping instead
+        of case_id mapping, which correctly handles duplicate case_ids.
         """
         # Create test attachment files
         attachment1 = tmp_path / "screenshot1.png"
@@ -1442,11 +1442,11 @@ class TestApiRequestHandler:
             {"case_id": 101, "attachments": [str(attachment2)]},
         ]
 
-        # Case ID to result ID mapping (this is built from add_results_for_cases response)
-        case_id_to_result_id = {100: 5001, 101: 5002}
+        # Request object ID to result ID mapping (this is built from add_results_for_cases response)
+        request_id_to_result_id = {id(report_results[0]): 5001, id(report_results[1]): 5002}
 
         # Call upload_attachments
-        api_request_handler.upload_attachments(report_results, case_id_to_result_id)
+        api_request_handler.upload_attachments(report_results, request_id_to_result_id)
 
         # Verify both attachments were uploaded correctly
         history = requests_mock.request_history
@@ -1457,6 +1457,47 @@ class TestApiRequestHandler:
         urls = [req.url.lower() for req in upload_requests]
         assert any("add_attachment_to_result/5001" in url for url in urls), "Should upload to result 5001"
         assert any("add_attachment_to_result/5002" in url for url in urls), "Should upload to result 5002"
+
+    @pytest.mark.api_handler
+    def test_upload_attachments_duplicate_case_ids_different_results(
+        self, api_request_handler: ApiRequestHandler, requests_mock, tmp_path
+    ):
+        """Test that attachments are uploaded to correct results when same case_id appears multiple times."""
+        # Create test attachment files
+        attachment1 = tmp_path / "report1_screenshot.png"
+        attachment1.write_text("screenshot from report 1")
+        attachment2 = tmp_path / "report2_screenshot.png"
+        attachment2.write_text("screenshot from report 2")
+
+        # Mock successful attachment uploads
+        requests_mock.post(create_url("add_attachment_to_result/1001"), status_code=200, json={"attachment_id": 9001})
+        requests_mock.post(create_url("add_attachment_to_result/1002"), status_code=200, json={"attachment_id": 9002})
+
+        # Prepare test data - SAME case_id (123) but different result objects with different attachments
+        # This simulates what happens when glob pattern processes multiple reports with the same test
+        result1 = {"case_id": 123, "attachments": [str(attachment1)]}
+        result2 = {"case_id": 123, "attachments": [str(attachment2)]}
+        report_results = [result1, result2]
+
+        # Request object ID to result ID mapping
+        # Key insight: We map by object identity, NOT by case_id
+        request_id_to_result_id = {
+            id(result1): 1001,  # First occurrence of case 123
+            id(result2): 1002,  # Second occurrence of case 123
+        }
+
+        # Call upload_attachments
+        api_request_handler.upload_attachments(report_results, request_id_to_result_id)
+
+        # Verify both attachments were uploaded correctly
+        history = requests_mock.request_history
+        upload_requests = [req for req in history if "add_attachment_to_result" in req.url]
+        assert len(upload_requests) == 2, "Should have uploaded 2 attachments"
+
+        # Verify attachments went to DIFFERENT result IDs (not both to 1002)
+        urls = [req.url.lower() for req in upload_requests]
+        assert any("add_attachment_to_result/1001" in url for url in urls), "Should upload attachment1 to result 1001"
+        assert any("add_attachment_to_result/1002" in url for url in urls), "Should upload attachment2 to result 1002"
 
     @pytest.mark.api_handler
     def test_caching_reduces_api_calls(self, api_request_handler: ApiRequestHandler, requests_mock):

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -286,8 +286,8 @@ class ApiRequestHandler:
     ) -> Tuple[bool, str, List[str], List[str], List[str]]:
         return self.case_handler.update_existing_case_references(case_id, junit_refs, case_fields, strategy)
 
-    def upload_attachments(self, report_results: List[Dict], case_id_to_result_id: Dict[int, int]):
-        return self.result_handler.upload_attachments(report_results, case_id_to_result_id)
+    def upload_attachments(self, report_results: List[Dict], request_id_to_result_id: Dict[int, int]):
+        return self.result_handler.upload_attachments(report_results, request_id_to_result_id)
 
     def add_results(self, run_id: int) -> Tuple[List, str, int]:
         return self.result_handler.add_results(run_id)

--- a/trcli/api/result_handler.py
+++ b/trcli/api/result_handler.py
@@ -44,17 +44,18 @@ class ResultHandler:
         self.__get_all_tests_in_run = get_all_tests_in_run_callback
         self.handle_futures = handle_futures_callback
 
-    def upload_attachments(self, report_results: List[Dict], case_id_to_result_id: Dict[int, int]):
+    def upload_attachments(self, report_results: List[Dict], request_id_to_result_id: Dict[int, int]):
         """
         Upload attachments to test results.
 
         :param report_results: List of test results with attachments from report
-        :param case_id_to_result_id: Mapping from case_id to result_id
+        :param request_id_to_result_id: Mapping from request object id to result_id
         """
         failed_uploads = []
         for report_result in report_results:
             case_id = report_result["case_id"]
-            result_id = case_id_to_result_id.get(case_id)
+            # Use object identity to find the correct result_id for THIS specific result
+            result_id = request_id_to_result_id.get(id(report_result))
 
             if result_id is None:
                 self.environment.elog(f"Unable to find result_id for case {case_id}, skipping attachments.")
@@ -133,18 +134,18 @@ class ResultHandler:
                 # Iterate through futures to get all responses from done tasks (not cancelled)
                 responses = ResultHandler.retrieve_results_after_cancelling(futures)
         responses = [response.response_text for response in responses]
-        results = [result for results_list in responses for result in results_list]
 
-        # Build case_id to result_id mapping based on order correspondence
+        # Build request to result_id mapping based on order correspondence
         # TestRail API preserves order, so we can match requests to responses
-        case_id_to_result_id = {}
+        # Use id() to uniquely identify each request result object (handles duplicate case_ids)
+        request_id_to_result_id = {}
         for request_body, response_results in zip(add_results_data_chunks, responses):
-            # Match request case_ids to response result_ids by order
+            # Match request result objects to response result_ids by order
             for request_result, response_result in zip(request_body["results"], response_results):
-                case_id = request_result.get("case_id")
                 result_id = response_result.get("id")
-                if case_id and result_id:
-                    case_id_to_result_id[case_id] = result_id
+                if result_id:
+                    # Use object identity to uniquely map each request to its API response
+                    request_id_to_result_id[id(request_result)] = result_id
 
         report_results_w_attachments = []
         for results_data_chunk in add_results_data_chunks:
@@ -158,7 +159,7 @@ class ResultHandler:
             self.environment.log(
                 f"Uploading {attachments_count} attachments " f"for {len(report_results_w_attachments)} test results."
             )
-            self.upload_attachments(report_results_w_attachments, case_id_to_result_id)
+            self.upload_attachments(report_results_w_attachments, request_id_to_result_id)
         else:
             self.environment.log(f"No attachments found to upload.")
 


### PR DESCRIPTION
### Solution description
Changed the mapping to use object identity (id()) instead of case_id, allowing each result object to be uniquely tracked even when multiple results share the same case_id.

### Changes
Results Handler (api/result_handler.py):
 - Changed case_id_to_result_id to request_id_to_result_id mapping, updated add_results() method to map by object identity, updated upload_attachments() signature and implementation and removed unused results variable.

API Request Handler (api/api_request_handler.py):
- Updated upload_attachments() wrapper method signature

Unit Test (tests/test_api_request_handler.py):
- Updated 4 attachment test to use new approach and added new test: test_upload_attachments_duplicate_case_ids_different_results

### Potential impacts
None

### Steps to test

1. Execute parse_junit command against several reports (via glob support) that:
 - have the same case in them and both have attachment to upload to result
 - have the same case in them and one of them (the first to be parsed) has attachment to uploaded to result

2. Open created run in TestRail and verify how exactly attachments are uploaded

### PR Tasks
- [x] PR reference added to issue
- [ ] README updated
- [x] Unit tests added/updated
