### PR TITLE
TRCLI-270: Get/Read Export command for Cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The TestRail CLI currently supports:
 - **Auto-generating test cases from OpenAPI specifications**
 - **Creating new test runs for results to be uploaded to**
 - **Managing project labels for better organization and categorization**
+- **Retrieving and listing test cases with advanced filtering**
 
 To see further documentation about the TestRail CLI, please refer to the 
 [TestRail CLI documentation pages](https://support.gurock.com/hc/en-us/articles/7146548750868-TestRail-CLI)
@@ -46,6 +47,7 @@ Supported and loaded modules:
     - labels: Manage labels (add, update, delete, list)
     - results: Manage test results (list, update)
     - references: Manage references (cases and runs)
+    - cases: Manage test cases (get, list with filters)
 ```
 
 CLI general reference
@@ -90,6 +92,7 @@ Options:
 
 Commands:
   add_run        Add a new test run in TestRail
+  cases          Manage test cases in TestRail
   export_gherkin Export BDD test case from TestRail as .feature file
   import_gherkin Upload Gherkin .feature file to TestRail
   labels         Manage labels in TestRail
@@ -1428,6 +1431,250 @@ trcli results list --help
 trcli results update --help
 ```
 
+#### Managing Test Cases
+
+The TestRail CLI provides the `cases` command for retrieving and listing test cases from TestRail. This command is useful for discovering test cases, exporting case data, and integrating with external tools or CI/CD pipelines.
+
+##### Cases Command Overview
+
+The `cases` command supports two subcommands:
+
+| Subcommand | Purpose | Use Case |
+|------------|---------|----------|
+| `cases get` | Retrieve a single test case by ID | Get detailed information about a specific test case |
+| `cases list` | List test cases with filters | Discover cases, export case data, filter by suite/priority |
+
+##### Reference
+
+```shell
+$ trcli cases --help
+Usage: trcli cases [OPTIONS] COMMAND [ARGS]...
+
+  Manage test cases in TestRail
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  get   Get a single test case by ID
+  list  List test cases from TestRail
+```
+
+##### Retrieving a Single Test Case
+
+Get detailed information about a specific test case by its ID:
+
+```shell
+# Get a test case (using config file)
+$ trcli cases get -c config.yml --case-id 123
+
+# Get a test case with all parameters
+$ trcli cases get \
+  --host https://yourinstance.testrail.io \
+  --username <your_username> \
+  --password <your_password> \
+  --project "Your Project" \
+  --case-id 123
+
+# Get case with all fields displayed
+$ trcli cases get -c config.yml --case-id 123 --show-all-fields
+
+# Get case as JSON (for piping to jq or other tools)
+$ trcli cases get -c config.yml --case-id 123 --json-output
+```
+
+**Output example:**
+```
+Cases Get Execution Parameters
+> TestRail instance: https://yourinstance.testrail.io (user: user@example.com)
+> Project: Your Project
+
+Retrieving case ID 123...
+
+Case ID: 123
+  Title: Login functionality test
+  Section ID: 1
+  Suite ID: 2
+  Template ID: 1
+  Type ID: 1
+  Priority ID: 2
+  References: JIRA-123, JIRA-456
+  Created By: 1
+  Created On: 1646317844
+  Updated By: 1
+  Updated On: 1646317844
+  Labels: automated, regression
+  Custom Fields: 3 field(s)
+```
+
+**JSON output example:**
+```json
+{
+  "id": 123,
+  "title": "Login functionality test",
+  "section_id": 1,
+  "suite_id": 2,
+  "template_id": 1,
+  "type_id": 1,
+  "priority_id": 2,
+  "refs": "JIRA-123, JIRA-456",
+  "created_by": 1,
+  "created_on": 1646317844,
+  "updated_by": 1,
+  "updated_on": 1646317844,
+  "labels": [
+    {
+      "id": 1,
+      "title": "automated"
+    },
+    {
+      "id": 2,
+      "title": "regression"
+    }
+  ],
+  "custom_steps": "Step 1\nStep 2\nStep 3"
+}
+```
+
+##### Listing Test Cases with Filters
+
+List test cases from a project with optional filtering by suite, priority, or text search:
+
+```shell
+# List all cases in a project (using config file)
+$ trcli cases list -c config.yml
+
+# List cases with suite filter
+$ trcli cases list -c config.yml --suite-id 2
+
+# List cases with priority filter (high priority only)
+$ trcli cases list -c config.yml --priority-id 4
+
+# List cases with multiple priorities
+$ trcli cases list -c config.yml --priority-id "3,4"
+
+# List cases with text search
+$ trcli cases list -c config.yml --filter "login"
+
+# Combine multiple filters
+$ trcli cases list -c config.yml --suite-id 2 --priority-id 4 --filter "authentication"
+
+# Pagination support
+$ trcli cases list -c config.yml --offset 250 --limit 100
+
+# JSON output for integration with other tools
+$ trcli cases list -c config.yml --suite-id 2 --json-output | jq '.cases[].title'
+```
+
+**Output example:**
+```
+Cases List Execution Parameters
+> TestRail instance: https://yourinstance.testrail.io (user: user@example.com)
+> Project: Your Project
+
+Retrieving cases for project ID 1 (suite_id=2)...
+Found 3 case(s) (showing 1-3):
+
+  Case ID: 123
+    Title: Login functionality test
+    Section ID: 1
+    Suite ID: 2
+    Priority ID: 2
+    Type ID: 1
+    Labels: automated, regression
+    Custom Fields: 3 field(s)
+
+  Case ID: 124
+    Title: Password validation test
+    Section ID: 1
+    Suite ID: 2
+    Priority ID: 3
+    Type ID: 1
+    Labels: automated
+    Custom Fields: 2 field(s)
+
+  Case ID: 125
+    Title: User registration test
+    Section ID: 1
+    Suite ID: 2
+    Priority ID: 2
+    Type ID: 1
+    References: JIRA-789
+    Custom Fields: 3 field(s)
+```
+
+##### Configuration File Support
+
+The `cases` command supports configuration files, allowing you to specify connection details and project information once:
+
+**config.yml:**
+```yaml
+host: https://yourinstance.testrail.io
+username: user@example.com
+password: your_password
+project: Your Project          # Project name (required)
+```
+
+Then use with the `-c` flag:
+```shell
+$ trcli cases list -c config.yml
+$ trcli cases get -c config.yml --case-id 123
+```
+
+##### Command Options Reference
+
+**Get Command:**
+```shell
+$ trcli cases get --help
+Options:
+  --case-id          Case ID to retrieve.  [x>=1; required]
+  --json-output      Output case as raw JSON from API.
+  --show-all-fields  Show all fields including custom fields in detail.
+  --help             Show this message and exit.
+```
+
+**List Command:**
+```shell
+$ trcli cases list --help
+Options:
+  --suite-id         Filter by suite ID.  [x>=1]
+  --priority-id      Filter by priority ID (comma-separated for multiple, e.g., '3,4').
+  --filter           Filter by text search (case title).
+  --offset           Offset for pagination (default: 0).
+  --limit            Limit for pagination (default: 250).
+  --json-output      Output cases as raw JSON from API.
+  --show-all-fields  Show all fields including custom fields in detail.
+  --help             Show this message and exit.
+```
+
+##### Use Cases
+
+**1. Export case data for documentation:**
+```shell
+$ trcli cases list -c config.yml --json-output > cases_export.json
+```
+
+**2. Find all high-priority cases:**
+```shell
+$ trcli cases list -c config.yml --priority-id 4
+```
+
+**3. Integration with CI/CD pipelines:**
+```shell
+# Get test cases and pipe to analysis tool
+$ trcli cases list -c config.yml --suite-id 2 --json-output | jq -r '.cases[] | select(.labels[].title == "automated") | .title'
+```
+
+**4. Discover cases by keyword:**
+```shell
+$ trcli cases list -c config.yml --filter "API"
+```
+
+**5. Verify case details before test execution:**
+```shell
+$ trcli cases get -c config.yml --case-id 123 --show-all-fields
+```
+
 #### Labels Management
 
 The TestRail CLI provides comprehensive label management capabilities using the `labels` command. Labels help categorize and organize your test management assets efficiently, making it easier to filter and manage test cases, runs, and projects.
@@ -2028,490 +2275,6 @@ $ trcli -h https://yourinstance.testrail.io --username <your_username> --passwor
   --project "Web App" \
   labels tests get --test-ids "4001,4002,4003"
 ```
-
-#### References Management
-
-The TestRail CLI provides comprehensive reference management capabilities using the `references` command. References help link test assets to external requirements, user stories, or other documentation, making it easier to track test coverage and maintain traceability.
-
-The TestRail CLI supports complete reference management for test cases with the following operations:
-- **Add**: Add references to existing test cases without removing existing ones
-- **Update**: Replace all existing references with new ones
-- **Delete**: Remove all or specific references from test cases
-
-All reference operations support validation and error handling, with a 2000-character limit for the total references field per test case.
-
-##### Reference Management Features
-
-**Test Case References Support:**
-- **Add** references to test cases while preserving existing ones (2000 characters maximum, single or multiple test cases)
-- **Update** references by replacing existing ones entirely
-- **Delete** all references or specific references from test cases
-
-###### Adding References to Test Cases
-Add references to test cases without removing existing ones. New references are appended to any existing references.
-
-```shell
-# Add references to a single test case
-$ trcli -h https://yourinstance.testrail.io --username <your_username> --password <your_password> \
-  --project "Your Project" \
-  references cases add --case-ids 123 --refs "REQ-001,REQ-002"
-
-# Add references to multiple test cases
-$ trcli -h https://yourinstance.testrail.io --username <your_username> --password <your_password> \
-  --project "Your Project" \
-  references cases add --case-ids "123,124,125" --refs "STORY-456,BUG-789"
-```
-
-**Output example:**
-```
-Adding references to 2 test case(s)...
-References: REQ-001, REQ-002
-  ✓ Test case 123: References added successfully
-  ✓ Test case 124: References added successfully
-Successfully added references to 2 test case(s)
-```
-
-###### Updating References on Test Cases
-Replace all existing references with new ones. This completely overwrites any existing references.
-
-```shell
-# Update references for a single test case
-$ trcli -h https://yourinstance.testrail.io --username <your_username> --password <your_password> \
-  --project "Your Project" \
-  references cases update --case-ids 123 --refs "REQ-003,REQ-004"
-
-# Update references for multiple test cases
-$ trcli -h https://yourinstance.testrail.io --username <your_username> --password <your_password> \
-  --project "Your Project" \
-  references cases update --case-ids "123,124" --refs "EPIC-100,STORY-200"
-```
-
-**Output example:**
-```
-Updating references for 2 test case(s)...
-New references: REQ-003, REQ-004
-  ✓ Test case 123: References updated successfully
-  ✓ Test case 124: References updated successfully
-Successfully updated references for 2 test case(s)
-```
-
-###### Deleting References from Test Cases
-Remove all references or specific references from test cases.
-
-```shell
-# Delete all references from test cases
-$ trcli -h https://yourinstance.testrail.io --username <your_username> --password <your_password> \
-  --project "Your Project" \
-  references cases delete --case-ids "123,124"
-
-# Delete specific references from test cases
-$ trcli -h https://yourinstance.testrail.io --username <your_username> --password <your_password> \
-  --project "Your Project" \
-  references cases delete --case-ids "123,124" --refs "REQ-001,STORY-456"
-```
-
-**Output example:**
-```
-Deleting all references from 2 test case(s)...
-  ✓ Test case 123: All references deleted successfully
-  ✓ Test case 124: All references deleted successfully
-Successfully deleted references from 2 test case(s)
-```
-
-##### Reference Management Command Reference
-
-**Main References Command:**
-```shell
-$ trcli references --help
-Usage: trcli references [OPTIONS] COMMAND [ARGS]...
-
-  Manage references in TestRail
-
-Options:
-  --help  Show this message and exit.
-
-Commands:
-  cases  Manage references for test cases
-```
-
-**Test Cases References Commands:**
-```shell
-$ trcli references cases --help
-Usage: trcli references cases [OPTIONS] COMMAND [ARGS]...
-
-  Manage references for test cases
-
-Options:
-  --help  Show this message and exit.
-
-Commands:
-  add     Add references to test cases
-  delete  Delete all or specific references from test cases
-  update  Update references on test cases by replacing existing ones
-```
-
-**Add References Command:**
-```shell
-$ trcli references cases add --help
-Options:
-  --case-ids  Comma-separated list of test case IDs [required]
-  --refs      Comma-separated list of references to add [required]
-  --help      Show this message and exit.
-```
-
-**Update References Command:**
-```shell
-$ trcli references cases update --help
-Options:
-  --case-ids  Comma-separated list of test case IDs [required]
-  --refs      Comma-separated list of references to replace existing ones [required]
-  --help      Show this message and exit.
-```
-
-**Delete References Command:**
-```shell
-$ trcli references cases delete --help
-Options:
-  --case-ids  Comma-separated list of test case IDs [required]
-  --refs      Comma-separated list of specific references to delete (optional)
-  --help      Show this message and exit.
-```
-
-### Reference
-```shell
-$ trcli add_run --help
-TestRail CLI v1.15.0
-Copyright 2025 Gurock Software GmbH - www.gurock.com
-Usage: trcli add_run [OPTIONS]
-
-Options:
-  --title                Title of Test Run to be created or updated in
-                         TestRail.
-  --run-id               ID of existing test run to update. If not provided, 
-                         a new run will be created.  [x>=1]
-  --suite-id             Suite ID to submit results to.  [x>=1]
-  --run-description      Summary text to be added to the test run.
-  --milestone-id         Milestone ID to which the Test Run should be
-                         associated to.  [x>=1]
-  --run-start-date       The expected or scheduled start date of this test run in MM/DD/YYYY format
-  --run-end-date         The expected or scheduled end date of this test run in MM/DD/YYYY format
-  --run-assigned-to-id   The ID of the user the test run should be assigned
-                         to.  [x>=1]
-  --clear-run-assigned-to-id  Clear the assignee of the test run (only valid
-                         when updating with --run-id).
-  --clear-run-description  Clear the description of the test run (only valid
-                         when updating with --run-id).
-  --clear-milestone-id   Clear the milestone association of the test run (only
-                         valid when updating with --run-id).
-  --clear-run-start-date  Clear the start date of the test run (only valid
-                         when updating with --run-id).
-  --clear-run-end-date   Clear the end date of the test run (only valid when
-                         updating with --run-id).
-  --clear-run-case-ids   Clear all case IDs from the test run (only valid when
-                         updating with --run-id).
-  --run-include-all      Use this option to include all test cases in this test run.
-  --auto-close-run       Use this option to automatically close the created run.
-  --run-case-ids         Comma separated list of test case IDs to include in
-                         the test run (i.e.: 1,2,3,4).
-  --run-refs             A comma-separated list of references/requirements (up to 250 characters)
-  --run-refs-action      Action to perform on references: 'add' (default), 'update' (replace all), 
-                         or 'delete' (remove all or specific)
-  -f, --file             Write run title and id to file.
-  --help                 Show this message and exit.
-```
-
-If the file parameter is used, the run title and id are written to the file in yaml format. Example:
-```text
-title: Run Title
-run_id: 1
-```
-
-This file can be used as the config file (or appended to an existing config file) in a later run.
-
-### Managing References in Test Runs
-
-The `add_run` command supports comprehensive reference management for test runs. References are stored in TestRail's "References" field and can contain up to 250 characters.
-
-#### Adding References to New Runs
-
-When creating a new test run, you can add references using the `--run-refs` option:
-
-```bash
-trcli -y -h https://example.testrail.io/ --project "My Project" \
-  add_run --title "My Test Run" --run-refs "JIRA-100,JIRA-200,REQ-001"
-```
-
-#### Managing References in Existing Runs
-
-For existing test runs, you can use the `--run-refs-action` option to specify how references should be handled:
-
-**Add References (default behavior):**
-```bash
-trcli -y -h https://example.testrail.io/ --project "My Project" \
-  add_run --run-id 123 --title "My Test Run" \
-  --run-refs "JIRA-300,JIRA-400" --run-refs-action "add"
-```
-
-**Update (Replace) All References:**
-```bash
-trcli -y -h https://example.testrail.io/ --project "My Project" \
-  add_run --run-id 123 --title "My Test Run" \
-  --run-refs "NEW-100,NEW-200" --run-refs-action "update"
-```
-
-**Delete Specific References:**
-```bash
-trcli -y -h https://example.testrail.io/ --project "My Project" \
-  add_run --run-id 123 --title "My Test Run" \
-  --run-refs "JIRA-100,JIRA-200" --run-refs-action "delete"
-```
-
-**Delete All References:**
-```bash
-trcli -y -h https://example.testrail.io/ --project "My Project" \
-  add_run --run-id 123 --title "My Test Run" \
-  --run-refs-action "delete"
-```
-
-#### Reference Management Rules
-
-- **Character Limit**: References field supports up to 250 characters
-- **Format**: Comma-separated list of reference IDs
-- **Duplicate Prevention**: When adding references, duplicates are automatically prevented
-- **Action Requirements**: `update` and `delete` actions require an existing run (--run-id must be provided)
-- **Validation**: Invalid reference formats are rejected with clear error messages
-
-### Managing Assignees in Test Runs
-
-The `add_run` command supports comprehensive assignee management for test runs. You can assign runs to users when creating or updating them, and clear assignees when needed.
-
-#### Assigning Runs to Users
-
-When creating a new test run or updating an existing one, you can assign it to a user using the `--run-assigned-to-id` option:
-
-```bash
-# Create a new run and assign to user ID 5
-trcli -y -h https://example.testrail.io/ --project "My Project" \
-  add_run --title "My Test Run" --run-assigned-to-id 5
-
-# Update an existing run and change the assignee
-trcli -y -h https://example.testrail.io/ --project "My Project" \
-  add_run --run-id 123 --title "My Test Run" --run-assigned-to-id 10
-```
-
-#### Clearing Assignees from Test Runs
-
-To remove the assignee from an existing test run, use the `--clear-run-assigned-to-id` flag:
-
-```bash
-# Clear the assignee from an existing run
-trcli -y -h https://example.testrail.io/ --project "My Project" \
-  add_run --run-id 123 --title "My Test Run" --clear-run-assigned-to-id
-```
-
-#### Assignee Management Rules
-
-- **Update Mode Only**: The `--clear-run-assigned-to-id` flag can only be used when updating an existing run (requires `--run-id`)
-- **Mutually Exclusive**: You cannot use both `--run-assigned-to-id` and `--clear-run-assigned-to-id` in the same command
-
-### Clearing Run Attributes
-
-The `add_run` command provides `--clear-*` flags to remove (set to null) various run attributes during updates. All clear flags require `--run-id` and are mutually exclusive with their corresponding set parameters.
-
-#### Available Clear Flags
-
-| Flag | Clears | API Effect | Mutually Exclusive With |
-|------|--------|------------|------------------------|
-| `--clear-run-description` | Description text | Sets `description: null` | `--run-description` |
-| `--clear-milestone-id` | Milestone association | Sets `milestone_id: null` | `--milestone-id` |
-| `--clear-run-start-date` | Start date | Sets `start_on: null` | `--run-start-date` |
-| `--clear-run-end-date` | End date | Sets `due_on: null` | `--run-end-date` |
-| `--clear-run-case-ids` | All case selections | Sets `include_all: false, case_ids: []` | `--run-case-ids`, `--run-include-all` |
-
-#### Clear Description Example
-
-```bash
-# Clear the description from a run
-trcli -y -h https://example.testrail.io/ --project "My Project" \
-  add_run --run-id 123 --title "My Test Run" --clear-run-description
-```
-
-#### Clear Milestone Example
-
-```bash
-# Remove milestone association
-trcli -y -h https://example.testrail.io/ --project "My Project" \
-  add_run --run-id 123 --title "My Test Run" --clear-milestone-id
-```
-
-#### Clear Dates Example
-
-```bash
-# Clear start date
-trcli -y -h https://example.testrail.io/ --project "My Project" \
-  add_run --run-id 123 --title "My Test Run" --clear-run-start-date
-
-# Clear end date
-trcli -y -h https://example.testrail.io/ --project "My Project" \
-  add_run --run-id 123 --title "My Test Run" --clear-run-end-date
-
-# Clear both dates at once
-trcli -y -h https://example.testrail.io/ --project "My Project" \
-  add_run --run-id 123 --title "My Test Run" --clear-run-start-date --clear-run-end-date
-```
-
-#### Clear Case Selection Example
-
-```bash
-# Clear all case selections (empty run)
-trcli -y -h https://example.testrail.io/ --project "My Project" \
-  add_run --run-id 123 --title "My Test Run" --clear-run-case-ids
-```
-
-#### Clear Multiple Attributes Example
-
-```bash
-# Clear multiple attributes in one command
-trcli -y -h https://example.testrail.io/ --project "My Project" \
-  add_run --run-id 123 --title "Clean Run" \
-  --clear-run-description \
-  --clear-milestone-id \
-  --clear-run-start-date \
-  --clear-run-end-date
-```
-
-Generating test cases from OpenAPI specs
------------------
-
-The `parse_openapi` command allows you to automatically generate and upload test cases to TestRail based on an
-OpenAPI specification. This feature is intended to be used once to quickly bootstrap your test case design,
-providing you with a solid base of test cases, which you can further expand on TestRail.
-
-### Reference
-```shell
-$ trcli parse_openapi --help
-TestRail CLI v1.15.0
-Copyright 2025 Gurock Software GmbH - www.gurock.com
-Usage: trcli parse_openapi [OPTIONS]
-
-  Parse OpenAPI spec and create cases in TestRail
-
-Options:
-  -f, --file      Filename and path.
-  --suite-id      Suite ID to create the tests in (if project is multi-suite).
-                  [x>=1]
-  --case-fields   List of case fields and values for new test cases creation.
-                  Usage: --case-fields type_id:1 --case-fields priority_id:3
-  --help          Show this message and exit.
-```
-
-### OpenAPI specification example
-```yaml
-openapi: 3.0.0
-info:
-  description: This is a sample API.
-  version: 1.0.0
-  title: My API
-paths:
-  /pet:
-    post:
-      summary: Add a new pet to the store
-      description: Add new pet to the store inventory.
-      operationId: addPet
-      responses:
-        '200':
-          description: Pet created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Pet'
-        '400':
-          description: Invalid request
-      requestBody:
-        $ref: '#/components/schemas/Pet'
-  '/pet/{petId}':
-    get:
-      summary: Find pet by ID
-      description: Returns a single pet
-      operationId: getPetById
-      parameters:
-        - name: petId
-          in: path
-          description: ID of pet to return
-          required: true
-          schema:
-            type: integer
-            format: int64
-      responses:
-        '200':
-          description: Successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Pet'
-        '400':
-          description: Invalid request
-        '404':
-          description: Pet not found
-components:
-  schemas:
-    Pet:
-      type: object
-      required:
-        - name
-      properties:
-        id:
-          type: integer
-          format: int64
-          readOnly: true
-        name:
-          description: The name given to a pet
-          type: string
-          example: Guru
-```
-
-### Generating test cases
-
-The test cases are generated based on the OpenAPI specification paths, operation verbs and possible response
-status codes, which provides a good basic test coverage for an API, although we recommend you further
-expand your test cases to cover specific business logic and workflows.
-
-| Pattern                               | Test case title example                           |
-|---------------------------------------|---------------------------------------------------|
-| `VERB /path -> status_code (summary)` | `GET /pet/{petId} -> 200 (Successful operation) ` |
-
-Parameter sources
------------------
-You can choose to set parameters from different sources, like a default config file,
-environment variables, custom config file, cli parameters or in some cases use
-default values.
-The priority of setting parameters from different sources is as per the table below, where 1 is the highest priority.
-
-| priority | source                |
-|----------|-----------------------|
-| 1        | cli parameters        |
-| 2        | custom config file    |
-| 3        | environment variables |
-| 4        | default config file   |
-| 5        | default value         |
-
-For more details, please refer to the [Parameter sources](https://support.gurock.com/hc/en-us/articles/12974525736084) documentation. 
-
-Return values and messaging
----------------------------
-trcli tool will return `0` to the console in case of success and value greater than `1` (usually `1` or `2`) in other cases.
-Messages that are being printed on the console are being redirected to `sys.stdout` or `sys.stderr`.
-
-
-Multithreading
---------------
-trcli allows users to upload test cases and results using multithreading. This is enabled by default and set to `MAX_WORKERS_ADD_CASE = 5` and
- `MAX_WORKERS_ADD_RESULTS = 10` in `trcli/settings.py`. To disable multithreading, set those to `1`.
-
-During performance tests we discovered that using more than 10 workers didn't improve time of upload and could cause errors. Please set it accordingly to your machine specs.
-Average time for uploading:
-- 2000 test cases was around 460 seconds
-- 5000 test cases was around 1000 seconds
 
 ### Parallel Pagination (Experimental)
 

--- a/tests/test_cmd_cases.py
+++ b/tests/test_cmd_cases.py
@@ -1,0 +1,431 @@
+import pytest
+from unittest import mock
+from unittest.mock import MagicMock, patch
+from click.testing import CliRunner
+
+from trcli.cli import Environment
+from trcli.commands import cmd_cases
+
+
+class TestCmdCases:
+    """Test class for cases command functionality"""
+
+    def setup_method(self):
+        """Set up test environment"""
+        self.runner = CliRunner()
+        self.environment = Environment(cmd="cases")
+        self.environment.host = "https://test.testrail.com"
+        self.environment.username = "test@example.com"
+        self.environment.password = "password"
+        self.environment.project = "Test Project"
+        self.environment.project_id = 1
+
+    def _setup_project_client_mock(self, mock_project_client, project_id=1):
+        """Helper to setup ProjectBasedClient mock"""
+        mock_client_instance = MagicMock()
+        mock_project_client.return_value = mock_client_instance
+        mock_client_instance.project.project_id = project_id
+        return mock_client_instance
+
+    @mock.patch("trcli.commands.cmd_cases.ProjectBasedClient")
+    def test_get_case_success(self, mock_project_client):
+        """Test successful case retrieval"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_handler.get_case.return_value = (
+            {
+                "id": 123,
+                "title": "Test Case Title",
+                "section_id": 1,
+                "suite_id": 2,
+                "template_id": 1,
+                "type_id": 1,
+                "priority_id": 2,
+                "refs": "JIRA-123",
+                "created_by": 1,
+                "created_on": 1234567890,
+                "updated_by": 1,
+                "updated_on": 1234567890,
+                "labels": [{"id": 1, "title": "label1"}],
+                "custom_steps": "Step 1\nStep 2",
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_cases.get, ["--case-id", "123"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.case_handler.get_case.assert_called_once_with(123)
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_cases.ProjectBasedClient")
+    def test_get_case_json_output(self, mock_project_client):
+        """Test case retrieval with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        case_data = {"id": 123, "title": "Test Case", "section_id": 1}
+        mock_client.api_request_handler.case_handler.get_case.return_value = (case_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_cases.get, ["--case-id", "123", "--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Check for prettified JSON (with newlines and indentation)
+            assert '"id": 123' in result.output
+            assert "\n" in result.output  # Prettified has newlines
+
+    @mock.patch("trcli.commands.cmd_cases.ProjectBasedClient")
+    def test_get_case_show_all_fields(self, mock_project_client):
+        """Test case retrieval with show all fields"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_handler.get_case.return_value = (
+            {
+                "id": 123,
+                "title": "Test Case",
+                "custom_field1": "value1",
+                "custom_field2": "value2",
+                "labels": [{"id": 1, "title": "label1"}, {"id": 2, "title": "label2"}],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_cases.get,
+                ["--case-id", "123", "--show-all-fields"],
+                obj=self.environment,
+            )
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_cases.ProjectBasedClient")
+    def test_get_case_api_error(self, mock_project_client):
+        """Test case retrieval with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_handler.get_case.return_value = ({}, "Case not found")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_cases.get, ["--case-id", "999"], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Failed to retrieve case: Case not found")
+
+    @mock.patch("trcli.commands.cmd_cases.ProjectBasedClient")
+    def test_list_cases_success(self, mock_project_client):
+        """Test successful cases listing"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_handler.get_cases.return_value = (
+            {
+                "offset": 0,
+                "limit": 250,
+                "size": 2,
+                "_links": {"next": None, "prev": None},
+                "cases": [
+                    {
+                        "id": 1,
+                        "title": "Case 1",
+                        "section_id": 1,
+                        "suite_id": 1,
+                        "priority_id": 2,
+                        "type_id": 1,
+                        "labels": [],
+                    },
+                    {
+                        "id": 2,
+                        "title": "Case 2",
+                        "section_id": 1,
+                        "suite_id": 1,
+                        "priority_id": 3,
+                        "type_id": 1,
+                        "labels": [{"id": 1, "title": "automated"}],
+                    },
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_cases.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.case_handler.get_cases.assert_called_once_with(
+                project_id=1, suite_id=None, priority_id=None, filter_text=None, limit=250, offset=0
+            )
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_cases.ProjectBasedClient")
+    def test_list_cases_with_filters(self, mock_project_client):
+        """Test cases listing with filters"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_handler.get_cases.return_value = (
+            {"offset": 0, "limit": 250, "size": 0, "_links": {}, "cases": []},
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_cases.list,
+                ["--suite-id", "2", "--priority-id", "3,4", "--filter", "login"],
+                obj=self.environment,
+            )
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.case_handler.get_cases.assert_called_once_with(
+                project_id=1, suite_id=2, priority_id="3,4", filter_text="login", limit=250, offset=0
+            )
+
+    @mock.patch("trcli.commands.cmd_cases.ProjectBasedClient")
+    def test_list_cases_with_pagination(self, mock_project_client):
+        """Test cases listing with pagination parameters"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_handler.get_cases.return_value = (
+            {
+                "offset": 100,
+                "limit": 50,
+                "size": 50,
+                "_links": {"next": "/api/v2/get_cases/1&offset=150", "prev": "/api/v2/get_cases/1&offset=50"},
+                "cases": [{"id": i, "title": f"Case {i}"} for i in range(100, 150)],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_cases.list, ["--offset", "100", "--limit", "50"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.case_handler.get_cases.assert_called_once_with(
+                project_id=1, suite_id=None, priority_id=None, filter_text=None, limit=50, offset=100
+            )
+
+    @mock.patch("trcli.commands.cmd_cases.ProjectBasedClient")
+    def test_list_cases_json_output(self, mock_project_client):
+        """Test cases listing with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        response_data = {"offset": 0, "limit": 250, "size": 1, "cases": [{"id": 1, "title": "Test"}]}
+        mock_client.api_request_handler.case_handler.get_cases.return_value = (response_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_cases.list, ["--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Check for prettified JSON (with newlines and indentation)
+            assert '"offset": 0' in result.output
+            assert "\n" in result.output  # Prettified has newlines
+
+    @mock.patch("trcli.commands.cmd_cases.ProjectBasedClient")
+    def test_list_cases_show_all_fields(self, mock_project_client):
+        """Test cases listing with show all fields"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_handler.get_cases.return_value = (
+            {
+                "offset": 0,
+                "limit": 250,
+                "size": 1,
+                "cases": [
+                    {
+                        "id": 1,
+                        "title": "Test Case",
+                        "custom_field1": "value1",
+                        "custom_field2": "value2",
+                        "labels": [{"id": 1, "title": "label1"}],
+                    }
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_cases.list, ["--show-all-fields"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_cases.ProjectBasedClient")
+    def test_list_cases_empty_result(self, mock_project_client):
+        """Test cases listing with empty result"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_handler.get_cases.return_value = (
+            {"offset": 0, "limit": 250, "size": 0, "cases": []},
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_cases.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_log.assert_any_call("No cases found.")
+
+    @mock.patch("trcli.commands.cmd_cases.ProjectBasedClient")
+    def test_list_cases_api_error(self, mock_project_client):
+        """Test cases listing with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_handler.get_cases.return_value = ({}, "Project not found")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_cases.list, [], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Failed to retrieve cases: Project not found")
+
+    @mock.patch("trcli.commands.cmd_cases.ProjectBasedClient")
+    def test_list_cases_with_next_link(self, mock_project_client):
+        """Test cases listing shows pagination hint when next link is present"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_handler.get_cases.return_value = (
+            {
+                "offset": 0,
+                "limit": 250,
+                "size": 250,
+                "_links": {"next": "/api/v2/get_cases/1&offset=250", "prev": None},
+                "cases": [{"id": i, "title": f"Case {i}"} for i in range(1, 251)],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_cases.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            log_calls = [str(call) for call in mock_log.call_args_list]
+            pagination_hint_found = any("More results available" in str(call) for call in log_calls)
+            assert pagination_hint_found
+
+    @mock.patch("trcli.commands.cmd_cases.ProjectBasedClient")
+    def test_list_cases_with_labels_display(self, mock_project_client):
+        """Test cases listing displays labels correctly"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_handler.get_cases.return_value = (
+            {
+                "offset": 0,
+                "limit": 250,
+                "size": 1,
+                "cases": [
+                    {
+                        "id": 1,
+                        "title": "Test Case",
+                        "section_id": 1,
+                        "priority_id": 2,
+                        "type_id": 1,
+                        "labels": [{"id": 1, "title": "automated"}, {"id": 2, "title": "regression"}],
+                    }
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_cases.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            log_calls_str = " ".join([str(call) for call in mock_log.call_args_list])
+            assert "automated" in log_calls_str or "Labels" in log_calls_str
+
+    @mock.patch("trcli.commands.cmd_cases.ProjectBasedClient")
+    def test_get_case_with_project_id_from_config(self, mock_project_client):
+        """Test case retrieval uses project_id from environment when not provided"""
+        mock_client = self._setup_project_client_mock(mock_project_client, project_id=42)
+        case_data = {"id": 123, "title": "Test Case", "section_id": 1}
+        mock_client.api_request_handler.case_handler.get_case.return_value = (case_data, "")
+
+        self.environment.project_id = 42
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_cases.get, ["--case-id", "123"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.case_handler.get_case.assert_called_once_with(123)
+
+    @mock.patch("trcli.commands.cmd_cases.ProjectBasedClient")
+    def test_list_cases_with_project_id_from_config(self, mock_project_client):
+        """Test cases listing uses project_id from environment when not provided"""
+        mock_client = self._setup_project_client_mock(mock_project_client, project_id=99)
+        mock_client.api_request_handler.case_handler.get_cases.return_value = (
+            {"offset": 0, "limit": 250, "size": 1, "cases": [{"id": 1, "title": "Test"}]},
+            "",
+        )
+
+        self.environment.project_id = 99
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_cases.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.case_handler.get_cases.assert_called_once_with(
+                project_id=99, suite_id=None, priority_id=None, filter_text=None, limit=250, offset=0
+            )
+
+    @mock.patch("trcli.commands.cmd_cases.ProjectBasedClient")
+    def test_get_case_with_project_name(self, mock_project_client):
+        """Test case retrieval with project name from config"""
+        mock_client = self._setup_project_client_mock(mock_project_client, project_id=42)
+        case_data = {"id": 123, "title": "Test Case", "section_id": 1}
+        mock_client.api_request_handler.case_handler.get_case.return_value = (case_data, "")
+
+        # Set project name in environment (as if from config file)
+        self.environment.project = "TRCLI AI Eval Single"
+        self.environment.project_id = None  # No project_id, only name
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_cases.get, ["--case-id", "123"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Verify resolve_project was called to convert name to ID
+            mock_client.resolve_project.assert_called_once()
+            mock_client.api_request_handler.case_handler.get_case.assert_called_once_with(123)
+
+    @mock.patch("trcli.commands.cmd_cases.ProjectBasedClient")
+    def test_list_cases_with_project_name(self, mock_project_client):
+        """Test cases listing with project name from config"""
+        mock_client = self._setup_project_client_mock(mock_project_client, project_id=99)
+        mock_client.api_request_handler.case_handler.get_cases.return_value = (
+            {"offset": 0, "limit": 250, "size": 1, "cases": [{"id": 1, "title": "Test"}]},
+            "",
+        )
+
+        # Set project name in environment (as if from config file)
+        self.environment.project = "TRCLI AI Eval Single"
+        self.environment.project_id = None  # No project_id, only name
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_cases.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Verify resolve_project was called to convert name to ID
+            mock_client.resolve_project.assert_called_once()
+            mock_client.api_request_handler.case_handler.get_cases.assert_called_once_with(
+                project_id=99, suite_id=None, priority_id=None, filter_text=None, limit=250, offset=0
+            )

--- a/trcli/api/case_handler.py
+++ b/trcli/api/case_handler.py
@@ -261,3 +261,60 @@ class CaseHandler:
                 update_response.error_message or f"Failed to update automation_id (HTTP {update_response.status_code})"
             )
             return False, error_msg
+
+    def get_case(self, case_id: int) -> Tuple[dict, str]:
+        """
+        Retrieve a single test case by ID
+
+        :param case_id: TestRail case ID
+        :returns: Tuple with (case_data_dict, error_message)
+        """
+        response = self.client.send_get(f"get_case/{case_id}")
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""
+
+    def get_cases(
+        self,
+        project_id: int,
+        suite_id: int = None,
+        priority_id: str = None,
+        filter_text: str = None,
+        limit: int = 250,
+        offset: int = 0,
+    ) -> Tuple[dict, str]:
+        """
+        Retrieve test cases for a project with optional filters
+
+        :param project_id: TestRail project ID
+        :param suite_id: Optional suite ID filter
+        :param priority_id: Optional priority ID filter (comma-separated for multiple)
+        :param filter_text: Optional text search filter
+        :param limit: Maximum number of cases to return (default: 250)
+        :param offset: Offset for pagination (default: 0)
+        :returns: Tuple with (paginated_response_dict, error_message)
+                  Response dict contains: cases, offset, limit, size, _links
+        """
+        # Build query parameters
+        params = []
+        if suite_id is not None:
+            params.append(f"suite_id={suite_id}")
+        if priority_id is not None:
+            params.append(f"priority_id={priority_id}")
+        if filter_text is not None:
+            params.append(f"filter={filter_text}")
+        if limit != 250:
+            params.append(f"limit={limit}")
+        if offset > 0:
+            params.append(f"offset={offset}")
+
+        # Build URL
+        query_string = "&".join(params) if params else ""
+        url = f"get_cases/{project_id}"
+        if query_string:
+            url = f"{url}&{query_string}"
+
+        response = self.client.send_get(url)
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""

--- a/trcli/commands/cmd_cases.py
+++ b/trcli/commands/cmd_cases.py
@@ -1,0 +1,286 @@
+import builtins
+import click
+import json
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def print_config(env: Environment, action: str):
+    env.log(
+        f"Cases {action} Execution Parameters"
+        f"\n> TestRail instance: {env.host} (user: {env.username})"
+        f"\n> Project: {env.project if env.project else env.project_id}"
+    )
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.pass_context
+@pass_environment
+def cli(environment: Environment, context: click.Context, *args, **kwargs):
+    """Manage test cases in TestRail"""
+    environment.cmd = "cases"
+    environment.set_parameters(context)
+
+
+@cli.command()
+@click.option("--case-id", type=click.IntRange(min=1), required=True, metavar="", help="Case ID to retrieve.")
+@click.option("--json-output", is_flag=True, help="Output case as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields including custom fields in detail.")
+@click.pass_context
+@pass_environment
+def get(
+    environment: Environment,
+    context: click.Context,
+    case_id: int,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """Get a single test case by ID"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Get")
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    environment.log(f"Retrieving case ID {case_id}...")
+
+    # Retrieve the case using CaseHandler from ProjectBasedClient
+    case_data, error_message = project_client.api_request_handler.case_handler.get_case(case_id)
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve case: {error_message}")
+        raise SystemExit(1)
+
+    # Verify case belongs to the specified project
+    if case_data.get("suite_id"):
+        # Cases with suite_id belong to multi-suite projects
+        # We should verify project_id, but API doesn't return it directly
+        # For now, we trust the user provided correct project_id
+        pass
+
+    # Handle output format
+    if json_output:
+        # Output prettified JSON response
+        print(json.dumps(case_data, indent=2))
+    else:
+        # Display case details
+        environment.log("")
+        environment.log(f"Case ID: {case_data.get('id', 'N/A')}")
+        environment.log(f"  Title: {case_data.get('title', 'N/A')}")
+        environment.log(f"  Section ID: {case_data.get('section_id', 'N/A')}")
+        environment.log(f"  Suite ID: {case_data.get('suite_id', 'N/A')}")
+        environment.log(f"  Template ID: {case_data.get('template_id', 'N/A')}")
+        environment.log(f"  Type ID: {case_data.get('type_id', 'N/A')}")
+        environment.log(f"  Priority ID: {case_data.get('priority_id', 'N/A')}")
+
+        if case_data.get("milestone_id"):
+            environment.log(f"  Milestone ID: {case_data.get('milestone_id')}")
+
+        if case_data.get("refs"):
+            environment.log(f"  References: {case_data.get('refs')}")
+
+        environment.log(f"  Created By: {case_data.get('created_by', 'N/A')}")
+        environment.log(f"  Created On: {case_data.get('created_on', 'N/A')}")
+        environment.log(f"  Updated By: {case_data.get('updated_by', 'N/A')}")
+        environment.log(f"  Updated On: {case_data.get('updated_on', 'N/A')}")
+
+        if case_data.get("estimate"):
+            environment.log(f"  Estimate: {case_data.get('estimate')}")
+
+        if case_data.get("estimate_forecast"):
+            environment.log(f"  Estimate Forecast: {case_data.get('estimate_forecast')}")
+
+        # Display labels
+        labels = case_data.get("labels", [])
+        if labels:
+            if show_all_fields:
+                environment.log(f"  Labels ({len(labels)}):")
+                for label in labels:
+                    environment.log(f"    - ID: {label.get('id')}, Title: {label.get('title')}")
+            else:
+                label_titles = ", ".join([label.get("title", "") for label in labels])
+                environment.log(f"  Labels: {label_titles}")
+        else:
+            environment.log("  Labels: (none)")
+
+        if show_all_fields:
+            # Show all custom fields
+            custom_fields = {k: v for k, v in case_data.items() if k.startswith("custom_")}
+            if custom_fields:
+                environment.log(f"  Custom Fields ({len(custom_fields)}):")
+                for key, value in custom_fields.items():
+                    display_name = key.replace("_", " ").title()
+                    if value is None:
+                        display_value = "N/A"
+                    elif isinstance(value, builtins.list):
+                        if value:
+                            display_value = f"{len(value)} item(s): {value}"
+                        else:
+                            display_value = "[]"
+                    else:
+                        display_value = value
+                    environment.log(f"    {display_name}: {display_value}")
+        else:
+            # Show count of custom fields
+            custom_fields = {k: v for k, v in case_data.items() if k.startswith("custom_")}
+            if custom_fields:
+                environment.log(f"  Custom Fields: {len(custom_fields)} field(s)")
+
+
+@cli.command()
+@click.option("--suite-id", type=click.IntRange(min=1), metavar="", help="Filter by suite ID.")
+@click.option("--priority-id", metavar="", help="Filter by priority ID (comma-separated for multiple, e.g., '3,4').")
+@click.option("--filter", "filter_text", metavar="", help="Filter by text search (case title).")
+@click.option("--offset", type=int, default=0, metavar="", help="Offset for pagination (default: 0).")
+@click.option("--limit", type=int, default=250, metavar="", help="Limit for pagination (default: 250).")
+@click.option("--json-output", is_flag=True, help="Output cases as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields including custom fields in detail.")
+@click.pass_context
+@pass_environment
+def list(
+    environment: Environment,
+    context: click.Context,
+    suite_id: int,
+    priority_id: str,
+    filter_text: str,
+    offset: int,
+    limit: int,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """List test cases from TestRail"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "List")
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    # Build filter description
+    filters = []
+    if suite_id:
+        filters.append(f"suite_id={suite_id}")
+    if priority_id:
+        filters.append(f"priority_id={priority_id}")
+    if filter_text:
+        filters.append(f"filter='{filter_text}'")
+
+    filter_desc = ", ".join(filters) if filters else "no filters"
+    environment.log(f"Retrieving cases for project ID {project_client.project.project_id} ({filter_desc})...")
+
+    # Retrieve cases using CaseHandler from ProjectBasedClient
+    response_data, error_message = project_client.api_request_handler.case_handler.get_cases(
+        project_id=project_client.project.project_id,
+        suite_id=suite_id,
+        priority_id=priority_id,
+        filter_text=filter_text,
+        limit=limit,
+        offset=offset,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve cases: {error_message}")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        # Output prettified JSON response
+        print(json.dumps(response_data, indent=2))
+    else:
+        # Display cases line by line
+        cases = response_data.get("cases", [])
+        response_offset = response_data.get("offset", 0)
+        response_limit = response_data.get("limit", 250)
+        response_size = response_data.get("size", 0)
+        next_link = response_data.get("_links", {}).get("next")
+
+        if not cases:
+            environment.log("No cases found.")
+        else:
+            environment.log(
+                f"Found {response_size} case(s) (showing {response_offset + 1}-{response_offset + len(cases)}):"
+            )
+            if next_link:
+                environment.log("  (More results available - use --offset and --limit for pagination)")
+            environment.log("")
+
+            for case in cases:
+                if show_all_fields:
+                    # Show all fields from API response
+                    environment.log(f"  Case ID: {case.get('id', 'N/A')}")
+
+                    # Iterate through all fields in the case
+                    for key, value in case.items():
+                        if key == "id":
+                            continue  # Already displayed as Case ID
+
+                        # Format field name for display
+                        display_name = key.replace("_", " ").title()
+
+                        # Handle None values
+                        if value is None:
+                            display_value = "N/A"
+                        elif isinstance(value, builtins.list):
+                            # Handle list fields (like labels)
+                            if key == "labels" and value:
+                                label_titles = ", ".join([label.get("title", "") for label in value])
+                                display_value = f"{len(value)} label(s): {label_titles}"
+                            elif value:
+                                display_value = f"{len(value)} item(s): {value}"
+                            else:
+                                display_value = "[]"
+                        else:
+                            display_value = value
+
+                        environment.log(f"    {display_name}: {display_value}")
+
+                    environment.log("")
+                else:
+                    # Display compact format
+                    environment.log(f"  Case ID: {case.get('id', 'N/A')}")
+                    environment.log(f"    Title: {case.get('title', 'N/A')}")
+                    environment.log(f"    Section ID: {case.get('section_id', 'N/A')}")
+
+                    if case.get("suite_id"):
+                        environment.log(f"    Suite ID: {case.get('suite_id')}")
+
+                    environment.log(f"    Priority ID: {case.get('priority_id', 'N/A')}")
+                    environment.log(f"    Type ID: {case.get('type_id', 'N/A')}")
+
+                    if case.get("refs"):
+                        refs = case.get("refs", "")
+                        if len(refs) > 50:
+                            refs = refs[:50] + "..."
+                        environment.log(f"    References: {refs}")
+
+                    # Display labels
+                    labels = case.get("labels", [])
+                    if labels:
+                        label_titles = ", ".join([label.get("title", "") for label in labels])
+                        environment.log(f"    Labels: {label_titles}")
+
+                    # Show custom fields count
+                    custom_fields = {k: v for k, v in case.items() if k.startswith("custom_")}
+                    if custom_fields:
+                        environment.log(f"    Custom Fields: {len(custom_fields)} field(s)")
+
+                    environment.log("")

--- a/trcli/constants.py
+++ b/trcli/constants.py
@@ -89,6 +89,8 @@ COMMAND_FAULT_MAPPING = dict(
     parse_robot=dict(**FAULT_MAPPING, **PARSE_COMMON_FAULT_MAPPING, **PARSE_JUNIT_OR_ROBOT_FAULT_MAPPING),
     labels=dict(**FAULT_MAPPING),
     references=dict(**FAULT_MAPPING),
+    results=dict(**FAULT_MAPPING),
+    cases=dict(**FAULT_MAPPING),
 )
 
 PROMPT_MESSAGES = dict(


### PR DESCRIPTION
### Solution description
Implemented a new cases command command for retrieving and listing test cases from TestRail. This command is useful for discovering test cases, exporting case data, and integrating with external tools or CI/CD pipelines.

### Changes
Implemented a new case command with get (for specific test cases) and list (for entire suite or filtered by keyword/priority)

### Potential impacts
None.

### Steps to test
See updated README file: 1434 - 1676

### PR Tasks
- [x] PR reference added to issue
- [x] README updated
- [x] Unit tests added/updated
