### PR TITLE
TRCLI-279: Get/Read Export command for Milestones

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/). Version numb
 _released 06-24-2026
 
 ### Added
- - **Added more data query commands for comprehensive AI automation support**
+ - **New `runs` command**: Query and retrieve test run information from TestRail with `get` and `list` subcommands. Provides execution metrics, status tracking, and configuration details. Note: Only returns standalone runs (not runs within test plans).
 
 ## [1.15.0]
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -12,6 +12,7 @@ _released 06-24-2026
 
 ### Added
  - **New `runs` command**: Query and retrieve test run information from TestRail with `get` and `list` subcommands. Provides execution metrics, status tracking, and configuration details. Note: Only returns standalone runs (not runs within test plans).
+ - **New `milestones` command**: Query and retrieve milestone information from TestRail with `get` and `list` subcommands. Track project milestones, monitor completion status, due dates, and references.
 
 ## [1.15.0]
 

--- a/README.md
+++ b/README.md
@@ -1466,7 +1466,7 @@ Get detailed information about a specific test case by its ID:
 
 ```shell
 # Get a test case (using config file)
-$ trcli cases get -c config.yml --case-id 123
+$ trcli -c config.yml cases get --case-id 123
 
 # Get a test case with all parameters
 $ trcli cases get \
@@ -1477,10 +1477,10 @@ $ trcli cases get \
   --case-id 123
 
 # Get case with all fields displayed
-$ trcli cases get -c config.yml --case-id 123 --show-all-fields
+$ trcli -c config.yml cases get --case-id 123 --show-all-fields
 
 # Get case as JSON (for piping to jq or other tools)
-$ trcli cases get -c config.yml --case-id 123 --json-output
+$ trcli -c config.yml cases get --case-id 123 --json-output
 ```
 
 **Output example:**
@@ -1542,28 +1542,28 @@ List test cases from a project with optional filtering by suite, priority, or te
 
 ```shell
 # List all cases in a project (using config file)
-$ trcli cases list -c config.yml
+$ trcli -c config.yml cases list
 
 # List cases with suite filter
-$ trcli cases list -c config.yml --suite-id 2
+$ trcli -c config.yml cases list --suite-id 2
 
 # List cases with priority filter (high priority only)
-$ trcli cases list -c config.yml --priority-id 4
+$ trcli -c config.yml cases list --priority-id 4
 
 # List cases with multiple priorities
-$ trcli cases list -c config.yml --priority-id "3,4"
+$ trcli -c config.yml cases list --priority-id "3,4"
 
 # List cases with text search
-$ trcli cases list -c config.yml --filter "login"
+$ trcli -c config.yml cases list --filter "login"
 
 # Combine multiple filters
-$ trcli cases list -c config.yml --suite-id 2 --priority-id 4 --filter "authentication"
+$ trcli -c config.yml cases list --suite-id 2 --priority-id 4 --filter "authentication"
 
 # Pagination support
-$ trcli cases list -c config.yml --offset 250 --limit 100
+$ trcli -c config.yml cases list --offset 250 --limit 100
 
 # JSON output for integration with other tools
-$ trcli cases list -c config.yml --suite-id 2 --json-output | jq '.cases[].title'
+$ trcli -c config.yml cases list --suite-id 2 --json-output | jq '.cases[].title'
 ```
 
 **Output example:**
@@ -1617,8 +1617,8 @@ project: Your Project          # Project name (required)
 
 Then use with the `-c` flag:
 ```shell
-$ trcli cases list -c config.yml
-$ trcli cases get -c config.yml --case-id 123
+$ trcli -c config.yml cases list
+$ trcli -c config.yml cases get --case-id 123
 ```
 
 ##### Command Options Reference
@@ -1651,28 +1651,28 @@ Options:
 
 **1. Export case data for documentation:**
 ```shell
-$ trcli cases list -c config.yml --json-output > cases_export.json
+$ trcli -c config.yml cases list --json-output > cases_export.json
 ```
 
 **2. Find all high-priority cases:**
 ```shell
-$ trcli cases list -c config.yml --priority-id 4
+$ trcli -c config.yml cases list --priority-id 4
 ```
 
 **3. Integration with CI/CD pipelines:**
 ```shell
 # Get test cases and pipe to analysis tool
-$ trcli cases list -c config.yml --suite-id 2 --json-output | jq -r '.cases[] | select(.labels[].title == "automated") | .title'
+$ trcli -c config.yml cases list --suite-id 2 --json-output | jq -r '.cases[] | select(.labels[].title == "automated") | .title'
 ```
 
 **4. Discover cases by keyword:**
 ```shell
-$ trcli cases list -c config.yml --filter "API"
+$ trcli -c config.yml cases list --filter "API"
 ```
 
 **5. Verify case details before test execution:**
 ```shell
-$ trcli cases get -c config.yml --case-id 123 --show-all-fields
+$ trcli -c config.yml cases get --case-id 123 --show-all-fields
 ```
 
 #### Managing Test Suites
@@ -1717,10 +1717,10 @@ Get detailed information about a specific test suite by its ID :
 
 ```shell
 # Get suite with all fields displayed
-$ trcli suites get -c config.yml --suite-id 1 --show-all-fields
+$ trcli -c config.yml suites get --suite-id 1 --show-all-fields
 
 # Get suite as JSON (for piping to jq or other tools)
-$ trcli suites get -c config.yml --suite-id 1 --json-output
+$ trcli -c config.yml suites get --suite-id 1 --json-output
 ```
 
 ##### Listing Test Suites
@@ -1729,7 +1729,7 @@ List test suites from a project with pagination support:
 
 ```shell
 # List all suites in a project (using config file)
-$ trcli suites list -c config.yml
+$ trcli -c config.yml suites list
 
 # List all suites with all parameters
 $ trcli suites list \
@@ -1739,13 +1739,13 @@ $ trcli suites list \
   --project "Your Project"
 
 # Pagination support
-$ trcli suites list -c config.yml --offset 250 --limit 100
+$ trcli -c config.yml suites list --offset 250 --limit 100
 
 # JSON output for integration with other tools
-$ trcli suites list -c config.yml --json-output | jq '.suites[].name'
+$ trcli -c config.yml suites list --json-output | jq '.suites[].name'
 
 # Show all fields for each suite
-$ trcli suites list -c config.yml --show-all-fields
+$ trcli -c config.yml suites list --show-all-fields
 ```
 
 ##### Configuration File Support
@@ -1762,8 +1762,8 @@ project: Your Project          # Project name (required)
 
 Then use with the `-c` flag:
 ```shell
-$ trcli suites list -c config.yml
-$ trcli suites get -c config.yml --suite-id 1
+$ trcli -c config.yml suites list
+$ trcli -c config.yml suites get --suite-id 1
 ```
 
 ##### Command Options Reference
@@ -1793,29 +1793,29 @@ Options:
 
 **1. Export suite data for documentation:**
 ```shell
-$ trcli suites list -c config.yml --json-output > suites_export.json
+$ trcli -c config.yml suites list --json-output > suites_export.json
 ```
 
 **2. Discover suites in a multi-suite project:**
 ```shell
-$ trcli suites list -c config.yml
+$ trcli -c config.yml suites list
 ```
 
 **3. Integration with CI/CD pipelines:**
 ```shell
 # Get all suite names and process them
-$ trcli suites list -c config.yml --json-output | jq -r '.suites[] | .name'
+$ trcli -c config.yml suites list --json-output | jq -r '.suites[] | .name'
 ```
 
 **4. Verify suite details before test execution:**
 ```shell
-$ trcli suites get -c config.yml --suite-id 1 --show-all-fields
+$ trcli -c config.yml suites get --suite-id 1 --show-all-fields
 ```
 
 **5. Identify suite IDs for multi-suite workflows:**
 ```shell
 # Find suite ID by name
-$ trcli suites list -c config.yml --json-output | jq '.suites[] | select(.name=="API Tests") | .id'
+$ trcli -c config.yml suites list --json-output | jq '.suites[] | select(.name=="API Tests") | .id'
 ```
 
 #### Managing Test Plans
@@ -1853,7 +1853,7 @@ Get detailed information about a specific test plan by its ID, including all ent
 
 ```shell
 # Get a test plan (using config file)
-$ trcli plans get -c config.yml --plan-id 10
+$ trcli -c config.yml plans get --plan-id 10
 
 # Get a test plan with all parameters
 $ trcli plans get \
@@ -1864,10 +1864,10 @@ $ trcli plans get \
   --plan-id 10
 
 # Get plan with all fields displayed
-$ trcli plans get -c config.yml --plan-id 10 --show-all-fields
+$ trcli -c config.yml plans get --plan-id 10 --show-all-fields
 
 # Get plan as JSON (for piping to jq or other tools)
-$ trcli plans get -c config.yml --plan-id 10 --json-output
+$ trcli -c config.yml plans get --plan-id 10 --json-output
 ``` 
 
 ##### Listing Test Plans
@@ -1876,7 +1876,7 @@ List test plans from a project with pagination support:
 
 ```shell
 # List all plans in a project (using config file)
-$ trcli plans list -c config.yml
+$ trcli -c config.yml plans list
 
 # List all plans with all parameters
 $ trcli plans list \
@@ -1886,13 +1886,13 @@ $ trcli plans list \
   --project "Your Project"
 
 # Pagination support
-$ trcli plans list -c config.yml --offset 250 --limit 100
+$ trcli -c config.yml plans list --offset 250 --limit 100
 
 # JSON output for integration with other tools
-$ trcli plans list -c config.yml --json-output | jq '.plans[].name'
+$ trcli -c config.yml plans list --json-output | jq '.plans[].name'
 
 # Show all fields for each plan
-$ trcli plans list -c config.yml --show-all-fields
+$ trcli -c config.yml plans list --show-all-fields
 ```
 
 ##### Configuration File Support
@@ -1909,8 +1909,8 @@ project: Your Project          # Project name (required)
 
 Then use with the `-c` flag:
 ```shell
-$ trcli plans list -c config.yml
-$ trcli plans get -c config.yml --plan-id 10
+$ trcli -c config.yml plans list
+$ trcli -c config.yml plans get --plan-id 10
 ```
 
 ##### Command Options Reference
@@ -1940,12 +1940,12 @@ Options:
 
 **1. Monitor release testing progress:**
 ```shell
-$ trcli plans get -c config.yml --plan-id 10
+$ trcli -c config.yml plans get --plan-id 10
 ```
 
 **2. Export plan data for reporting:**
 ```shell
-$ trcli plans list -c config.yml --json-output > plans_report.json
+$ trcli -c config.yml plans list --json-output > plans_report.json
 ```
 
 ### Managing Sections
@@ -1984,7 +1984,7 @@ Get detailed information about a specific section by its ID:
 
 ```shell
 # Get a section (using config file)
-$ trcli sections get -c config.yml --section-id 10
+$ trcli -c config.yml sections get --section-id 10
 
 # Get a section with all parameters
 $ trcli sections get \
@@ -1995,10 +1995,10 @@ $ trcli sections get \
   --section-id 10
 
 # Get section with all fields displayed
-$ trcli sections get -c config.yml --section-id 10 --show-all-fields
+$ trcli -c config.yml sections get --section-id 10 --show-all-fields
 
 # Get section as JSON (for piping to jq or other tools)
-$ trcli sections get -c config.yml --section-id 10 --json-output
+$ trcli -c config.yml sections get --section-id 10 --json-output
 ```
 ##### Listing Sections
 
@@ -2006,7 +2006,7 @@ List sections from a project with pagination support:
 
 ```shell
 # List all sections in a project (using config file)
-$ trcli sections list -c config.yml
+$ trcli -c config.yml sections list
 
 # List all sections with all parameters
 $ trcli sections list \
@@ -2016,13 +2016,13 @@ $ trcli sections list \
   --project "Your Project"
 
 # Pagination support
-$ trcli sections list -c config.yml --offset 250 --limit 100
+$ trcli -c config.yml sections list --offset 250 --limit 100
 
 # JSON output for integration with other tools
-$ trcli sections list -c config.yml --json-output | jq '.sections[].name'
+$ trcli -c config.yml sections list --json-output | jq '.sections[].name'
 
 # Show all fields for each section
-$ trcli sections list -c config.yml --show-all-fields
+$ trcli -c config.yml sections list --show-all-fields
 ```
 
 ### Managing Runs
@@ -2063,7 +2063,7 @@ Get detailed information about a specific run by its ID:
 
 ```shell
 # Get a run (using config file)
-$ trcli runs get -c config.yml --run-id 100
+$ trcli -c config.yml runs get --run-id 100
 
 # Get a run with all parameters
 $ trcli runs get \
@@ -2074,10 +2074,10 @@ $ trcli runs get \
   --run-id 100
 
 # Get run with all fields displayed (includes timestamps, config IDs, milestone, etc.)
-$ trcli runs get -c config.yml --run-id 100 --show-all-fields
+$ trcli -c config.yml runs get --run-id 100 --show-all-fields
 
 # Get run as JSON (for piping to jq or other tools)
-$ trcli runs get -c config.yml --run-id 100 --json-output
+$ trcli -c config.yml runs get --run-id 100 --json-output
 ```
 ##### Listing Runs
 
@@ -2085,7 +2085,7 @@ List runs from a project with pagination support:
 
 ```shell
 # List all runs in a project (using config file)
-$ trcli runs list -c config.yml
+$ trcli -c config.yml runs list
 
 # List all runs with all parameters
 $ trcli runs list \
@@ -2095,13 +2095,13 @@ $ trcli runs list \
   --project "Your Project"
 
 # Pagination support
-$ trcli runs list -c config.yml --offset 0 --limit 50
+$ trcli -c config.yml runs list --offset 0 --limit 50
 
 # JSON output for integration with other tools
-$ trcli runs list -c config.yml --json-output | jq '.runs[].name'
+$ trcli -c config.yml runs list --json-output | jq '.runs[].name'
 
 # Show all fields for each run
-$ trcli runs list -c config.yml --show-all-fields
+$ trcli -c config.yml runs list --show-all-fields
 ```
 
 #### Labels Management

--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ Commands:
   parse_openapi  Parse OpenAPI spec and create cases in TestRail
   parse_robot    Parse Robot Framework report and upload results to TestRail
   references     Manage references in TestRail
+  results        Manage test results in TestRail
+  sections       Manage test sections in TestRail
+  suites         Manage test suites in TestRail
+  runs           Manage test runs in TestRail
+  milestones     Manage milestones in TestRail
   update         Update TRCLI to the latest version from PyPI.
 ```
 
@@ -2102,6 +2107,83 @@ $ trcli -c config.yml runs list --json-output | jq '.runs[].name'
 
 # Show all fields for each run
 $ trcli -c config.yml runs list --show-all-fields
+```
+
+### Managing Milestones
+
+The TestRail CLI provides the `milestones` command for retrieving and listing milestones from TestRail. Milestones represent important project dates and deliverables, helping track progress toward releases and major project goals. This command is useful for monitoring milestone status, tracking completion dates, exporting milestone data, and integrating milestone information into project management workflows.
+
+### Milestones Command Overview
+
+The `milestones` command supports two subcommands:
+
+| Subcommand | Purpose |
+|------------|---------|
+| `milestones get` | Retrieve a single milestone by ID | Get detailed information about a milestone including status, due dates, and completion |
+| `milestones list` | List milestones in a project | Track project milestones, monitor progress, and export milestone data |
+
+### Reference
+
+```shell
+
+$ trcli milestones --help
+
+Usage: trcli milestones [OPTIONS] COMMAND [ARGS]...
+  Manage milestones in TestRail
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  get   Get a single milestone by ID
+  list  List milestones from TestRail
+```
+
+##### Retrieving a Single Milestone
+
+Get detailed information about a specific milestone by its ID:
+
+```shell
+# Get a milestone (using config file)
+$ trcli -c config.yml milestones get --milestone-id 1
+
+# Get a milestone with all parameters
+$ trcli milestones get \
+  --host https://yourinstance.testrail.io \
+  --username <your_username> \
+  --password <your_password> \
+  --project "Your Project" \
+  --milestone-id 1
+
+# Get milestone with all fields displayed (includes timestamps, references, URL, etc.)
+$ trcli -c config.yml milestones get --milestone-id 1 --show-all-fields
+
+# Get milestone as JSON (for piping to jq or other tools)
+$ trcli -c config.yml milestones get --milestone-id 1 --json-output
+```
+##### Listing Milestones
+
+List milestones from a project with pagination support:
+
+```shell
+# List all milestones in a project (using config file)
+$ trcli -c config.yml milestones list
+
+# List all milestones with all parameters
+$ trcli milestones list \
+  --host https://yourinstance.testrail.io \
+  --username <your_username> \
+  --password <your_password> \
+  --project "Your Project"
+
+# Pagination support
+$ trcli -c config.yml milestones list --offset 0 --limit 50
+
+# JSON output for integration with other tools
+$ trcli -c config.yml milestones list --json-output | jq '.milestones[].name'
+
+# Show all fields for each milestone
+$ trcli -c config.yml milestones list --show-all-fields
 ```
 
 #### Labels Management

--- a/README.md
+++ b/README.md
@@ -2025,6 +2025,85 @@ $ trcli sections list -c config.yml --json-output | jq '.sections[].name'
 $ trcli sections list -c config.yml --show-all-fields
 ```
 
+### Managing Runs
+
+The TestRail CLI provides the `runs` command for retrieving and listing test runs from TestRail. Test runs represent the execution of a set of test cases, tracking their results and providing execution metrics. This command is useful for monitoring test execution progress, auditing run configurations, exporting run data, and integrating run information into automation workflows.
+
+**Note:** The `runs` command only returns standalone test runs (runs not part of a test plan). To query runs within test plans, use the `plans` command.
+
+### Runs Command Overview
+
+The `runs` command supports two subcommands:
+
+| Subcommand | Purpose |
+|------------|---------|
+| `runs get` | Retrieve a single run by ID | Get detailed information about a run including execution status, test counts, and configuration |
+| `runs list` | List runs in a project | Monitor active runs, track execution progress, and export run data |
+
+### Reference
+
+```shell
+
+$ trcli runs --help
+
+Usage: trcli runs [OPTIONS] COMMAND [ARGS]...
+  Manage runs in TestRail
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  get   Get a single run by ID
+  list  List runs from TestRail
+```
+
+##### Retrieving a Single Run
+
+Get detailed information about a specific run by its ID:
+
+```shell
+# Get a run (using config file)
+$ trcli runs get -c config.yml --run-id 100
+
+# Get a run with all parameters
+$ trcli runs get \
+  --host https://yourinstance.testrail.io \
+  --username <your_username> \
+  --password <your_password> \
+  --project "Your Project" \
+  --run-id 100
+
+# Get run with all fields displayed (includes timestamps, config IDs, milestone, etc.)
+$ trcli runs get -c config.yml --run-id 100 --show-all-fields
+
+# Get run as JSON (for piping to jq or other tools)
+$ trcli runs get -c config.yml --run-id 100 --json-output
+```
+##### Listing Runs
+
+List runs from a project with pagination support:
+
+```shell
+# List all runs in a project (using config file)
+$ trcli runs list -c config.yml
+
+# List all runs with all parameters
+$ trcli runs list \
+  --host https://yourinstance.testrail.io \
+  --username <your_username> \
+  --password <your_password> \
+  --project "Your Project"
+
+# Pagination support
+$ trcli runs list -c config.yml --offset 0 --limit 50
+
+# JSON output for integration with other tools
+$ trcli runs list -c config.yml --json-output | jq '.runs[].name'
+
+# Show all fields for each run
+$ trcli runs list -c config.yml --show-all-fields
+```
+
 #### Labels Management
 
 The TestRail CLI provides comprehensive label management capabilities using the `labels` command. Labels help categorize and organize your test management assets efficiently, making it easier to filter and manage test cases, runs, and projects.

--- a/tests/test_cmd_milestones.py
+++ b/tests/test_cmd_milestones.py
@@ -1,0 +1,384 @@
+import pytest
+from unittest import mock
+from unittest.mock import MagicMock, patch
+from click.testing import CliRunner
+
+from trcli.cli import Environment
+from trcli.commands import cmd_milestones
+
+
+class TestCmdMilestones:
+    """Test class for milestones command functionality"""
+
+    def setup_method(self):
+        """Set up test environment"""
+        self.runner = CliRunner()
+        self.environment = Environment(cmd="milestones")
+        self.environment.host = "https://test.testrail.com"
+        self.environment.username = "test@example.com"
+        self.environment.password = "password"
+        self.environment.project = "Test Project"
+        self.environment.project_id = 1
+
+    def _setup_project_client_mock(self, mock_project_client, project_id=1):
+        """Helper to setup ProjectBasedClient mock"""
+        mock_client_instance = MagicMock()
+        mock_project_client.return_value = mock_client_instance
+        mock_client_instance.project.project_id = project_id
+        return mock_client_instance
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_get_milestone_success(self, mock_project_client):
+        """Test successful milestone retrieval"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.milestone_handler.get_milestone.return_value = (
+            {
+                "id": 1,
+                "name": "Release 1.5",
+                "description": "Major feature release",
+                "project_id": 1,
+                "is_completed": True,
+                "completed_on": 1389968184,
+                "due_on": 1391968184,
+                "refs": "RF-1, RF-2",
+                "url": "http://test.testrail.com/index.php?/milestones/view/1",
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_milestones.get, ["--milestone-id", "1"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.milestone_handler.get_milestone.assert_called_once_with(1)
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_get_milestone_json_output(self, mock_project_client):
+        """Test milestone retrieval with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        milestone_data = {
+            "id": 1,
+            "name": "Release 1.5",
+            "description": "Major feature release",
+            "project_id": 1,
+            "is_completed": False,
+            "due_on": 1391968184,
+        }
+        mock_client.api_request_handler.milestone_handler.get_milestone.return_value = (milestone_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(
+                cmd_milestones.get, ["--milestone-id", "1", "--json-output"], obj=self.environment
+            )
+
+            assert result.exit_code == 0
+            # Check for prettified JSON (with newlines and indentation)
+            assert '"id": 1' in result.output
+            assert "\n" in result.output  # Prettified has newlines
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_get_milestone_show_all_fields(self, mock_project_client):
+        """Test milestone retrieval with show all fields"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.milestone_handler.get_milestone.return_value = (
+            {
+                "id": 1,
+                "name": "Release 1.5",
+                "description": "Major feature release with new capabilities",
+                "project_id": 1,
+                "is_completed": True,
+                "completed_on": 1389968184,
+                "due_on": 1391968184,
+                "refs": "RF-1, RF-2",
+                "url": "http://test.testrail.com/index.php?/milestones/view/1",
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_milestones.get, ["--milestone-id", "1", "--show-all-fields"], obj=self.environment
+            )
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_get_milestone_api_error(self, mock_project_client):
+        """Test milestone retrieval with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.milestone_handler.get_milestone.return_value = ({}, "Milestone not found")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_milestones.get, ["--milestone-id", "999"], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Failed to retrieve milestone: Milestone not found")
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_list_milestones_success(self, mock_project_client):
+        """Test successful milestones listing"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.milestone_handler.get_milestones.return_value = (
+            {
+                "offset": 0,
+                "limit": 250,
+                "size": 2,
+                "_links": {"next": None, "prev": None},
+                "milestones": [
+                    {
+                        "id": 1,
+                        "name": "Release 1.5",
+                        "description": "Major feature release",
+                        "project_id": 1,
+                        "is_completed": False,
+                        "due_on": 1391968184,
+                    },
+                    {
+                        "id": 2,
+                        "name": "Release 1.6",
+                        "description": "Bug fix release",
+                        "project_id": 1,
+                        "is_completed": False,
+                        "due_on": 1393968184,
+                    },
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_milestones.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.milestone_handler.get_milestones.assert_called_once_with(
+                project_id=1, limit=250, offset=0
+            )
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_list_milestones_with_pagination(self, mock_project_client):
+        """Test milestones listing with custom pagination"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.milestone_handler.get_milestones.return_value = (
+            {
+                "offset": 50,
+                "limit": 100,
+                "size": 1,
+                "_links": {"next": None, "prev": None},
+                "milestones": [
+                    {
+                        "id": 3,
+                        "name": "Release 2.0",
+                        "description": "Next generation",
+                        "project_id": 1,
+                        "is_completed": False,
+                        "due_on": 1395968184,
+                    }
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_milestones.list, ["--offset", "50", "--limit", "100"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.milestone_handler.get_milestones.assert_called_once_with(
+                project_id=1, limit=100, offset=50
+            )
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_list_milestones_json_output(self, mock_project_client):
+        """Test milestones listing with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        milestones_data = {
+            "offset": 0,
+            "limit": 250,
+            "size": 1,
+            "_links": {"next": None, "prev": None},
+            "milestones": [
+                {
+                    "id": 1,
+                    "name": "Release 1.5",
+                    "is_completed": False,
+                }
+            ],
+        }
+        mock_client.api_request_handler.milestone_handler.get_milestones.return_value = (milestones_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_milestones.list, ["--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Check for prettified JSON
+            assert '"milestones"' in result.output
+            assert "\n" in result.output
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_list_milestones_show_all_fields(self, mock_project_client):
+        """Test milestones listing with show all fields"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.milestone_handler.get_milestones.return_value = (
+            {
+                "offset": 0,
+                "limit": 250,
+                "size": 1,
+                "_links": {"next": None, "prev": None},
+                "milestones": [
+                    {
+                        "id": 1,
+                        "name": "Release 1.5",
+                        "description": "Major feature release",
+                        "project_id": 1,
+                        "is_completed": True,
+                        "completed_on": 1389968184,
+                        "due_on": 1391968184,
+                        "refs": "RF-1, RF-2",
+                        "url": "http://test.testrail.com/index.php?/milestones/view/1",
+                    }
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_milestones.list, ["--show-all-fields"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_list_milestones_empty_result(self, mock_project_client):
+        """Test milestones listing with no milestones"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.milestone_handler.get_milestones.return_value = (
+            {"offset": 0, "limit": 250, "size": 0, "_links": {"next": None, "prev": None}, "milestones": []},
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_milestones.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_list_milestones_api_error(self, mock_project_client):
+        """Test milestones listing with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.milestone_handler.get_milestones.return_value = ({}, "Project not found")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_milestones.list, [], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Failed to retrieve milestones: Project not found")
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_list_milestones_with_next_link(self, mock_project_client):
+        """Test milestones listing with pagination next link"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.milestone_handler.get_milestones.return_value = (
+            {
+                "offset": 0,
+                "limit": 250,
+                "size": 251,
+                "_links": {
+                    "next": "index.php?/api/v2/get_milestones/1&offset=250",
+                    "prev": None,
+                },
+                "milestones": [
+                    {
+                        "id": 1,
+                        "name": "Release 1.5",
+                        "is_completed": False,
+                    }
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_milestones.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_get_milestone_with_project_id_from_config(self, mock_project_client):
+        """Test get milestone using project_id from configuration"""
+        mock_client = self._setup_project_client_mock(mock_project_client, project_id=5)
+        self.environment.project_id = 5
+        mock_client.api_request_handler.milestone_handler.get_milestone.return_value = (
+            {"id": 1, "name": "Release 1.0", "project_id": 5, "is_completed": False},
+            "",
+        )
+
+        with patch.object(self.environment, "log"), patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_milestones.get, ["--milestone-id", "1"], obj=self.environment)
+
+            assert result.exit_code == 0
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_list_milestones_with_project_id_from_config(self, mock_project_client):
+        """Test list milestones using project_id from configuration"""
+        mock_client = self._setup_project_client_mock(mock_project_client, project_id=5)
+        self.environment.project_id = 5
+        mock_client.api_request_handler.milestone_handler.get_milestones.return_value = (
+            {"offset": 0, "limit": 250, "size": 0, "_links": {}, "milestones": []},
+            "",
+        )
+
+        with patch.object(self.environment, "log"), patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_milestones.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.milestone_handler.get_milestones.assert_called_once_with(
+                project_id=5, limit=250, offset=0
+            )
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_get_milestone_with_project_name(self, mock_project_client):
+        """Test get milestone using project name resolution"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        self.environment.project = "Test Project"
+        mock_client.api_request_handler.milestone_handler.get_milestone.return_value = (
+            {"id": 1, "name": "Release 1.0", "project_id": 1, "is_completed": False},
+            "",
+        )
+
+        with patch.object(self.environment, "log"), patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_milestones.get, ["--milestone-id", "1"], obj=self.environment)
+
+            assert result.exit_code == 0

--- a/tests/test_cmd_runs.py
+++ b/tests/test_cmd_runs.py
@@ -1,0 +1,413 @@
+import pytest
+from unittest import mock
+from unittest.mock import MagicMock, patch
+from click.testing import CliRunner
+
+from trcli.cli import Environment
+from trcli.commands import cmd_runs
+
+
+class TestCmdRuns:
+    """Test class for runs command functionality"""
+
+    def setup_method(self):
+        """Set up test environment"""
+        self.runner = CliRunner()
+        self.environment = Environment(cmd="runs")
+        self.environment.host = "https://test.testrail.com"
+        self.environment.username = "test@example.com"
+        self.environment.password = "password"
+        self.environment.project = "Test Project"
+        self.environment.project_id = 1
+
+    def _setup_project_client_mock(self, mock_project_client, project_id=1):
+        """Helper to setup ProjectBasedClient mock"""
+        mock_client_instance = MagicMock()
+        mock_project_client.return_value = mock_client_instance
+        mock_client_instance.project.project_id = project_id
+        return mock_client_instance
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_get_run_success(self, mock_project_client):
+        """Test successful run retrieval"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.run_handler.get_run.return_value = (
+            {
+                "id": 81,
+                "name": "File Formats",
+                "description": "Test file format handling",
+                "suite_id": 4,
+                "project_id": 1,
+                "is_completed": False,
+                "completed_on": None,
+                "passed_count": 2,
+                "failed_count": 2,
+                "blocked_count": 0,
+                "retest_count": 1,
+                "untested_count": 3,
+                "config": "Firefox, Ubuntu 12",
+                "config_ids": [2, 6],
+                "milestone_id": 7,
+                "plan_id": 80,
+                "assignedto_id": 6,
+                "refs": "SAN-1",
+                "include_all": False,
+                "created_by": 1,
+                "created_on": 1393845644,
+                "url": "http://test.testrail.com/index.php?/runs/view/81",
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.get, ["--run-id", "81"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.run_handler.get_run.assert_called_once_with(81)
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_get_run_json_output(self, mock_project_client):
+        """Test run retrieval with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        run_data = {
+            "id": 81,
+            "name": "File Formats",
+            "suite_id": 4,
+            "is_completed": False,
+            "passed_count": 2,
+            "failed_count": 1,
+        }
+        mock_client.api_request_handler.run_handler.get_run.return_value = (run_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_runs.get, ["--run-id", "81", "--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Check for prettified JSON (with newlines and indentation)
+            assert '"id": 81' in result.output
+            assert "\n" in result.output  # Prettified has newlines
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_get_run_show_all_fields(self, mock_project_client):
+        """Test run retrieval with show all fields"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.run_handler.get_run.return_value = (
+            {
+                "id": 81,
+                "name": "File Formats",
+                "description": "Test description",
+                "suite_id": 4,
+                "project_id": 1,
+                "is_completed": False,
+                "passed_count": 2,
+                "failed_count": 1,
+                "blocked_count": 0,
+                "retest_count": 0,
+                "untested_count": 3,
+                "config": "Firefox, Ubuntu 12",
+                "config_ids": [2, 6],
+                "milestone_id": 7,
+                "plan_id": 80,
+                "assignedto_id": 6,
+                "refs": "SAN-1",
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.get, ["--run-id", "81", "--show-all-fields"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_get_run_api_error(self, mock_project_client):
+        """Test run retrieval with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.run_handler.get_run.return_value = ({}, "Run not found")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.get, ["--run-id", "999"], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Failed to retrieve run: Run not found")
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_list_runs_success(self, mock_project_client):
+        """Test successful runs listing"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.run_handler.get_runs.return_value = (
+            {
+                "offset": 0,
+                "limit": 250,
+                "size": 2,
+                "_links": {"next": None, "prev": None},
+                "runs": [
+                    {
+                        "id": 81,
+                        "name": "File Formats",
+                        "suite_id": 4,
+                        "is_completed": False,
+                        "passed_count": 2,
+                        "failed_count": 2,
+                        "blocked_count": 0,
+                        "untested_count": 3,
+                    },
+                    {
+                        "id": 82,
+                        "name": "System Tests",
+                        "suite_id": 5,
+                        "is_completed": True,
+                        "passed_count": 10,
+                        "failed_count": 0,
+                        "blocked_count": 0,
+                        "untested_count": 0,
+                    },
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.run_handler.get_runs.assert_called_once_with(
+                project_id=1, limit=250, offset=0
+            )
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_list_runs_with_pagination(self, mock_project_client):
+        """Test runs listing with pagination parameters"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.run_handler.get_runs.return_value = (
+            {
+                "offset": 100,
+                "limit": 50,
+                "size": 50,
+                "_links": {
+                    "next": "/api/v2/get_runs/1&offset=150",
+                    "prev": "/api/v2/get_runs/1&offset=50",
+                },
+                "runs": [{"id": i, "name": f"Run {i}", "suite_id": 1, "is_completed": False} for i in range(100, 150)],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.list, ["--offset", "100", "--limit", "50"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.run_handler.get_runs.assert_called_once_with(
+                project_id=1, limit=50, offset=100
+            )
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_list_runs_json_output(self, mock_project_client):
+        """Test runs listing with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        response_data = {
+            "offset": 0,
+            "limit": 250,
+            "size": 1,
+            "runs": [{"id": 81, "name": "Test", "suite_id": 1, "is_completed": False}],
+        }
+        mock_client.api_request_handler.run_handler.get_runs.return_value = (response_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_runs.list, ["--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Check for prettified JSON (with newlines and indentation)
+            assert '"offset": 0' in result.output
+            assert "\n" in result.output  # Prettified has newlines
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_list_runs_show_all_fields(self, mock_project_client):
+        """Test runs listing with show all fields"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.run_handler.get_runs.return_value = (
+            {
+                "offset": 0,
+                "limit": 250,
+                "size": 1,
+                "runs": [
+                    {
+                        "id": 81,
+                        "name": "File Formats",
+                        "description": "Test description",
+                        "suite_id": 4,
+                        "is_completed": False,
+                        "passed_count": 2,
+                        "failed_count": 1,
+                        "blocked_count": 0,
+                        "untested_count": 3,
+                    }
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.list, ["--show-all-fields"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_list_runs_empty_result(self, mock_project_client):
+        """Test runs listing with empty result"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.run_handler.get_runs.return_value = (
+            {"offset": 0, "limit": 250, "size": 0, "runs": []},
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_log.assert_any_call("No runs found.")
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_list_runs_api_error(self, mock_project_client):
+        """Test runs listing with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.run_handler.get_runs.return_value = ({}, "Project not found")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.list, [], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Failed to retrieve runs: Project not found")
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_list_runs_with_next_link(self, mock_project_client):
+        """Test runs listing shows pagination hint when next link is present"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.run_handler.get_runs.return_value = (
+            {
+                "offset": 0,
+                "limit": 250,
+                "size": 250,
+                "_links": {"next": "/api/v2/get_runs/1&offset=250", "prev": None},
+                "runs": [{"id": i, "name": f"Run {i}", "suite_id": 1, "is_completed": False} for i in range(1, 251)],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            log_calls = [str(call) for call in mock_log.call_args_list]
+            pagination_hint_found = any("More results available" in str(call) for call in log_calls)
+            assert pagination_hint_found
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_get_run_with_project_id_from_config(self, mock_project_client):
+        """Test run retrieval uses project_id from environment when not provided"""
+        mock_client = self._setup_project_client_mock(mock_project_client, project_id=42)
+        run_data = {"id": 81, "name": "File Formats", "suite_id": 4, "is_completed": False}
+        mock_client.api_request_handler.run_handler.get_run.return_value = (run_data, "")
+
+        self.environment.project_id = 42
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.get, ["--run-id", "81"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.run_handler.get_run.assert_called_once_with(81)
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_list_runs_with_project_id_from_config(self, mock_project_client):
+        """Test runs listing uses project_id from environment when not provided"""
+        mock_client = self._setup_project_client_mock(mock_project_client, project_id=99)
+        mock_client.api_request_handler.run_handler.get_runs.return_value = (
+            {"offset": 0, "limit": 250, "size": 1, "runs": [{"id": 81, "name": "Test", "suite_id": 1}]},
+            "",
+        )
+
+        self.environment.project_id = 99
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.run_handler.get_runs.assert_called_once_with(
+                project_id=99, limit=250, offset=0
+            )
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_get_run_with_project_name(self, mock_project_client):
+        """Test run retrieval with project name from config"""
+        mock_client = self._setup_project_client_mock(mock_project_client, project_id=42)
+        run_data = {"id": 81, "name": "File Formats", "suite_id": 4, "is_completed": False}
+        mock_client.api_request_handler.run_handler.get_run.return_value = (run_data, "")
+
+        # Set project name in environment (as if from config file)
+        self.environment.project = "TRCLI Test Project"
+        self.environment.project_id = None  # No project_id, only name
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.get, ["--run-id", "81"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Verify resolve_project was called to convert name to ID
+            mock_client.resolve_project.assert_called_once()
+            mock_client.api_request_handler.run_handler.get_run.assert_called_once_with(81)
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_list_runs_with_project_name(self, mock_project_client):
+        """Test runs listing with project name from config"""
+        mock_client = self._setup_project_client_mock(mock_project_client, project_id=99)
+        mock_client.api_request_handler.run_handler.get_runs.return_value = (
+            {"offset": 0, "limit": 250, "size": 1, "runs": [{"id": 81, "name": "Test", "suite_id": 1}]},
+            "",
+        )
+
+        # Set project name in environment (as if from config file)
+        self.environment.project = "TRCLI Test Project"
+        self.environment.project_id = None  # No project_id, only name
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Verify resolve_project was called to convert name to ID
+            mock_client.resolve_project.assert_called_once()
+            mock_client.api_request_handler.run_handler.get_runs.assert_called_once_with(
+                project_id=99, limit=250, offset=0
+            )

--- a/tests/test_data/cli_test_data.py
+++ b/tests/test_data/cli_test_data.py
@@ -78,6 +78,7 @@ trcli_description = (
     "    - sections: Query test sections\n"
     "    - plans: Query test plans\n"
     "    - runs: Query test runs\n"
+    "    - milestones: Query milestones\n"
     "    - results: Query and update test results\n"
 )
 

--- a/tests/test_data/cli_test_data.py
+++ b/tests/test_data/cli_test_data.py
@@ -73,6 +73,12 @@ trcli_description = (
     "    - add_run: Create a new test run\n"
     "    - labels: Manage labels (projects, cases, and tests)\n"
     "    - references: Manage references (cases and runs)\n"
+    "    - cases: Query test cases\n"
+    "    - suites: Query test suites\n"
+    "    - sections: Query test sections\n"
+    "    - plans: Query test plans\n"
+    "    - runs: Query test runs\n"
+    "    - results: Query and update test results\n"
 )
 
 trcli_help_description = "TestRail CLI"

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -16,6 +16,7 @@ from trcli.api.run_handler import RunHandler
 from trcli.api.bdd_handler import BddHandler
 from trcli.api.case_handler import CaseHandler
 from trcli.api.plan_handler import PlanHandler
+from trcli.api.milestone_handler import MilestoneHandler
 from trcli.cli import Environment
 from trcli.constants import (
     ProjectErrors,
@@ -86,6 +87,7 @@ class ApiRequestHandler:
             retrieve_results_callback=ApiRequestHandler.retrieve_results_after_cancelling,
         )
         self.plan_handler = PlanHandler(api_client, environment)
+        self.milestone_handler = MilestoneHandler(api_client)
 
         # BDD case cache for feature name matching (shared by CucumberParser and JunitParser)
         # Structure: {"{project_id}_{suite_id}": {normalized_name: [case_dict, case_dict, ...]}}

--- a/trcli/api/milestone_handler.py
+++ b/trcli/api/milestone_handler.py
@@ -1,0 +1,68 @@
+"""
+MilestoneHandler - Handles all milestone-related operations for TestRail
+
+It manages milestone query operations including:
+- Retrieving a single milestone by ID
+- Listing milestones for a project
+"""
+
+from beartype.typing import Tuple
+
+from trcli.api.api_client import APIClient
+
+
+class MilestoneHandler:
+    """Handles all milestone-related operations for TestRail"""
+
+    def __init__(self, client: APIClient):
+        """
+        Initialize the MilestoneHandler
+
+        :param client: APIClient instance for making API calls
+        """
+        self.client = client
+
+    def get_milestone(self, milestone_id: int) -> Tuple[dict, str]:
+        """
+        Retrieve a single milestone by ID
+
+        :param milestone_id: TestRail milestone ID
+        :returns: Tuple with (milestone_data_dict, error_message)
+        """
+        response = self.client.send_get(f"get_milestone/{milestone_id}")
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""
+
+    def get_milestones(
+        self,
+        project_id: int,
+        limit: int = 250,
+        offset: int = 0,
+    ) -> Tuple[dict, str]:
+        """
+        Retrieve milestones for a project with pagination
+
+        :param project_id: TestRail project ID
+        :param limit: Maximum number of milestones to return (default: 250)
+        :param offset: Offset for pagination (default: 0)
+        :returns: Tuple with (paginated_response_dict, error_message)
+                  Response dict contains: milestones, offset, limit, size, _links
+        """
+        # Build query parameters
+        params = []
+        if limit != 250:
+            params.append(f"limit={limit}")
+        if offset > 0:
+            params.append(f"offset={offset}")
+
+        # Build URL
+        query_string = "&".join(params) if params else ""
+        url = f"get_milestones/{project_id}"
+        if query_string:
+            url = f"{url}&{query_string}"
+
+        response = self.client.send_get(url)
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""

--- a/trcli/api/run_handler.py
+++ b/trcli/api/run_handler.py
@@ -376,6 +376,52 @@ class RunHandler:
         response = self.client.send_post(f"delete_run/{run_id}", payload={})
         return response.response_text, response.error_message
 
+    def get_run(self, run_id: int) -> Tuple[dict, str]:
+        """
+        Retrieve a single test run by ID
+
+        :param run_id: TestRail run ID
+        :returns: Tuple with (run_data_dict, error_message)
+        """
+        response = self.client.send_get(f"get_run/{run_id}")
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""
+
+    def get_runs(
+        self,
+        project_id: int,
+        limit: int = 250,
+        offset: int = 0,
+    ) -> Tuple[dict, str]:
+        """
+        Retrieve test runs for a project with pagination.
+        Only returns test runs that are not part of a test plan.
+
+        :param project_id: TestRail project ID
+        :param limit: Maximum number of runs to return (default: 250)
+        :param offset: Offset for pagination (default: 0)
+        :returns: Tuple with (paginated_response_dict, error_message)
+                  Response dict contains: runs, offset, limit, size, _links
+        """
+        # Build query parameters
+        params = []
+        if limit != 250:
+            params.append(f"limit={limit}")
+        if offset > 0:
+            params.append(f"offset={offset}")
+
+        # Build URL
+        query_string = "&".join(params) if params else ""
+        url = f"get_runs/{project_id}"
+        if query_string:
+            url = f"{url}&{query_string}"
+
+        response = self.client.send_get(url)
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""
+
     def add_plan(
         self,
         project_id: int,

--- a/trcli/commands/cmd_milestones.py
+++ b/trcli/commands/cmd_milestones.py
@@ -1,0 +1,267 @@
+import builtins
+import click
+import json
+from datetime import datetime
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def print_config(env: Environment, action: str):
+    env.log(
+        f"Milestones {action} Execution Parameters"
+        f"\n> TestRail instance: {env.host} (user: {env.username})"
+        f"\n> Project: {env.project if env.project else env.project_id}"
+    )
+
+
+def format_timestamp(timestamp):
+    """Format Unix timestamp to readable date, returns 'N/A' if None"""
+    if timestamp:
+        return datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S")
+    return "N/A"
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.pass_context
+@pass_environment
+def cli(environment: Environment, context: click.Context, *args, **kwargs):
+    """Manage milestones in TestRail"""
+    environment.cmd = "milestones"
+    environment.set_parameters(context)
+
+
+@cli.command()
+@click.option("--milestone-id", type=click.IntRange(min=1), required=True, metavar="", help="Milestone ID to retrieve.")
+@click.option("--json-output", is_flag=True, help="Output milestone as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields including custom fields in detail.")
+@click.pass_context
+@pass_environment
+def get(
+    environment: Environment,
+    context: click.Context,
+    milestone_id: int,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """Get a single milestone by ID"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Get")
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    environment.log(f"Retrieving milestone ID {milestone_id}...")
+
+    # Retrieve the milestone using MilestoneHandler from ProjectBasedClient
+    milestone_data, error_message = project_client.api_request_handler.milestone_handler.get_milestone(milestone_id)
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve milestone: {error_message}")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        # Output prettified JSON response
+        print(json.dumps(milestone_data, indent=2))
+    else:
+        # Display milestone details
+        environment.log("")
+        environment.log(f"Milestone ID: {milestone_data.get('id', 'N/A')}")
+        environment.log(f"  Name: {milestone_data.get('name', 'N/A')}")
+
+        if milestone_data.get("description"):
+            description = milestone_data.get("description")
+            # Truncate long descriptions in non-show-all-fields mode
+            if not show_all_fields and len(description) > 100:
+                description = description[:100] + "..."
+            environment.log(f"  Description: {description}")
+        else:
+            environment.log("  Description: (none)")
+
+        environment.log(f"  Project ID: {milestone_data.get('project_id', 'N/A')}")
+
+        # Status information
+        is_completed = milestone_data.get("is_completed", False)
+        environment.log(f"  Status: {'Completed' if is_completed else 'Active'}")
+
+        # Due date
+        due_on = milestone_data.get("due_on")
+        if due_on:
+            environment.log(f"  Due On: {format_timestamp(due_on)}")
+        else:
+            environment.log("  Due On: (not set)")
+
+        if show_all_fields:
+            # Show additional fields
+            if milestone_data.get("refs"):
+                environment.log(f"  References: {milestone_data.get('refs')}")
+
+            completed_on = milestone_data.get("completed_on")
+            if completed_on:
+                environment.log(f"  Completed On: {format_timestamp(completed_on)}")
+
+            if milestone_data.get("url"):
+                environment.log(f"  URL: {milestone_data.get('url')}")
+
+            # Show all other fields (custom fields)
+            standard_fields = [
+                "id",
+                "name",
+                "description",
+                "project_id",
+                "is_completed",
+                "due_on",
+                "completed_on",
+                "refs",
+                "url",
+            ]
+            custom_fields = {k: v for k, v in milestone_data.items() if k not in standard_fields}
+            if custom_fields:
+                environment.log("  Custom Fields:")
+                for key, value in sorted(custom_fields.items()):
+                    environment.log(f"    {key}: {value}")
+
+    environment.log("")
+    environment.log("Milestone retrieval completed successfully.")
+
+
+@cli.command()
+@click.option(
+    "--offset",
+    type=click.IntRange(min=0),
+    default=0,
+    metavar="",
+    help="Offset for pagination (default: 0).",
+)
+@click.option(
+    "--limit",
+    type=click.IntRange(min=1, max=250),
+    default=250,
+    metavar="",
+    help="Maximum number of milestones to return (default: 250, max: 250).",
+)
+@click.option("--json-output", is_flag=True, help="Output milestones as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields including custom fields for each milestone.")
+@click.pass_context
+@pass_environment
+def list(
+    environment: Environment,
+    context: click.Context,
+    offset: int,
+    limit: int,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """List milestones from TestRail"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "List")
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    environment.log(
+        f"Retrieving milestones for project ID {project_client.project.project_id} (offset: {offset}, limit: {limit})..."
+    )
+
+    # Retrieve milestones using MilestoneHandler
+    milestones_data, error_message = project_client.api_request_handler.milestone_handler.get_milestones(
+        project_id=project_client.project.project_id, limit=limit, offset=offset
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve milestones: {error_message}")
+        raise SystemExit(1)
+
+    milestones = milestones_data.get("milestones", [])
+    total_count = milestones_data.get("size", 0)
+    returned_count = len(milestones)
+
+    if json_output:
+        # Output prettified JSON response
+        print(json.dumps(milestones_data, indent=2))
+    else:
+        environment.log(f"Found {total_count} milestone(s), displaying {returned_count}.")
+        environment.log("")
+
+        if not milestones:
+            environment.log("No milestones found.")
+        else:
+            for milestone in milestones:
+                # Compact format by default
+                status = "✓ Completed" if milestone.get("is_completed") else "○ Active"
+                due_on = format_timestamp(milestone.get("due_on")) if milestone.get("due_on") else "No due date"
+
+                environment.log(f"Milestone ID: {milestone.get('id')}")
+                environment.log(f"  Name: {milestone.get('name')}")
+
+                # Show description if present
+                if milestone.get("description"):
+                    description = milestone.get("description")
+                    if not show_all_fields and len(description) > 80:
+                        description = description[:80] + "..."
+                    environment.log(f"  Description: {description}")
+
+                environment.log(f"  Status: {status}")
+                environment.log(f"  Due On: {due_on}")
+                environment.log(f"  Project ID: {milestone.get('project_id', 'N/A')}")
+
+                if show_all_fields:
+                    # Show additional fields in detailed view
+                    if milestone.get("refs"):
+                        environment.log(f"  References: {milestone.get('refs')}")
+
+                    completed_on = milestone.get("completed_on")
+                    if completed_on:
+                        environment.log(f"  Completed On: {format_timestamp(completed_on)}")
+
+                    if milestone.get("url"):
+                        environment.log(f"  URL: {milestone.get('url')}")
+
+                    # Show custom fields
+                    standard_fields = [
+                        "id",
+                        "name",
+                        "description",
+                        "project_id",
+                        "is_completed",
+                        "due_on",
+                        "completed_on",
+                        "refs",
+                        "url",
+                    ]
+                    custom_fields = {k: v for k, v in milestone.items() if k not in standard_fields}
+                    if custom_fields:
+                        environment.log("  Custom Fields:")
+                        for key, value in sorted(custom_fields.items()):
+                            environment.log(f"    {key}: {value}")
+
+                environment.log("")
+
+        # Pagination info
+        next_link = milestones_data.get("_links", {}).get("next")
+        if next_link:
+            next_offset = offset + limit
+            environment.log(f"More results available. Use --offset {next_offset} to retrieve next page.")
+
+    environment.log("")
+    environment.log("Milestone listing completed successfully.")

--- a/trcli/commands/cmd_runs.py
+++ b/trcli/commands/cmd_runs.py
@@ -1,0 +1,315 @@
+import builtins
+import click
+import json
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def print_config(env: Environment, action: str):
+    env.log(
+        f"Runs {action} Execution Parameters"
+        f"\n> TestRail instance: {env.host} (user: {env.username})"
+        f"\n> Project: {env.project if env.project else env.project_id}"
+    )
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.pass_context
+@pass_environment
+def cli(environment: Environment, context: click.Context, *args, **kwargs):
+    """Manage test runs in TestRail"""
+    environment.cmd = "runs"
+    environment.set_parameters(context)
+
+
+@cli.command()
+@click.option("--run-id", type=click.IntRange(min=1), required=True, metavar="", help="Run ID to retrieve.")
+@click.option("--json-output", is_flag=True, help="Output run as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields including custom fields in detail.")
+@click.pass_context
+@pass_environment
+def get(
+    environment: Environment,
+    context: click.Context,
+    run_id: int,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """Get a single test run by ID"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Get")
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    environment.log(f"Retrieving run ID {run_id}...")
+
+    # Retrieve the run using RunHandler from ProjectBasedClient
+    run_data, error_message = project_client.api_request_handler.run_handler.get_run(run_id)
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve run: {error_message}")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        # Output prettified JSON response
+        print(json.dumps(run_data, indent=2))
+    else:
+        # Display run details
+        environment.log("")
+        environment.log(f"Run ID: {run_data.get('id', 'N/A')}")
+        environment.log(f"  Name: {run_data.get('name', 'N/A')}")
+
+        if run_data.get("description"):
+            description = run_data.get("description")
+            # Truncate long descriptions in non-show-all-fields mode
+            if not show_all_fields and len(description) > 100:
+                description = description[:100] + "..."
+            environment.log(f"  Description: {description}")
+        else:
+            environment.log("  Description: (none)")
+
+        environment.log(f"  Suite ID: {run_data.get('suite_id', 'N/A')}")
+        environment.log(f"  Project ID: {run_data.get('project_id', 'N/A')}")
+
+        # Status information
+        is_completed = run_data.get("is_completed", False)
+        environment.log(f"  Status: {'Completed' if is_completed else 'Active'}")
+
+        if is_completed and run_data.get("completed_on"):
+            environment.log(f"  Completed On: {run_data.get('completed_on')}")
+
+        # Test counts
+        environment.log("  Test Status Counts:")
+        environment.log(f"    Passed: {run_data.get('passed_count', 0)}")
+        environment.log(f"    Failed: {run_data.get('failed_count', 0)}")
+        environment.log(f"    Blocked: {run_data.get('blocked_count', 0)}")
+        environment.log(f"    Retest: {run_data.get('retest_count', 0)}")
+        environment.log(f"    Untested: {run_data.get('untested_count', 0)}")
+
+        if show_all_fields:
+            # Show additional fields
+            if run_data.get("config"):
+                environment.log(f"  Configuration: {run_data.get('config')}")
+
+            if run_data.get("config_ids"):
+                environment.log(f"  Configuration IDs: {run_data.get('config_ids')}")
+
+            if run_data.get("milestone_id"):
+                environment.log(f"  Milestone ID: {run_data.get('milestone_id')}")
+
+            if run_data.get("plan_id"):
+                environment.log(f"  Plan ID: {run_data.get('plan_id')}")
+
+            if run_data.get("assignedto_id"):
+                environment.log(f"  Assigned To ID: {run_data.get('assignedto_id')}")
+
+            if run_data.get("refs"):
+                environment.log(f"  References: {run_data.get('refs')}")
+
+            environment.log(f"  Include All: {'Yes' if run_data.get('include_all') else 'No'}")
+            environment.log(f"  Created By: {run_data.get('created_by', 'N/A')}")
+            environment.log(f"  Created On: {run_data.get('created_on', 'N/A')}")
+
+            if run_data.get("updated_on"):
+                environment.log(f"  Updated On: {run_data.get('updated_on')}")
+
+            if run_data.get("url"):
+                environment.log(f"  URL: {run_data.get('url')}")
+
+            # Show custom status counts
+            custom_counts = {
+                k: v for k, v in run_data.items() if k.startswith("custom_status") and k.endswith("_count")
+            }
+            if any(v > 0 for v in custom_counts.values()):
+                environment.log("  Custom Status Counts:")
+                for key, value in custom_counts.items():
+                    if value > 0:
+                        status_num = key.replace("custom_status", "").replace("_count", "")
+                        environment.log(f"    Custom Status {status_num}: {value}")
+
+            # Show all other fields
+            standard_fields = [
+                "id",
+                "name",
+                "description",
+                "suite_id",
+                "project_id",
+                "is_completed",
+                "completed_on",
+                "passed_count",
+                "failed_count",
+                "blocked_count",
+                "retest_count",
+                "untested_count",
+                "config",
+                "config_ids",
+                "milestone_id",
+                "plan_id",
+                "assignedto_id",
+                "refs",
+                "include_all",
+                "created_by",
+                "created_on",
+                "updated_on",
+                "url",
+                "custom_status1_count",
+                "custom_status2_count",
+                "custom_status3_count",
+                "custom_status4_count",
+                "custom_status5_count",
+                "custom_status6_count",
+                "custom_status7_count",
+            ]
+            other_fields = {k: v for k, v in run_data.items() if k not in standard_fields}
+            if other_fields:
+                environment.log(f"\n  Additional Fields ({len(other_fields)}):")
+                for key, value in other_fields.items():
+                    display_name = key.replace("_", " ").title()
+                    if value is None:
+                        display_value = "N/A"
+                    elif isinstance(value, builtins.list):
+                        if value:
+                            display_value = f"{len(value)} item(s): {value}"
+                        else:
+                            display_value = "[]"
+                    else:
+                        display_value = value
+                    environment.log(f"    {display_name}: {display_value}")
+
+
+@cli.command()
+@click.option("--offset", type=int, default=0, metavar="", help="Offset for pagination (default: 0).")
+@click.option("--limit", type=int, default=250, metavar="", help="Limit for pagination (default: 250).")
+@click.option("--json-output", is_flag=True, help="Output runs as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields including custom fields in detail.")
+@click.pass_context
+@pass_environment
+def list(
+    environment: Environment,
+    context: click.Context,
+    offset: int,
+    limit: int,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """List test runs from TestRail"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "List")
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    environment.log(f"Retrieving runs for project ID {project_client.project.project_id}...")
+    environment.log("(Note: Only returns runs not part of test plans)")
+
+    # Retrieve runs using RunHandler from ProjectBasedClient
+    response_data, error_message = project_client.api_request_handler.run_handler.get_runs(
+        project_id=project_client.project.project_id,
+        limit=limit,
+        offset=offset,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve runs: {error_message}")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        # Output prettified JSON response
+        print(json.dumps(response_data, indent=2))
+    else:
+        # Display runs line by line
+        runs = response_data.get("runs", [])
+        response_offset = response_data.get("offset", 0)
+        response_limit = response_data.get("limit", 250)
+        response_size = response_data.get("size", 0)
+        next_link = response_data.get("_links", {}).get("next")
+
+        if not runs:
+            environment.log("No runs found.")
+        else:
+            environment.log(
+                f"Found {response_size} run(s) (showing {response_offset + 1}-{response_offset + len(runs)}):"
+            )
+            if next_link:
+                environment.log("  (More results available - use --offset and --limit for pagination)")
+            environment.log("")
+
+            for run in runs:
+                if show_all_fields:
+                    # Show all fields from API response
+                    environment.log(f"  Run ID: {run.get('id', 'N/A')}")
+
+                    # Iterate through all fields in the run
+                    for key, value in run.items():
+                        if key == "id":
+                            continue  # Already displayed as Run ID
+
+                        # Format field name for display
+                        display_name = key.replace("_", " ").title()
+
+                        # Handle None values
+                        if value is None:
+                            display_value = "N/A"
+                        elif isinstance(value, bool):
+                            display_value = "Yes" if value else "No"
+                        elif isinstance(value, builtins.list):
+                            if value:
+                                display_value = f"{len(value)} item(s): {value}"
+                            else:
+                                display_value = "[]"
+                        else:
+                            display_value = value
+
+                        environment.log(f"    {display_name}: {display_value}")
+
+                    environment.log("")
+                else:
+                    # Display compact format
+                    environment.log(f"  Run ID: {run.get('id', 'N/A')}")
+                    environment.log(f"    Name: {run.get('name', 'N/A')}")
+
+                    if run.get("description"):
+                        description = run.get("description")
+                        # Truncate long descriptions in compact mode
+                        if len(description) > 80:
+                            description = description[:80] + "..."
+                        environment.log(f"    Description: {description}")
+
+                    is_completed = run.get("is_completed", False)
+                    environment.log(f"    Status: {'Completed' if is_completed else 'Active'}")
+
+                    # Show test counts
+                    passed = run.get("passed_count", 0)
+                    failed = run.get("failed_count", 0)
+                    blocked = run.get("blocked_count", 0)
+                    untested = run.get("untested_count", 0)
+                    environment.log(
+                        f"    Tests: Passed={passed}, Failed={failed}, Blocked={blocked}, Untested={untested}"
+                    )
+
+                    environment.log(f"    Suite ID: {run.get('suite_id', 'N/A')}")
+
+                    environment.log("")

--- a/trcli/constants.py
+++ b/trcli/constants.py
@@ -94,6 +94,7 @@ COMMAND_FAULT_MAPPING = dict(
     suites=dict(**FAULT_MAPPING),
     plans=dict(**FAULT_MAPPING),
     sections=dict(**FAULT_MAPPING),
+    runs=dict(**FAULT_MAPPING),
 )
 
 PROMPT_MESSAGES = dict(
@@ -119,7 +120,13 @@ TOOL_USAGE = f"""Supported and loaded modules:
     - parse_openapi: OpenAPI YML Files
     - add_run: Create a new test run
     - labels: Manage labels (projects, cases, and tests)
-    - references: Manage references (cases and runs)"""
+    - references: Manage references (cases and runs)
+    - cases: Query test cases
+    - suites: Query test suites
+    - sections: Query test sections
+    - plans: Query test plans
+    - runs: Query test runs
+    - results: Query and update test results"""
 
 MISSING_COMMAND_SLOGAN = """Usage: trcli [OPTIONS] COMMAND [ARGS]...\nTry 'trcli --help' for help.
 \nError: Missing command."""

--- a/trcli/constants.py
+++ b/trcli/constants.py
@@ -95,6 +95,7 @@ COMMAND_FAULT_MAPPING = dict(
     plans=dict(**FAULT_MAPPING),
     sections=dict(**FAULT_MAPPING),
     runs=dict(**FAULT_MAPPING),
+    milestones=dict(**FAULT_MAPPING),
 )
 
 PROMPT_MESSAGES = dict(
@@ -126,6 +127,7 @@ TOOL_USAGE = f"""Supported and loaded modules:
     - sections: Query test sections
     - plans: Query test plans
     - runs: Query test runs
+    - milestones: Query milestones
     - results: Query and update test results"""
 
 MISSING_COMMAND_SLOGAN = """Usage: trcli [OPTIONS] COMMAND [ARGS]...\nTry 'trcli --help' for help.


### PR DESCRIPTION
### Solution description
Implemented a new milestones command that allows users to retrieve milestones information from TestRail. This is significantly useful for more flexible automation.

### Changes
Added a new milestones command with get and list subcommands, also supports pagination and json output.

### Potential impacts
None.

### Steps to test
See updated README: 2116 - 2186

### PR Tasks
- [x] PR reference added to issue
- [x] README updated
- [x] Unit tests added/updated
