### PR TITLE
TRCLI-281: Get/Read export command for Case Fields

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/). Version numb
 _released 06-24-2026
 
 ### Added
- - **Added more data query commands for comprehensive AI automation support**
+ - **New `runs` command**: Query and retrieve test run information from TestRail with `get` and `list` subcommands. Provides execution metrics, status tracking, and configuration details. Note: Only returns standalone runs (not runs within test plans).
 
 ## [1.15.0]
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -12,6 +12,7 @@ _released 06-24-2026
 
 ### Added
  - **New `runs` command**: Query and retrieve test run information from TestRail with `get` and `list` subcommands. Provides execution metrics, status tracking, and configuration details. Note: Only returns standalone runs (not runs within test plans).
+ - **New `milestones` command**: Query and retrieve milestone information from TestRail with `get` and `list` subcommands. Track project milestones, monitor completion status, due dates, and references.
 
 ## [1.15.0]
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -13,6 +13,7 @@ _released 06-24-2026
 ### Added
  - **New `runs` command**: Query and retrieve test run information from TestRail with `get` and `list` subcommands. Provides execution metrics, status tracking, and configuration details. Note: Only returns standalone runs (not runs within test plans).
  - **New `milestones` command**: Query and retrieve milestone information from TestRail with `get` and `list` subcommands. Track project milestones, monitor completion status, due dates, and references.
+ - **New `statuses` command**: Query and retrieve status information from TestRail with `all`: List all test result statuses (Passed, Failed, Blocked, etc.) with system/custom flags, colors, and behavior properties and `case`: List all case statuses (Approved, Draft, etc.) for case workflow management (requires TestRail Enterprise 7.3+)
 
 ## [1.15.0]
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -14,6 +14,7 @@ _released 06-24-2026
  - **New `runs` command**: Query and retrieve test run information from TestRail with `get` and `list` subcommands. Provides execution metrics, status tracking, and configuration details. Note: Only returns standalone runs (not runs within test plans).
  - **New `milestones` command**: Query and retrieve milestone information from TestRail with `get` and `list` subcommands. Track project milestones, monitor completion status, due dates, and references.
  - **New `statuses` command**: Query and retrieve status information from TestRail with `all`: List all test result statuses (Passed, Failed, Blocked, etc.) with system/custom flags, colors, and behavior properties and `case`: List all case statuses (Approved, Draft, etc.) for case workflow management (requires TestRail Enterprise 7.3+)
+ - **New `casefields` command**: Query and retrieve all test case custom fields from TestRail. Lists available fields with their types, configurations, and project applicability. Supports `--project` to show only fields applicable to a specific project (overrides project in config file), and `--show-all-fields` for detailed configuration information including field options and requirements.
 
 ## [1.15.0]
 

--- a/README.md
+++ b/README.md
@@ -1466,7 +1466,7 @@ Get detailed information about a specific test case by its ID:
 
 ```shell
 # Get a test case (using config file)
-$ trcli cases get -c config.yml --case-id 123
+$ trcli -c config.yml cases get --case-id 123
 
 # Get a test case with all parameters
 $ trcli cases get \
@@ -1477,10 +1477,10 @@ $ trcli cases get \
   --case-id 123
 
 # Get case with all fields displayed
-$ trcli cases get -c config.yml --case-id 123 --show-all-fields
+$ trcli -c config.yml cases get --case-id 123 --show-all-fields
 
 # Get case as JSON (for piping to jq or other tools)
-$ trcli cases get -c config.yml --case-id 123 --json-output
+$ trcli -c config.yml cases get --case-id 123 --json-output
 ```
 
 **Output example:**
@@ -1542,28 +1542,28 @@ List test cases from a project with optional filtering by suite, priority, or te
 
 ```shell
 # List all cases in a project (using config file)
-$ trcli cases list -c config.yml
+$ trcli -c config.yml cases list
 
 # List cases with suite filter
-$ trcli cases list -c config.yml --suite-id 2
+$ trcli -c config.yml cases list --suite-id 2
 
 # List cases with priority filter (high priority only)
-$ trcli cases list -c config.yml --priority-id 4
+$ trcli -c config.yml cases list --priority-id 4
 
 # List cases with multiple priorities
-$ trcli cases list -c config.yml --priority-id "3,4"
+$ trcli -c config.yml cases list --priority-id "3,4"
 
 # List cases with text search
-$ trcli cases list -c config.yml --filter "login"
+$ trcli -c config.yml cases list --filter "login"
 
 # Combine multiple filters
-$ trcli cases list -c config.yml --suite-id 2 --priority-id 4 --filter "authentication"
+$ trcli -c config.yml cases list --suite-id 2 --priority-id 4 --filter "authentication"
 
 # Pagination support
-$ trcli cases list -c config.yml --offset 250 --limit 100
+$ trcli -c config.yml cases list --offset 250 --limit 100
 
 # JSON output for integration with other tools
-$ trcli cases list -c config.yml --suite-id 2 --json-output | jq '.cases[].title'
+$ trcli -c config.yml cases list --suite-id 2 --json-output | jq '.cases[].title'
 ```
 
 **Output example:**
@@ -1617,8 +1617,8 @@ project: Your Project          # Project name (required)
 
 Then use with the `-c` flag:
 ```shell
-$ trcli cases list -c config.yml
-$ trcli cases get -c config.yml --case-id 123
+$ trcli -c config.yml cases list
+$ trcli -c config.yml cases get --case-id 123
 ```
 
 ##### Command Options Reference
@@ -1651,28 +1651,28 @@ Options:
 
 **1. Export case data for documentation:**
 ```shell
-$ trcli cases list -c config.yml --json-output > cases_export.json
+$ trcli -c config.yml cases list --json-output > cases_export.json
 ```
 
 **2. Find all high-priority cases:**
 ```shell
-$ trcli cases list -c config.yml --priority-id 4
+$ trcli -c config.yml cases list --priority-id 4
 ```
 
 **3. Integration with CI/CD pipelines:**
 ```shell
 # Get test cases and pipe to analysis tool
-$ trcli cases list -c config.yml --suite-id 2 --json-output | jq -r '.cases[] | select(.labels[].title == "automated") | .title'
+$ trcli -c config.yml cases list --suite-id 2 --json-output | jq -r '.cases[] | select(.labels[].title == "automated") | .title'
 ```
 
 **4. Discover cases by keyword:**
 ```shell
-$ trcli cases list -c config.yml --filter "API"
+$ trcli -c config.yml cases list --filter "API"
 ```
 
 **5. Verify case details before test execution:**
 ```shell
-$ trcli cases get -c config.yml --case-id 123 --show-all-fields
+$ trcli -c config.yml cases get --case-id 123 --show-all-fields
 ```
 
 #### Managing Test Suites
@@ -1717,10 +1717,10 @@ Get detailed information about a specific test suite by its ID :
 
 ```shell
 # Get suite with all fields displayed
-$ trcli suites get -c config.yml --suite-id 1 --show-all-fields
+$ trcli -c config.yml suites get --suite-id 1 --show-all-fields
 
 # Get suite as JSON (for piping to jq or other tools)
-$ trcli suites get -c config.yml --suite-id 1 --json-output
+$ trcli -c config.yml suites get --suite-id 1 --json-output
 ```
 
 ##### Listing Test Suites
@@ -1729,7 +1729,7 @@ List test suites from a project with pagination support:
 
 ```shell
 # List all suites in a project (using config file)
-$ trcli suites list -c config.yml
+$ trcli -c config.yml suites list
 
 # List all suites with all parameters
 $ trcli suites list \
@@ -1739,13 +1739,13 @@ $ trcli suites list \
   --project "Your Project"
 
 # Pagination support
-$ trcli suites list -c config.yml --offset 250 --limit 100
+$ trcli -c config.yml suites list --offset 250 --limit 100
 
 # JSON output for integration with other tools
-$ trcli suites list -c config.yml --json-output | jq '.suites[].name'
+$ trcli -c config.yml suites list --json-output | jq '.suites[].name'
 
 # Show all fields for each suite
-$ trcli suites list -c config.yml --show-all-fields
+$ trcli -c config.yml suites list --show-all-fields
 ```
 
 ##### Configuration File Support
@@ -1762,8 +1762,8 @@ project: Your Project          # Project name (required)
 
 Then use with the `-c` flag:
 ```shell
-$ trcli suites list -c config.yml
-$ trcli suites get -c config.yml --suite-id 1
+$ trcli -c config.yml suites list
+$ trcli -c config.yml suites get --suite-id 1
 ```
 
 ##### Command Options Reference
@@ -1793,29 +1793,29 @@ Options:
 
 **1. Export suite data for documentation:**
 ```shell
-$ trcli suites list -c config.yml --json-output > suites_export.json
+$ trcli -c config.yml suites list --json-output > suites_export.json
 ```
 
 **2. Discover suites in a multi-suite project:**
 ```shell
-$ trcli suites list -c config.yml
+$ trcli -c config.yml suites list
 ```
 
 **3. Integration with CI/CD pipelines:**
 ```shell
 # Get all suite names and process them
-$ trcli suites list -c config.yml --json-output | jq -r '.suites[] | .name'
+$ trcli -c config.yml suites list --json-output | jq -r '.suites[] | .name'
 ```
 
 **4. Verify suite details before test execution:**
 ```shell
-$ trcli suites get -c config.yml --suite-id 1 --show-all-fields
+$ trcli -c config.yml suites get --suite-id 1 --show-all-fields
 ```
 
 **5. Identify suite IDs for multi-suite workflows:**
 ```shell
 # Find suite ID by name
-$ trcli suites list -c config.yml --json-output | jq '.suites[] | select(.name=="API Tests") | .id'
+$ trcli -c config.yml suites list --json-output | jq '.suites[] | select(.name=="API Tests") | .id'
 ```
 
 #### Managing Test Plans
@@ -1853,7 +1853,7 @@ Get detailed information about a specific test plan by its ID, including all ent
 
 ```shell
 # Get a test plan (using config file)
-$ trcli plans get -c config.yml --plan-id 10
+$ trcli -c config.yml plans get --plan-id 10
 
 # Get a test plan with all parameters
 $ trcli plans get \
@@ -1864,10 +1864,10 @@ $ trcli plans get \
   --plan-id 10
 
 # Get plan with all fields displayed
-$ trcli plans get -c config.yml --plan-id 10 --show-all-fields
+$ trcli -c config.yml plans get --plan-id 10 --show-all-fields
 
 # Get plan as JSON (for piping to jq or other tools)
-$ trcli plans get -c config.yml --plan-id 10 --json-output
+$ trcli -c config.yml plans get --plan-id 10 --json-output
 ``` 
 
 ##### Listing Test Plans
@@ -1876,7 +1876,7 @@ List test plans from a project with pagination support:
 
 ```shell
 # List all plans in a project (using config file)
-$ trcli plans list -c config.yml
+$ trcli -c config.yml plans list
 
 # List all plans with all parameters
 $ trcli plans list \
@@ -1886,13 +1886,13 @@ $ trcli plans list \
   --project "Your Project"
 
 # Pagination support
-$ trcli plans list -c config.yml --offset 250 --limit 100
+$ trcli -c config.yml plans list --offset 250 --limit 100
 
 # JSON output for integration with other tools
-$ trcli plans list -c config.yml --json-output | jq '.plans[].name'
+$ trcli -c config.yml plans list --json-output | jq '.plans[].name'
 
 # Show all fields for each plan
-$ trcli plans list -c config.yml --show-all-fields
+$ trcli -c config.yml plans list --show-all-fields
 ```
 
 ##### Configuration File Support
@@ -1909,8 +1909,8 @@ project: Your Project          # Project name (required)
 
 Then use with the `-c` flag:
 ```shell
-$ trcli plans list -c config.yml
-$ trcli plans get -c config.yml --plan-id 10
+$ trcli -c config.yml plans list
+$ trcli -c config.yml plans get --plan-id 10
 ```
 
 ##### Command Options Reference
@@ -1940,12 +1940,12 @@ Options:
 
 **1. Monitor release testing progress:**
 ```shell
-$ trcli plans get -c config.yml --plan-id 10
+$ trcli -c config.yml plans get --plan-id 10
 ```
 
 **2. Export plan data for reporting:**
 ```shell
-$ trcli plans list -c config.yml --json-output > plans_report.json
+$ trcli -c config.yml plans list --json-output > plans_report.json
 ```
 
 ### Managing Sections
@@ -1984,7 +1984,7 @@ Get detailed information about a specific section by its ID:
 
 ```shell
 # Get a section (using config file)
-$ trcli sections get -c config.yml --section-id 10
+$ trcli -c config.yml sections get --section-id 10
 
 # Get a section with all parameters
 $ trcli sections get \
@@ -1995,10 +1995,10 @@ $ trcli sections get \
   --section-id 10
 
 # Get section with all fields displayed
-$ trcli sections get -c config.yml --section-id 10 --show-all-fields
+$ trcli -c config.yml sections get --section-id 10 --show-all-fields
 
 # Get section as JSON (for piping to jq or other tools)
-$ trcli sections get -c config.yml --section-id 10 --json-output
+$ trcli -c config.yml sections get --section-id 10 --json-output
 ```
 ##### Listing Sections
 
@@ -2006,7 +2006,7 @@ List sections from a project with pagination support:
 
 ```shell
 # List all sections in a project (using config file)
-$ trcli sections list -c config.yml
+$ trcli -c config.yml sections list
 
 # List all sections with all parameters
 $ trcli sections list \
@@ -2016,13 +2016,13 @@ $ trcli sections list \
   --project "Your Project"
 
 # Pagination support
-$ trcli sections list -c config.yml --offset 250 --limit 100
+$ trcli -c config.yml sections list --offset 250 --limit 100
 
 # JSON output for integration with other tools
-$ trcli sections list -c config.yml --json-output | jq '.sections[].name'
+$ trcli -c config.yml sections list --json-output | jq '.sections[].name'
 
 # Show all fields for each section
-$ trcli sections list -c config.yml --show-all-fields
+$ trcli -c config.yml sections list --show-all-fields
 ```
 
 ### Managing Runs
@@ -2063,7 +2063,7 @@ Get detailed information about a specific run by its ID:
 
 ```shell
 # Get a run (using config file)
-$ trcli runs get -c config.yml --run-id 100
+$ trcli -c config.yml runs get --run-id 100
 
 # Get a run with all parameters
 $ trcli runs get \
@@ -2074,10 +2074,10 @@ $ trcli runs get \
   --run-id 100
 
 # Get run with all fields displayed (includes timestamps, config IDs, milestone, etc.)
-$ trcli runs get -c config.yml --run-id 100 --show-all-fields
+$ trcli -c config.yml runs get --run-id 100 --show-all-fields
 
 # Get run as JSON (for piping to jq or other tools)
-$ trcli runs get -c config.yml --run-id 100 --json-output
+$ trcli -c config.yml runs get --run-id 100 --json-output
 ```
 ##### Listing Runs
 
@@ -2085,7 +2085,7 @@ List runs from a project with pagination support:
 
 ```shell
 # List all runs in a project (using config file)
-$ trcli runs list -c config.yml
+$ trcli -c config.yml runs list
 
 # List all runs with all parameters
 $ trcli runs list \
@@ -2095,13 +2095,13 @@ $ trcli runs list \
   --project "Your Project"
 
 # Pagination support
-$ trcli runs list -c config.yml --offset 0 --limit 50
+$ trcli -c config.yml runs list --offset 0 --limit 50
 
 # JSON output for integration with other tools
-$ trcli runs list -c config.yml --json-output | jq '.runs[].name'
+$ trcli -c config.yml runs list --json-output | jq '.runs[].name'
 
 # Show all fields for each run
-$ trcli runs list -c config.yml --show-all-fields
+$ trcli -c config.yml runs list --show-all-fields
 ```
 
 #### Labels Management

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Commands:
   suites         Manage test suites in TestRail
   runs           Manage test runs in TestRail
   milestones     Manage milestones in TestRail
+  statuses       Manage test statuses in TestRail
   update         Update TRCLI to the latest version from PyPI.
 ```
 
@@ -2184,6 +2185,157 @@ $ trcli -c config.yml milestones list --json-output | jq '.milestones[].name'
 
 # Show all fields for each milestone
 $ trcli -c config.yml milestones list --show-all-fields
+```
+
+### Statuses Command
+
+The TestRail CLI provides the `statuses` command for retrieving status information from TestRail. This includes both test result statuses (Passed, Failed, Blocked, etc.) and case statuses (Approved, Draft, etc.). These statuses are crucial for mapping test results correctly and managing test case workflows.
+
+#### Statuses Command Overview
+
+The `statuses` command supports two subcommands:
+
+| Subcommand | Purpose | API Endpoint |
+|------------|---------|--------------|
+| `all` | List all test result statuses | Retrieve available test result statuses (Passed, Failed, Blocked, etc.) |
+| `case` | List all case statuses (Enterprise 7.3+) | Retrieve test case statuses (Approved, Draft, etc.) for case workflows |
+
+#### Reference
+
+```shell
+$ trcli statuses --help
+
+Usage: trcli statuses [OPTIONS] COMMAND [ARGS]...
+  Manage test statuses in TestRail
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  all   List all test result statuses from TestRail
+  case  List all case statuses from TestRail (Enterprise 7.3+)
+```
+
+##### Listing Test Result Statuses
+
+List all test result statuses available for a project:
+
+```shell
+# List all test result statuses (using config file)
+$ trcli -c config.yml statuses all
+
+# List all statuses with all parameters
+$ trcli statuses all \
+  --host https://yourinstance.testrail.io \
+  --username <your_username> \
+  --password <your_password> \
+  --project "Your Project"
+
+# Show all fields including color values
+$ trcli -c config.yml statuses all --show-all-fields
+
+# JSON output for integration with other tools
+$ trcli -c config.yml statuses all --json-output | jq '.[].name'
+```
+
+**Example Output:**
+
+```shell
+$ trcli -c config.yml statuses all
+
+Statuses List (Test Result Statuses) Execution Parameters
+> TestRail instance: https://yourinstance.testrail.io (user: test@example.com)
+> Project: Your Project
+
+Retrieving test result statuses for project ID 1...
+Found 5 test result status(es):
+
+Status ID: 1
+  Name: passed
+  Label: Passed
+  System Status: Yes
+  Is Untested: No
+  Is Final: Yes
+
+Status ID: 2
+  Name: blocked
+  Label: Blocked
+  System Status: Yes
+  Is Untested: No
+  Is Final: No
+
+Status ID: 3
+  Name: untested
+  Label: Untested
+  System Status: Yes
+  Is Untested: Yes
+  Is Final: No
+
+Status ID: 4
+  Name: retest
+  Label: Retest
+  System Status: Yes
+  Is Untested: No
+  Is Final: No
+
+Status ID: 5
+  Name: failed
+  Label: Failed
+  System Status: Yes
+  Is Untested: No
+  Is Final: Yes
+
+
+Status listing completed successfully.
+```
+
+##### Listing Case Statuses
+
+List all case statuses (requires TestRail Enterprise 7.3+):
+
+```shell
+# List all case statuses (using config file)
+$ trcli -c config.yml statuses case
+
+# List case statuses with all parameters
+$ trcli statuses case \
+  --host https://yourinstance.testrail.io \
+  --username <your_username> \
+  --password <your_password> \
+  --project "Your Project"
+
+# Show all fields including abbreviations
+$ trcli -c config.yml statuses case --show-all-fields
+
+# JSON output for integration
+$ trcli -c config.yml statuses case --json-output | jq '.[].name'
+```
+
+**Example Output:**
+
+```shell
+$ trcli -c config.yml statuses case
+
+Statuses List (Case Statuses) Execution Parameters
+> TestRail instance: https://yourinstance.testrail.io (user: test@example.com)
+> Project: Your Project
+
+Retrieving case statuses...
+Note: This command requires TestRail Enterprise 7.3 or later.
+Found 2 case status(es):
+
+Case Status ID: 1
+  Name: Approved
+  Is Default: No
+  Is Approved: Yes
+
+Case Status ID: 2
+  Name: Draft
+  Is Default: Yes
+  Is Approved: No
+
+
+Case status listing completed successfully.
 ```
 
 #### Labels Management

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Commands:
   runs           Manage test runs in TestRail
   milestones     Manage milestones in TestRail
   statuses       Manage test statuses in TestRail
+  casefields     List case fields in TestRail
   update         Update TRCLI to the latest version from PyPI.
 ```
 
@@ -2336,6 +2337,40 @@ Case Status ID: 2
 
 
 Case status listing completed successfully.
+```
+
+### Case Fields Command
+
+The TestRail CLI provides the `casefields` command for retrieving all available test case custom fields from TestRail. This command helps you understand what custom fields are available for test cases, their types, configurations, and which projects they apply to.
+
+#### Reference
+
+```shell
+$ trcli casefields --help
+
+Usage: trcli casefields [OPTIONS]
+  List all case fields from TestRail
+
+Options:
+  --json-output      Output case fields as raw JSON from API.
+  --show-all-fields  Show all fields including configs and options.
+  --help             Show this message and exit.
+```
+
+#### Listing Case Fields
+
+```shell
+# List all case fields
+$ trcli -c config.yml casefields
+
+# Show all fields including configurations
+$ trcli -c config.yml casefields --show-all-fields
+
+# Filter to show only fields for a specific project (auto-filters when --project is specified)
+$ trcli -c config.yml --project "Your Project" casefields
+
+# JSON output
+$ trcli -c config.yml casefields --json-output | jq '.[].label'
 ```
 
 #### Labels Management

--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ Commands:
   parse_openapi  Parse OpenAPI spec and create cases in TestRail
   parse_robot    Parse Robot Framework report and upload results to TestRail
   references     Manage references in TestRail
+  results        Manage test results in TestRail
+  sections       Manage test sections in TestRail
+  suites         Manage test suites in TestRail
+  runs           Manage test runs in TestRail
+  milestones     Manage milestones in TestRail
   update         Update TRCLI to the latest version from PyPI.
 ```
 
@@ -2102,6 +2107,83 @@ $ trcli -c config.yml runs list --json-output | jq '.runs[].name'
 
 # Show all fields for each run
 $ trcli -c config.yml runs list --show-all-fields
+```
+
+### Managing Milestones
+
+The TestRail CLI provides the `milestones` command for retrieving and listing milestones from TestRail. Milestones represent important project dates and deliverables, helping track progress toward releases and major project goals. This command is useful for monitoring milestone status, tracking completion dates, exporting milestone data, and integrating milestone information into project management workflows.
+
+### Milestones Command Overview
+
+The `milestones` command supports two subcommands:
+
+| Subcommand | Purpose |
+|------------|---------|
+| `milestones get` | Retrieve a single milestone by ID | Get detailed information about a milestone including status, due dates, and completion |
+| `milestones list` | List milestones in a project | Track project milestones, monitor progress, and export milestone data |
+
+### Reference
+
+```shell
+
+$ trcli milestones --help
+
+Usage: trcli milestones [OPTIONS] COMMAND [ARGS]...
+  Manage milestones in TestRail
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  get   Get a single milestone by ID
+  list  List milestones from TestRail
+```
+
+##### Retrieving a Single Milestone
+
+Get detailed information about a specific milestone by its ID:
+
+```shell
+# Get a milestone (using config file)
+$ trcli -c config.yml milestones get --milestone-id 1
+
+# Get a milestone with all parameters
+$ trcli milestones get \
+  --host https://yourinstance.testrail.io \
+  --username <your_username> \
+  --password <your_password> \
+  --project "Your Project" \
+  --milestone-id 1
+
+# Get milestone with all fields displayed (includes timestamps, references, URL, etc.)
+$ trcli -c config.yml milestones get --milestone-id 1 --show-all-fields
+
+# Get milestone as JSON (for piping to jq or other tools)
+$ trcli -c config.yml milestones get --milestone-id 1 --json-output
+```
+##### Listing Milestones
+
+List milestones from a project with pagination support:
+
+```shell
+# List all milestones in a project (using config file)
+$ trcli -c config.yml milestones list
+
+# List all milestones with all parameters
+$ trcli milestones list \
+  --host https://yourinstance.testrail.io \
+  --username <your_username> \
+  --password <your_password> \
+  --project "Your Project"
+
+# Pagination support
+$ trcli -c config.yml milestones list --offset 0 --limit 50
+
+# JSON output for integration with other tools
+$ trcli -c config.yml milestones list --json-output | jq '.milestones[].name'
+
+# Show all fields for each milestone
+$ trcli -c config.yml milestones list --show-all-fields
 ```
 
 #### Labels Management

--- a/README.md
+++ b/README.md
@@ -2025,6 +2025,85 @@ $ trcli sections list -c config.yml --json-output | jq '.sections[].name'
 $ trcli sections list -c config.yml --show-all-fields
 ```
 
+### Managing Runs
+
+The TestRail CLI provides the `runs` command for retrieving and listing test runs from TestRail. Test runs represent the execution of a set of test cases, tracking their results and providing execution metrics. This command is useful for monitoring test execution progress, auditing run configurations, exporting run data, and integrating run information into automation workflows.
+
+**Note:** The `runs` command only returns standalone test runs (runs not part of a test plan). To query runs within test plans, use the `plans` command.
+
+### Runs Command Overview
+
+The `runs` command supports two subcommands:
+
+| Subcommand | Purpose |
+|------------|---------|
+| `runs get` | Retrieve a single run by ID | Get detailed information about a run including execution status, test counts, and configuration |
+| `runs list` | List runs in a project | Monitor active runs, track execution progress, and export run data |
+
+### Reference
+
+```shell
+
+$ trcli runs --help
+
+Usage: trcli runs [OPTIONS] COMMAND [ARGS]...
+  Manage runs in TestRail
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  get   Get a single run by ID
+  list  List runs from TestRail
+```
+
+##### Retrieving a Single Run
+
+Get detailed information about a specific run by its ID:
+
+```shell
+# Get a run (using config file)
+$ trcli runs get -c config.yml --run-id 100
+
+# Get a run with all parameters
+$ trcli runs get \
+  --host https://yourinstance.testrail.io \
+  --username <your_username> \
+  --password <your_password> \
+  --project "Your Project" \
+  --run-id 100
+
+# Get run with all fields displayed (includes timestamps, config IDs, milestone, etc.)
+$ trcli runs get -c config.yml --run-id 100 --show-all-fields
+
+# Get run as JSON (for piping to jq or other tools)
+$ trcli runs get -c config.yml --run-id 100 --json-output
+```
+##### Listing Runs
+
+List runs from a project with pagination support:
+
+```shell
+# List all runs in a project (using config file)
+$ trcli runs list -c config.yml
+
+# List all runs with all parameters
+$ trcli runs list \
+  --host https://yourinstance.testrail.io \
+  --username <your_username> \
+  --password <your_password> \
+  --project "Your Project"
+
+# Pagination support
+$ trcli runs list -c config.yml --offset 0 --limit 50
+
+# JSON output for integration with other tools
+$ trcli runs list -c config.yml --json-output | jq '.runs[].name'
+
+# Show all fields for each run
+$ trcli runs list -c config.yml --show-all-fields
+```
+
 #### Labels Management
 
 The TestRail CLI provides comprehensive label management capabilities using the `labels` command. Labels help categorize and organize your test management assets efficiently, making it easier to filter and manage test cases, runs, and projects.

--- a/tests/test_cmd_case_fields.py
+++ b/tests/test_cmd_case_fields.py
@@ -1,0 +1,340 @@
+import pytest
+from unittest import mock
+from unittest.mock import MagicMock, patch
+from click.testing import CliRunner
+
+from trcli.cli import Environment
+from trcli.commands import cmd_casefields
+
+
+class TestCmdCaseFields:
+    """Test class for case-fields command functionality"""
+
+    def setup_method(self):
+        """Set up test environment"""
+        self.runner = CliRunner()
+        self.environment = Environment(cmd="casefields")
+        self.environment.host = "https://test.testrail.com"
+        self.environment.username = "test@example.com"
+        self.environment.password = "password"
+        self.environment.project = "Test Project"
+        self.environment.project_id = 1
+
+    def _setup_project_client_mock(self, mock_project_client, project_id=1):
+        """Helper to setup ProjectBasedClient mock"""
+        mock_client_instance = MagicMock()
+        mock_project_client.return_value = mock_client_instance
+        mock_client_instance.project.project_id = project_id
+        return mock_client_instance
+
+    @mock.patch("trcli.commands.cmd_casefields.ProjectBasedClient")
+    def test_list_case_fields_success(self, mock_project_client):
+        """Test successful case fields listing"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_field_handler.get_case_fields.return_value = (
+            [
+                {
+                    "id": 1,
+                    "label": "Preconditions",
+                    "name": "preconds",
+                    "system_name": "custom_preconds",
+                    "type_id": 3,
+                    "is_active": True,
+                    "description": "The preconditions of this test case.",
+                    "display_order": 1,
+                    "configs": [
+                        {
+                            "context": {"is_global": True, "project_ids": None},
+                            "id": "config1",
+                            "options": {
+                                "default_value": "",
+                                "format": "markdown",
+                                "is_required": False,
+                                "rows": "5",
+                            },
+                        }
+                    ],
+                },
+                {
+                    "id": 2,
+                    "label": "Steps",
+                    "name": "steps",
+                    "system_name": "custom_steps",
+                    "type_id": 10,
+                    "is_active": True,
+                    "description": "Test steps",
+                    "display_order": 2,
+                    "configs": [
+                        {
+                            "context": {"is_global": False, "project_ids": [1, 2]},
+                            "id": "config2",
+                            "options": {"is_required": True},
+                        }
+                    ],
+                },
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_casefields.cli, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.case_field_handler.get_case_fields.assert_called_once()
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_casefields.ProjectBasedClient")
+    def test_list_case_fields_json_output(self, mock_project_client):
+        """Test case fields listing with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        case_fields_data = [
+            {
+                "id": 1,
+                "label": "Preconditions",
+                "name": "preconds",
+                "system_name": "custom_preconds",
+                "type_id": 3,
+                "is_active": True,
+                "configs": [{"context": {"is_global": True, "project_ids": None}}],
+            },
+        ]
+        mock_client.api_request_handler.case_field_handler.get_case_fields.return_value = (case_fields_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_casefields.cli, ["--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert '"id": 1' in result.output
+            assert '"label": "Preconditions"' in result.output
+            assert "\n" in result.output
+
+    @mock.patch("trcli.commands.cmd_casefields.ProjectBasedClient")
+    def test_list_case_fields_show_all_fields(self, mock_project_client):
+        """Test case fields listing with show all fields"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_field_handler.get_case_fields.return_value = (
+            [
+                {
+                    "id": 1,
+                    "label": "Preconditions",
+                    "name": "preconds",
+                    "system_name": "custom_preconds",
+                    "type_id": 3,
+                    "is_active": True,
+                    "description": "The preconditions of this test case.",
+                    "display_order": 1,
+                    "configs": [
+                        {
+                            "context": {"is_global": True, "project_ids": None},
+                            "id": "config1",
+                            "options": {"is_required": False, "default_value": "None"},
+                        }
+                    ],
+                }
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_casefields.cli, ["--show-all-fields"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_casefields.ProjectBasedClient")
+    def test_list_case_fields_with_project_auto_filter(self, mock_project_client):
+        """Test case fields auto-filtering when project is specified"""
+        mock_client = self._setup_project_client_mock(mock_project_client, project_id=1)
+        mock_client.api_request_handler.case_field_handler.get_case_fields.return_value = (
+            [
+                {
+                    "id": 1,
+                    "label": "Global Field",
+                    "name": "global_field",
+                    "system_name": "custom_global",
+                    "type_id": 1,
+                    "is_active": True,
+                    "configs": [{"context": {"is_global": True, "project_ids": None}}],
+                },
+                {
+                    "id": 2,
+                    "label": "Project Field",
+                    "name": "project_field",
+                    "system_name": "custom_project",
+                    "type_id": 1,
+                    "is_active": True,
+                    "configs": [{"context": {"is_global": False, "project_ids": [1, 2]}}],
+                },
+                {
+                    "id": 3,
+                    "label": "Other Project Field",
+                    "name": "other_field",
+                    "system_name": "custom_other",
+                    "type_id": 1,
+                    "is_active": True,
+                    "configs": [{"context": {"is_global": False, "project_ids": [3, 4]}}],
+                },
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            # Project is already set in self.environment.project
+            result = self.runner.invoke(cmd_casefields.cli, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Should show only 2 fields (global and project 1)
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_casefields.ProjectBasedClient")
+    def test_list_case_fields_without_project_shows_all(self, mock_project_client):
+        """Test case fields shows all fields when no project specified"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        self.environment.project = None
+        self.environment.project_id = None
+
+        mock_client.api_request_handler.case_field_handler.get_case_fields.return_value = (
+            [
+                {
+                    "id": 1,
+                    "label": "Field 1",
+                    "name": "field1",
+                    "system_name": "custom_field1",
+                    "type_id": 1,
+                    "is_active": True,
+                    "configs": [{"context": {"is_global": True, "project_ids": None}}],
+                },
+                {
+                    "id": 2,
+                    "label": "Field 2",
+                    "name": "field2",
+                    "system_name": "custom_field2",
+                    "type_id": 1,
+                    "is_active": True,
+                    "configs": [{"context": {"is_global": False, "project_ids": [1]}}],
+                },
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_casefields.cli, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Should show all fields (no filtering)
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_casefields.ProjectBasedClient")
+    def test_list_case_fields_empty_result(self, mock_project_client):
+        """Test case fields listing with no fields"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_field_handler.get_case_fields.return_value = ([], "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_casefields.cli, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_casefields.ProjectBasedClient")
+    def test_list_case_fields_api_error(self, mock_project_client):
+        """Test case fields listing with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_field_handler.get_case_fields.return_value = (
+            [],
+            "API connection failed",
+        )
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_casefields.cli, [], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Failed to retrieve case fields: API connection failed")
+
+    @mock.patch("trcli.commands.cmd_casefields.ProjectBasedClient")
+    def test_list_case_fields_all_type_ids(self, mock_project_client):
+        """Test case fields with all different type IDs"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_field_handler.get_case_fields.return_value = (
+            [
+                {
+                    "id": 1,
+                    "label": "String Field",
+                    "name": "string_field",
+                    "system_name": "custom_string",
+                    "type_id": 1,
+                    "is_active": True,
+                    "configs": [{"context": {"is_global": True, "project_ids": None}}],
+                },
+                {
+                    "id": 2,
+                    "label": "Dropdown Field",
+                    "name": "dropdown_field",
+                    "system_name": "custom_dropdown",
+                    "type_id": 6,
+                    "is_active": True,
+                    "configs": [{"context": {"is_global": True, "project_ids": None}}],
+                },
+                {
+                    "id": 3,
+                    "label": "Unknown Field",
+                    "name": "unknown_field",
+                    "system_name": "custom_unknown",
+                    "type_id": 99,
+                    "is_active": False,
+                    "configs": [{"context": {"is_global": True, "project_ids": None}}],
+                },
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_casefields.cli, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_casefields.ProjectBasedClient")
+    def test_list_case_fields_long_description_truncation(self, mock_project_client):
+        """Test that long descriptions are truncated in show-all-fields mode"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        long_description = "A" * 150  # 150 character description
+        mock_client.api_request_handler.case_field_handler.get_case_fields.return_value = (
+            [
+                {
+                    "id": 1,
+                    "label": "Field",
+                    "name": "field",
+                    "system_name": "custom_field",
+                    "type_id": 1,
+                    "is_active": True,
+                    "description": long_description,
+                    "configs": [{"context": {"is_global": True, "project_ids": None}}],
+                }
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_casefields.cli, ["--show-all-fields"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called

--- a/tests/test_cmd_milestones.py
+++ b/tests/test_cmd_milestones.py
@@ -1,0 +1,384 @@
+import pytest
+from unittest import mock
+from unittest.mock import MagicMock, patch
+from click.testing import CliRunner
+
+from trcli.cli import Environment
+from trcli.commands import cmd_milestones
+
+
+class TestCmdMilestones:
+    """Test class for milestones command functionality"""
+
+    def setup_method(self):
+        """Set up test environment"""
+        self.runner = CliRunner()
+        self.environment = Environment(cmd="milestones")
+        self.environment.host = "https://test.testrail.com"
+        self.environment.username = "test@example.com"
+        self.environment.password = "password"
+        self.environment.project = "Test Project"
+        self.environment.project_id = 1
+
+    def _setup_project_client_mock(self, mock_project_client, project_id=1):
+        """Helper to setup ProjectBasedClient mock"""
+        mock_client_instance = MagicMock()
+        mock_project_client.return_value = mock_client_instance
+        mock_client_instance.project.project_id = project_id
+        return mock_client_instance
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_get_milestone_success(self, mock_project_client):
+        """Test successful milestone retrieval"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.milestone_handler.get_milestone.return_value = (
+            {
+                "id": 1,
+                "name": "Release 1.5",
+                "description": "Major feature release",
+                "project_id": 1,
+                "is_completed": True,
+                "completed_on": 1389968184,
+                "due_on": 1391968184,
+                "refs": "RF-1, RF-2",
+                "url": "http://test.testrail.com/index.php?/milestones/view/1",
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_milestones.get, ["--milestone-id", "1"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.milestone_handler.get_milestone.assert_called_once_with(1)
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_get_milestone_json_output(self, mock_project_client):
+        """Test milestone retrieval with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        milestone_data = {
+            "id": 1,
+            "name": "Release 1.5",
+            "description": "Major feature release",
+            "project_id": 1,
+            "is_completed": False,
+            "due_on": 1391968184,
+        }
+        mock_client.api_request_handler.milestone_handler.get_milestone.return_value = (milestone_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(
+                cmd_milestones.get, ["--milestone-id", "1", "--json-output"], obj=self.environment
+            )
+
+            assert result.exit_code == 0
+            # Check for prettified JSON (with newlines and indentation)
+            assert '"id": 1' in result.output
+            assert "\n" in result.output  # Prettified has newlines
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_get_milestone_show_all_fields(self, mock_project_client):
+        """Test milestone retrieval with show all fields"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.milestone_handler.get_milestone.return_value = (
+            {
+                "id": 1,
+                "name": "Release 1.5",
+                "description": "Major feature release with new capabilities",
+                "project_id": 1,
+                "is_completed": True,
+                "completed_on": 1389968184,
+                "due_on": 1391968184,
+                "refs": "RF-1, RF-2",
+                "url": "http://test.testrail.com/index.php?/milestones/view/1",
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_milestones.get, ["--milestone-id", "1", "--show-all-fields"], obj=self.environment
+            )
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_get_milestone_api_error(self, mock_project_client):
+        """Test milestone retrieval with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.milestone_handler.get_milestone.return_value = ({}, "Milestone not found")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_milestones.get, ["--milestone-id", "999"], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Failed to retrieve milestone: Milestone not found")
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_list_milestones_success(self, mock_project_client):
+        """Test successful milestones listing"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.milestone_handler.get_milestones.return_value = (
+            {
+                "offset": 0,
+                "limit": 250,
+                "size": 2,
+                "_links": {"next": None, "prev": None},
+                "milestones": [
+                    {
+                        "id": 1,
+                        "name": "Release 1.5",
+                        "description": "Major feature release",
+                        "project_id": 1,
+                        "is_completed": False,
+                        "due_on": 1391968184,
+                    },
+                    {
+                        "id": 2,
+                        "name": "Release 1.6",
+                        "description": "Bug fix release",
+                        "project_id": 1,
+                        "is_completed": False,
+                        "due_on": 1393968184,
+                    },
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_milestones.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.milestone_handler.get_milestones.assert_called_once_with(
+                project_id=1, limit=250, offset=0
+            )
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_list_milestones_with_pagination(self, mock_project_client):
+        """Test milestones listing with custom pagination"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.milestone_handler.get_milestones.return_value = (
+            {
+                "offset": 50,
+                "limit": 100,
+                "size": 1,
+                "_links": {"next": None, "prev": None},
+                "milestones": [
+                    {
+                        "id": 3,
+                        "name": "Release 2.0",
+                        "description": "Next generation",
+                        "project_id": 1,
+                        "is_completed": False,
+                        "due_on": 1395968184,
+                    }
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_milestones.list, ["--offset", "50", "--limit", "100"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.milestone_handler.get_milestones.assert_called_once_with(
+                project_id=1, limit=100, offset=50
+            )
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_list_milestones_json_output(self, mock_project_client):
+        """Test milestones listing with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        milestones_data = {
+            "offset": 0,
+            "limit": 250,
+            "size": 1,
+            "_links": {"next": None, "prev": None},
+            "milestones": [
+                {
+                    "id": 1,
+                    "name": "Release 1.5",
+                    "is_completed": False,
+                }
+            ],
+        }
+        mock_client.api_request_handler.milestone_handler.get_milestones.return_value = (milestones_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_milestones.list, ["--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Check for prettified JSON
+            assert '"milestones"' in result.output
+            assert "\n" in result.output
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_list_milestones_show_all_fields(self, mock_project_client):
+        """Test milestones listing with show all fields"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.milestone_handler.get_milestones.return_value = (
+            {
+                "offset": 0,
+                "limit": 250,
+                "size": 1,
+                "_links": {"next": None, "prev": None},
+                "milestones": [
+                    {
+                        "id": 1,
+                        "name": "Release 1.5",
+                        "description": "Major feature release",
+                        "project_id": 1,
+                        "is_completed": True,
+                        "completed_on": 1389968184,
+                        "due_on": 1391968184,
+                        "refs": "RF-1, RF-2",
+                        "url": "http://test.testrail.com/index.php?/milestones/view/1",
+                    }
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_milestones.list, ["--show-all-fields"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_list_milestones_empty_result(self, mock_project_client):
+        """Test milestones listing with no milestones"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.milestone_handler.get_milestones.return_value = (
+            {"offset": 0, "limit": 250, "size": 0, "_links": {"next": None, "prev": None}, "milestones": []},
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_milestones.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_list_milestones_api_error(self, mock_project_client):
+        """Test milestones listing with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.milestone_handler.get_milestones.return_value = ({}, "Project not found")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_milestones.list, [], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Failed to retrieve milestones: Project not found")
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_list_milestones_with_next_link(self, mock_project_client):
+        """Test milestones listing with pagination next link"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.milestone_handler.get_milestones.return_value = (
+            {
+                "offset": 0,
+                "limit": 250,
+                "size": 251,
+                "_links": {
+                    "next": "index.php?/api/v2/get_milestones/1&offset=250",
+                    "prev": None,
+                },
+                "milestones": [
+                    {
+                        "id": 1,
+                        "name": "Release 1.5",
+                        "is_completed": False,
+                    }
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_milestones.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_get_milestone_with_project_id_from_config(self, mock_project_client):
+        """Test get milestone using project_id from configuration"""
+        mock_client = self._setup_project_client_mock(mock_project_client, project_id=5)
+        self.environment.project_id = 5
+        mock_client.api_request_handler.milestone_handler.get_milestone.return_value = (
+            {"id": 1, "name": "Release 1.0", "project_id": 5, "is_completed": False},
+            "",
+        )
+
+        with patch.object(self.environment, "log"), patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_milestones.get, ["--milestone-id", "1"], obj=self.environment)
+
+            assert result.exit_code == 0
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_list_milestones_with_project_id_from_config(self, mock_project_client):
+        """Test list milestones using project_id from configuration"""
+        mock_client = self._setup_project_client_mock(mock_project_client, project_id=5)
+        self.environment.project_id = 5
+        mock_client.api_request_handler.milestone_handler.get_milestones.return_value = (
+            {"offset": 0, "limit": 250, "size": 0, "_links": {}, "milestones": []},
+            "",
+        )
+
+        with patch.object(self.environment, "log"), patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_milestones.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.milestone_handler.get_milestones.assert_called_once_with(
+                project_id=5, limit=250, offset=0
+            )
+
+    @mock.patch("trcli.commands.cmd_milestones.ProjectBasedClient")
+    def test_get_milestone_with_project_name(self, mock_project_client):
+        """Test get milestone using project name resolution"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        self.environment.project = "Test Project"
+        mock_client.api_request_handler.milestone_handler.get_milestone.return_value = (
+            {"id": 1, "name": "Release 1.0", "project_id": 1, "is_completed": False},
+            "",
+        )
+
+        with patch.object(self.environment, "log"), patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_milestones.get, ["--milestone-id", "1"], obj=self.environment)
+
+            assert result.exit_code == 0

--- a/tests/test_cmd_runs.py
+++ b/tests/test_cmd_runs.py
@@ -1,0 +1,413 @@
+import pytest
+from unittest import mock
+from unittest.mock import MagicMock, patch
+from click.testing import CliRunner
+
+from trcli.cli import Environment
+from trcli.commands import cmd_runs
+
+
+class TestCmdRuns:
+    """Test class for runs command functionality"""
+
+    def setup_method(self):
+        """Set up test environment"""
+        self.runner = CliRunner()
+        self.environment = Environment(cmd="runs")
+        self.environment.host = "https://test.testrail.com"
+        self.environment.username = "test@example.com"
+        self.environment.password = "password"
+        self.environment.project = "Test Project"
+        self.environment.project_id = 1
+
+    def _setup_project_client_mock(self, mock_project_client, project_id=1):
+        """Helper to setup ProjectBasedClient mock"""
+        mock_client_instance = MagicMock()
+        mock_project_client.return_value = mock_client_instance
+        mock_client_instance.project.project_id = project_id
+        return mock_client_instance
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_get_run_success(self, mock_project_client):
+        """Test successful run retrieval"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.run_handler.get_run.return_value = (
+            {
+                "id": 81,
+                "name": "File Formats",
+                "description": "Test file format handling",
+                "suite_id": 4,
+                "project_id": 1,
+                "is_completed": False,
+                "completed_on": None,
+                "passed_count": 2,
+                "failed_count": 2,
+                "blocked_count": 0,
+                "retest_count": 1,
+                "untested_count": 3,
+                "config": "Firefox, Ubuntu 12",
+                "config_ids": [2, 6],
+                "milestone_id": 7,
+                "plan_id": 80,
+                "assignedto_id": 6,
+                "refs": "SAN-1",
+                "include_all": False,
+                "created_by": 1,
+                "created_on": 1393845644,
+                "url": "http://test.testrail.com/index.php?/runs/view/81",
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.get, ["--run-id", "81"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.run_handler.get_run.assert_called_once_with(81)
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_get_run_json_output(self, mock_project_client):
+        """Test run retrieval with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        run_data = {
+            "id": 81,
+            "name": "File Formats",
+            "suite_id": 4,
+            "is_completed": False,
+            "passed_count": 2,
+            "failed_count": 1,
+        }
+        mock_client.api_request_handler.run_handler.get_run.return_value = (run_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_runs.get, ["--run-id", "81", "--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Check for prettified JSON (with newlines and indentation)
+            assert '"id": 81' in result.output
+            assert "\n" in result.output  # Prettified has newlines
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_get_run_show_all_fields(self, mock_project_client):
+        """Test run retrieval with show all fields"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.run_handler.get_run.return_value = (
+            {
+                "id": 81,
+                "name": "File Formats",
+                "description": "Test description",
+                "suite_id": 4,
+                "project_id": 1,
+                "is_completed": False,
+                "passed_count": 2,
+                "failed_count": 1,
+                "blocked_count": 0,
+                "retest_count": 0,
+                "untested_count": 3,
+                "config": "Firefox, Ubuntu 12",
+                "config_ids": [2, 6],
+                "milestone_id": 7,
+                "plan_id": 80,
+                "assignedto_id": 6,
+                "refs": "SAN-1",
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.get, ["--run-id", "81", "--show-all-fields"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_get_run_api_error(self, mock_project_client):
+        """Test run retrieval with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.run_handler.get_run.return_value = ({}, "Run not found")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.get, ["--run-id", "999"], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Failed to retrieve run: Run not found")
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_list_runs_success(self, mock_project_client):
+        """Test successful runs listing"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.run_handler.get_runs.return_value = (
+            {
+                "offset": 0,
+                "limit": 250,
+                "size": 2,
+                "_links": {"next": None, "prev": None},
+                "runs": [
+                    {
+                        "id": 81,
+                        "name": "File Formats",
+                        "suite_id": 4,
+                        "is_completed": False,
+                        "passed_count": 2,
+                        "failed_count": 2,
+                        "blocked_count": 0,
+                        "untested_count": 3,
+                    },
+                    {
+                        "id": 82,
+                        "name": "System Tests",
+                        "suite_id": 5,
+                        "is_completed": True,
+                        "passed_count": 10,
+                        "failed_count": 0,
+                        "blocked_count": 0,
+                        "untested_count": 0,
+                    },
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.run_handler.get_runs.assert_called_once_with(
+                project_id=1, limit=250, offset=0
+            )
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_list_runs_with_pagination(self, mock_project_client):
+        """Test runs listing with pagination parameters"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.run_handler.get_runs.return_value = (
+            {
+                "offset": 100,
+                "limit": 50,
+                "size": 50,
+                "_links": {
+                    "next": "/api/v2/get_runs/1&offset=150",
+                    "prev": "/api/v2/get_runs/1&offset=50",
+                },
+                "runs": [{"id": i, "name": f"Run {i}", "suite_id": 1, "is_completed": False} for i in range(100, 150)],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.list, ["--offset", "100", "--limit", "50"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.run_handler.get_runs.assert_called_once_with(
+                project_id=1, limit=50, offset=100
+            )
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_list_runs_json_output(self, mock_project_client):
+        """Test runs listing with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        response_data = {
+            "offset": 0,
+            "limit": 250,
+            "size": 1,
+            "runs": [{"id": 81, "name": "Test", "suite_id": 1, "is_completed": False}],
+        }
+        mock_client.api_request_handler.run_handler.get_runs.return_value = (response_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_runs.list, ["--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Check for prettified JSON (with newlines and indentation)
+            assert '"offset": 0' in result.output
+            assert "\n" in result.output  # Prettified has newlines
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_list_runs_show_all_fields(self, mock_project_client):
+        """Test runs listing with show all fields"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.run_handler.get_runs.return_value = (
+            {
+                "offset": 0,
+                "limit": 250,
+                "size": 1,
+                "runs": [
+                    {
+                        "id": 81,
+                        "name": "File Formats",
+                        "description": "Test description",
+                        "suite_id": 4,
+                        "is_completed": False,
+                        "passed_count": 2,
+                        "failed_count": 1,
+                        "blocked_count": 0,
+                        "untested_count": 3,
+                    }
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.list, ["--show-all-fields"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_list_runs_empty_result(self, mock_project_client):
+        """Test runs listing with empty result"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.run_handler.get_runs.return_value = (
+            {"offset": 0, "limit": 250, "size": 0, "runs": []},
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_log.assert_any_call("No runs found.")
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_list_runs_api_error(self, mock_project_client):
+        """Test runs listing with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.run_handler.get_runs.return_value = ({}, "Project not found")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.list, [], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Failed to retrieve runs: Project not found")
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_list_runs_with_next_link(self, mock_project_client):
+        """Test runs listing shows pagination hint when next link is present"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.run_handler.get_runs.return_value = (
+            {
+                "offset": 0,
+                "limit": 250,
+                "size": 250,
+                "_links": {"next": "/api/v2/get_runs/1&offset=250", "prev": None},
+                "runs": [{"id": i, "name": f"Run {i}", "suite_id": 1, "is_completed": False} for i in range(1, 251)],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            log_calls = [str(call) for call in mock_log.call_args_list]
+            pagination_hint_found = any("More results available" in str(call) for call in log_calls)
+            assert pagination_hint_found
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_get_run_with_project_id_from_config(self, mock_project_client):
+        """Test run retrieval uses project_id from environment when not provided"""
+        mock_client = self._setup_project_client_mock(mock_project_client, project_id=42)
+        run_data = {"id": 81, "name": "File Formats", "suite_id": 4, "is_completed": False}
+        mock_client.api_request_handler.run_handler.get_run.return_value = (run_data, "")
+
+        self.environment.project_id = 42
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.get, ["--run-id", "81"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.run_handler.get_run.assert_called_once_with(81)
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_list_runs_with_project_id_from_config(self, mock_project_client):
+        """Test runs listing uses project_id from environment when not provided"""
+        mock_client = self._setup_project_client_mock(mock_project_client, project_id=99)
+        mock_client.api_request_handler.run_handler.get_runs.return_value = (
+            {"offset": 0, "limit": 250, "size": 1, "runs": [{"id": 81, "name": "Test", "suite_id": 1}]},
+            "",
+        )
+
+        self.environment.project_id = 99
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.run_handler.get_runs.assert_called_once_with(
+                project_id=99, limit=250, offset=0
+            )
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_get_run_with_project_name(self, mock_project_client):
+        """Test run retrieval with project name from config"""
+        mock_client = self._setup_project_client_mock(mock_project_client, project_id=42)
+        run_data = {"id": 81, "name": "File Formats", "suite_id": 4, "is_completed": False}
+        mock_client.api_request_handler.run_handler.get_run.return_value = (run_data, "")
+
+        # Set project name in environment (as if from config file)
+        self.environment.project = "TRCLI Test Project"
+        self.environment.project_id = None  # No project_id, only name
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.get, ["--run-id", "81"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Verify resolve_project was called to convert name to ID
+            mock_client.resolve_project.assert_called_once()
+            mock_client.api_request_handler.run_handler.get_run.assert_called_once_with(81)
+
+    @mock.patch("trcli.commands.cmd_runs.ProjectBasedClient")
+    def test_list_runs_with_project_name(self, mock_project_client):
+        """Test runs listing with project name from config"""
+        mock_client = self._setup_project_client_mock(mock_project_client, project_id=99)
+        mock_client.api_request_handler.run_handler.get_runs.return_value = (
+            {"offset": 0, "limit": 250, "size": 1, "runs": [{"id": 81, "name": "Test", "suite_id": 1}]},
+            "",
+        )
+
+        # Set project name in environment (as if from config file)
+        self.environment.project = "TRCLI Test Project"
+        self.environment.project_id = None  # No project_id, only name
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_runs.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Verify resolve_project was called to convert name to ID
+            mock_client.resolve_project.assert_called_once()
+            mock_client.api_request_handler.run_handler.get_runs.assert_called_once_with(
+                project_id=99, limit=250, offset=0
+            )

--- a/tests/test_cmd_statuses.py
+++ b/tests/test_cmd_statuses.py
@@ -1,0 +1,297 @@
+import pytest
+from unittest import mock
+from unittest.mock import MagicMock, patch
+from click.testing import CliRunner
+
+from trcli.cli import Environment
+from trcli.commands import cmd_statuses
+
+
+class TestCmdStatuses:
+    """Test class for statuses command functionality"""
+
+    def setup_method(self):
+        """Set up test environment"""
+        self.runner = CliRunner()
+        self.environment = Environment(cmd="statuses")
+        self.environment.host = "https://test.testrail.com"
+        self.environment.username = "test@example.com"
+        self.environment.password = "password"
+        self.environment.project = "Test Project"
+        self.environment.project_id = 1
+
+    def _setup_project_client_mock(self, mock_project_client, project_id=1):
+        """Helper to setup ProjectBasedClient mock"""
+        mock_client_instance = MagicMock()
+        mock_project_client.return_value = mock_client_instance
+        mock_client_instance.project.project_id = project_id
+        return mock_client_instance
+
+    # Tests for 'statuses all' subcommand
+    @mock.patch("trcli.commands.cmd_statuses.ProjectBasedClient")
+    def test_list_all_statuses_success(self, mock_project_client):
+        """Test successful test result statuses listing"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.status_handler.get_statuses.return_value = (
+            [
+                {
+                    "id": 1,
+                    "name": "passed",
+                    "label": "Passed",
+                    "is_system": True,
+                    "is_untested": False,
+                    "is_final": True,
+                    "color_dark": 12709313,
+                    "color_medium": 14527786,
+                    "color_bright": 15394764,
+                },
+                {
+                    "id": 5,
+                    "name": "failed",
+                    "label": "Failed",
+                    "is_system": True,
+                    "is_untested": False,
+                    "is_final": True,
+                    "color_dark": 12396910,
+                    "color_medium": 15829135,
+                    "color_bright": 16434723,
+                },
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_statuses.all, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.status_handler.get_statuses.assert_called_once_with(project_id=1)
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_statuses.ProjectBasedClient")
+    def test_list_all_statuses_json_output(self, mock_project_client):
+        """Test statuses listing with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        statuses_data = [
+            {
+                "id": 1,
+                "name": "passed",
+                "label": "Passed",
+                "is_system": True,
+                "is_untested": False,
+                "is_final": True,
+                "color_dark": 12709313,
+                "color_medium": 14527786,
+                "color_bright": 15394764,
+            },
+        ]
+        mock_client.api_request_handler.status_handler.get_statuses.return_value = (statuses_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_statuses.all, ["--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert '"id": 1' in result.output
+            assert '"name": "passed"' in result.output
+            assert "\n" in result.output
+
+    @mock.patch("trcli.commands.cmd_statuses.ProjectBasedClient")
+    def test_list_all_statuses_show_all_fields(self, mock_project_client):
+        """Test statuses listing with show all fields"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.status_handler.get_statuses.return_value = (
+            [
+                {
+                    "id": 1,
+                    "name": "passed",
+                    "label": "Passed",
+                    "is_system": True,
+                    "is_untested": False,
+                    "is_final": True,
+                    "color_dark": 12709313,
+                    "color_medium": 14527786,
+                    "color_bright": 15394764,
+                }
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_statuses.all, ["--show-all-fields"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_statuses.ProjectBasedClient")
+    def test_list_all_statuses_empty_result(self, mock_project_client):
+        """Test statuses listing with no statuses"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.status_handler.get_statuses.return_value = ([], "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_statuses.all, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_statuses.ProjectBasedClient")
+    def test_list_all_statuses_api_error(self, mock_project_client):
+        """Test statuses listing with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.status_handler.get_statuses.return_value = ([], "Project not found")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_statuses.all, [], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Failed to retrieve statuses: Project not found")
+
+    # Tests for 'statuses case' subcommand
+    @mock.patch("trcli.commands.cmd_statuses.ProjectBasedClient")
+    def test_list_case_statuses_success(self, mock_project_client):
+        """Test successful case statuses listing"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.status_handler.get_case_statuses.return_value = (
+            [
+                {
+                    "case_status_id": 1,
+                    "name": "Approved",
+                    "abbreviation": None,
+                    "is_default": False,
+                    "is_approved": True,
+                },
+                {
+                    "case_status_id": 2,
+                    "name": "Draft",
+                    "abbreviation": "DFT",
+                    "is_default": True,
+                    "is_approved": False,
+                },
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_statuses.case, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.status_handler.get_case_statuses.assert_called_once()
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_statuses.ProjectBasedClient")
+    def test_list_case_statuses_json_output(self, mock_project_client):
+        """Test case statuses listing with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        case_statuses_data = [
+            {
+                "case_status_id": 1,
+                "name": "Approved",
+                "abbreviation": None,
+                "is_default": False,
+                "is_approved": True,
+            },
+        ]
+        mock_client.api_request_handler.status_handler.get_case_statuses.return_value = (case_statuses_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_statuses.case, ["--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert '"case_status_id": 1' in result.output
+            assert '"name": "Approved"' in result.output
+            assert "\n" in result.output
+
+    @mock.patch("trcli.commands.cmd_statuses.ProjectBasedClient")
+    def test_list_case_statuses_show_all_fields(self, mock_project_client):
+        """Test case statuses listing with show all fields"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.status_handler.get_case_statuses.return_value = (
+            [
+                {
+                    "case_status_id": 2,
+                    "name": "Draft",
+                    "abbreviation": "DFT",
+                    "is_default": True,
+                    "is_approved": False,
+                }
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_statuses.case, ["--show-all-fields"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_statuses.ProjectBasedClient")
+    def test_list_case_statuses_empty_result(self, mock_project_client):
+        """Test case statuses listing with no case statuses"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.status_handler.get_case_statuses.return_value = ([], "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_statuses.case, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_statuses.ProjectBasedClient")
+    def test_list_case_statuses_api_error(self, mock_project_client):
+        """Test case statuses listing with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.status_handler.get_case_statuses.return_value = (
+            [],
+            "API endpoint not found",
+        )
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_statuses.case, [], obj=self.environment)
+
+            assert result.exit_code == 1
+            # Check that the error was logged (should be called at least once for the error message)
+            assert mock_elog.called
+
+    @mock.patch("trcli.commands.cmd_statuses.ProjectBasedClient")
+    def test_list_case_statuses_with_abbreviation_none(self, mock_project_client):
+        """Test case statuses with None abbreviation"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.status_handler.get_case_statuses.return_value = (
+            [
+                {
+                    "case_status_id": 1,
+                    "name": "Approved",
+                    "abbreviation": None,
+                    "is_default": False,
+                    "is_approved": True,
+                }
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_statuses.case, ["--show-all-fields"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called

--- a/tests/test_data/cli_test_data.py
+++ b/tests/test_data/cli_test_data.py
@@ -78,6 +78,7 @@ trcli_description = (
     "    - sections: Query test sections\n"
     "    - plans: Query test plans\n"
     "    - runs: Query test runs\n"
+    "    - milestones: Query milestones\n"
     "    - results: Query and update test results\n"
 )
 

--- a/tests/test_data/cli_test_data.py
+++ b/tests/test_data/cli_test_data.py
@@ -80,6 +80,7 @@ trcli_description = (
     "    - runs: Query test runs\n"
     "    - milestones: Query milestones\n"
     "    - statuses: Query test statuses\n"
+    "    - casefields: Query test case custom fields\n"
     "    - results: Query and update test results\n"
 )
 

--- a/tests/test_data/cli_test_data.py
+++ b/tests/test_data/cli_test_data.py
@@ -79,6 +79,7 @@ trcli_description = (
     "    - plans: Query test plans\n"
     "    - runs: Query test runs\n"
     "    - milestones: Query milestones\n"
+    "    - statuses: Query test statuses\n"
     "    - results: Query and update test results\n"
 )
 

--- a/tests/test_data/cli_test_data.py
+++ b/tests/test_data/cli_test_data.py
@@ -73,6 +73,12 @@ trcli_description = (
     "    - add_run: Create a new test run\n"
     "    - labels: Manage labels (projects, cases, and tests)\n"
     "    - references: Manage references (cases and runs)\n"
+    "    - cases: Query test cases\n"
+    "    - suites: Query test suites\n"
+    "    - sections: Query test sections\n"
+    "    - plans: Query test plans\n"
+    "    - runs: Query test runs\n"
+    "    - results: Query and update test results\n"
 )
 
 trcli_help_description = "TestRail CLI"

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -18,6 +18,7 @@ from trcli.api.case_handler import CaseHandler
 from trcli.api.plan_handler import PlanHandler
 from trcli.api.milestone_handler import MilestoneHandler
 from trcli.api.status_handler import StatusHandler
+from trcli.api.case_field_handler import CaseFieldHandler
 from trcli.cli import Environment
 from trcli.constants import (
     ProjectErrors,
@@ -90,6 +91,7 @@ class ApiRequestHandler:
         self.plan_handler = PlanHandler(api_client, environment)
         self.milestone_handler = MilestoneHandler(api_client)
         self.status_handler = StatusHandler(api_client)
+        self.case_field_handler = CaseFieldHandler(api_client)
 
         # BDD case cache for feature name matching (shared by CucumberParser and JunitParser)
         # Structure: {"{project_id}_{suite_id}": {normalized_name: [case_dict, case_dict, ...]}}

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -17,6 +17,7 @@ from trcli.api.bdd_handler import BddHandler
 from trcli.api.case_handler import CaseHandler
 from trcli.api.plan_handler import PlanHandler
 from trcli.api.milestone_handler import MilestoneHandler
+from trcli.api.status_handler import StatusHandler
 from trcli.cli import Environment
 from trcli.constants import (
     ProjectErrors,
@@ -88,6 +89,7 @@ class ApiRequestHandler:
         )
         self.plan_handler = PlanHandler(api_client, environment)
         self.milestone_handler = MilestoneHandler(api_client)
+        self.status_handler = StatusHandler(api_client)
 
         # BDD case cache for feature name matching (shared by CucumberParser and JunitParser)
         # Structure: {"{project_id}_{suite_id}": {normalized_name: [case_dict, case_dict, ...]}}

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -16,6 +16,7 @@ from trcli.api.run_handler import RunHandler
 from trcli.api.bdd_handler import BddHandler
 from trcli.api.case_handler import CaseHandler
 from trcli.api.plan_handler import PlanHandler
+from trcli.api.milestone_handler import MilestoneHandler
 from trcli.cli import Environment
 from trcli.constants import (
     ProjectErrors,
@@ -86,6 +87,7 @@ class ApiRequestHandler:
             retrieve_results_callback=ApiRequestHandler.retrieve_results_after_cancelling,
         )
         self.plan_handler = PlanHandler(api_client, environment)
+        self.milestone_handler = MilestoneHandler(api_client)
 
         # BDD case cache for feature name matching (shared by CucumberParser and JunitParser)
         # Structure: {"{project_id}_{suite_id}": {normalized_name: [case_dict, case_dict, ...]}}

--- a/trcli/api/case_field_handler.py
+++ b/trcli/api/case_field_handler.py
@@ -1,0 +1,33 @@
+"""
+CaseFieldHandler - Handles all case field-related operations for TestRail
+
+It manages case field query operations including:
+- Retrieving all available test case custom fields
+"""
+
+from beartype.typing import Tuple
+
+from trcli.api.api_client import APIClient
+
+
+class CaseFieldHandler:
+    """Handles all case field-related operations for TestRail"""
+
+    def __init__(self, client: APIClient):
+        """
+        Initialize the CaseFieldHandler
+
+        :param client: APIClient instance for making API calls
+        """
+        self.client = client
+
+    def get_case_fields(self) -> Tuple[list, str]:
+        """
+        Retrieve all available test case custom fields
+
+        :returns: Tuple with (case_fields_list, error_message)
+        """
+        response = self.client.send_get("get_case_fields")
+        if response.error_message:
+            return [], response.error_message
+        return response.response_text, ""

--- a/trcli/api/milestone_handler.py
+++ b/trcli/api/milestone_handler.py
@@ -1,0 +1,68 @@
+"""
+MilestoneHandler - Handles all milestone-related operations for TestRail
+
+It manages milestone query operations including:
+- Retrieving a single milestone by ID
+- Listing milestones for a project
+"""
+
+from beartype.typing import Tuple
+
+from trcli.api.api_client import APIClient
+
+
+class MilestoneHandler:
+    """Handles all milestone-related operations for TestRail"""
+
+    def __init__(self, client: APIClient):
+        """
+        Initialize the MilestoneHandler
+
+        :param client: APIClient instance for making API calls
+        """
+        self.client = client
+
+    def get_milestone(self, milestone_id: int) -> Tuple[dict, str]:
+        """
+        Retrieve a single milestone by ID
+
+        :param milestone_id: TestRail milestone ID
+        :returns: Tuple with (milestone_data_dict, error_message)
+        """
+        response = self.client.send_get(f"get_milestone/{milestone_id}")
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""
+
+    def get_milestones(
+        self,
+        project_id: int,
+        limit: int = 250,
+        offset: int = 0,
+    ) -> Tuple[dict, str]:
+        """
+        Retrieve milestones for a project with pagination
+
+        :param project_id: TestRail project ID
+        :param limit: Maximum number of milestones to return (default: 250)
+        :param offset: Offset for pagination (default: 0)
+        :returns: Tuple with (paginated_response_dict, error_message)
+                  Response dict contains: milestones, offset, limit, size, _links
+        """
+        # Build query parameters
+        params = []
+        if limit != 250:
+            params.append(f"limit={limit}")
+        if offset > 0:
+            params.append(f"offset={offset}")
+
+        # Build URL
+        query_string = "&".join(params) if params else ""
+        url = f"get_milestones/{project_id}"
+        if query_string:
+            url = f"{url}&{query_string}"
+
+        response = self.client.send_get(url)
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""

--- a/trcli/api/run_handler.py
+++ b/trcli/api/run_handler.py
@@ -376,6 +376,52 @@ class RunHandler:
         response = self.client.send_post(f"delete_run/{run_id}", payload={})
         return response.response_text, response.error_message
 
+    def get_run(self, run_id: int) -> Tuple[dict, str]:
+        """
+        Retrieve a single test run by ID
+
+        :param run_id: TestRail run ID
+        :returns: Tuple with (run_data_dict, error_message)
+        """
+        response = self.client.send_get(f"get_run/{run_id}")
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""
+
+    def get_runs(
+        self,
+        project_id: int,
+        limit: int = 250,
+        offset: int = 0,
+    ) -> Tuple[dict, str]:
+        """
+        Retrieve test runs for a project with pagination.
+        Only returns test runs that are not part of a test plan.
+
+        :param project_id: TestRail project ID
+        :param limit: Maximum number of runs to return (default: 250)
+        :param offset: Offset for pagination (default: 0)
+        :returns: Tuple with (paginated_response_dict, error_message)
+                  Response dict contains: runs, offset, limit, size, _links
+        """
+        # Build query parameters
+        params = []
+        if limit != 250:
+            params.append(f"limit={limit}")
+        if offset > 0:
+            params.append(f"offset={offset}")
+
+        # Build URL
+        query_string = "&".join(params) if params else ""
+        url = f"get_runs/{project_id}"
+        if query_string:
+            url = f"{url}&{query_string}"
+
+        response = self.client.send_get(url)
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""
+
     def add_plan(
         self,
         project_id: int,

--- a/trcli/api/status_handler.py
+++ b/trcli/api/status_handler.py
@@ -1,0 +1,46 @@
+"""
+StatusHandler - Handles all status-related operations for TestRail
+
+It manages status query operations including:
+- Retrieving all test result statuses
+- Retrieving all case statuses (TestRail Enterprise 7.3+)
+"""
+
+from beartype.typing import Tuple
+
+from trcli.api.api_client import APIClient
+
+
+class StatusHandler:
+    """Handles all status-related operations for TestRail"""
+
+    def __init__(self, client: APIClient):
+        """
+        Initialize the StatusHandler
+
+        :param client: APIClient instance for making API calls
+        """
+        self.client = client
+
+    def get_statuses(self, project_id: int) -> Tuple[list, str]:
+        """
+        Retrieve all test result statuses for a project
+
+        :param project_id: TestRail project ID
+        :returns: Tuple with (statuses_list, error_message)
+        """
+        response = self.client.send_get(f"get_statuses/{project_id}")
+        if response.error_message:
+            return [], response.error_message
+        return response.response_text, ""
+
+    def get_case_statuses(self) -> Tuple[list, str]:
+        """
+        Retrieve all case statuses (TestRail Enterprise 7.3+)
+
+        :returns: Tuple with (case_statuses_list, error_message)
+        """
+        response = self.client.send_get("get_case_statuses")
+        if response.error_message:
+            return [], response.error_message
+        return response.response_text, ""

--- a/trcli/commands/cmd_casefields.py
+++ b/trcli/commands/cmd_casefields.py
@@ -1,0 +1,173 @@
+import click
+import json
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+# Map type IDs to field type names
+FIELD_TYPE_NAMES = {
+    1: "String",
+    2: "Integer",
+    3: "Text",
+    4: "URL",
+    5: "Checkbox",
+    6: "Dropdown",
+    7: "User",
+    8: "Date",
+    9: "Milestone",
+    10: "Steps",
+    12: "Multi-select",
+}
+
+
+def print_config(env: Environment, project_filtered: bool):
+    env.log(f"Case Fields List Execution Parameters" f"\n> TestRail instance: {env.host} (user: {env.username})")
+    if project_filtered:
+        env.log(f"> Project: {env.project if env.project else f'ID {env.project_id}'}")
+        env.log("> Filtering fields for this project")
+
+
+def is_field_applicable_to_project(field: dict, project_id: int) -> bool:
+    """
+    Check if a case field is applicable to a specific project
+
+    :param field: Field dictionary from API
+    :param project_id: Project ID to check
+    :returns: True if field is applicable to the project
+    """
+    configs = field.get("configs", [])
+    if not configs:
+        return False
+
+    for config in configs:
+        context = config.get("context", {})
+        # Field is applicable if it's global or includes this project
+        if context.get("is_global", False):
+            return True
+        project_ids = context.get("project_ids")
+        if project_ids and project_id in project_ids:
+            return True
+
+    return False
+
+
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.option("--json-output", is_flag=True, help="Output case fields as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields including configs and options.")
+@click.pass_context
+@pass_environment
+def cli(
+    environment: Environment,
+    context: click.Context,
+    json_output: bool,
+    show_all_fields: bool,
+):
+    """List all case fields from TestRail"""
+    environment.cmd = "casefields"
+    environment.set_parameters(context)
+    environment.check_for_required_parameters()
+
+    # Create ProjectBasedClient
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Check if project is specified (either from config or command line)
+    project_specified = bool(environment.project or environment.project_id)
+    project_id = None
+
+    if project_specified:
+        # Resolve project to get project ID
+        project_client.resolve_project()
+        project_id = project_client.project.project_id
+
+    print_config(environment, project_specified)
+
+    if project_specified:
+        environment.log(f"Retrieving case fields for project ID {project_id}...")
+    else:
+        environment.log("Retrieving all case fields...")
+
+    # Retrieve case fields using CaseFieldHandler
+    case_fields_data, error_message = project_client.api_request_handler.case_field_handler.get_case_fields()
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve case fields: {error_message}")
+        raise SystemExit(1)
+
+    # Filter by project if project is specified
+    if project_specified and project_id:
+        filtered_fields = [field for field in case_fields_data if is_field_applicable_to_project(field, project_id)]
+        case_fields_data = filtered_fields
+
+    # Handle output format
+    if json_output:
+        # Output prettified JSON response
+        print(json.dumps(case_fields_data, indent=2))
+    else:
+        # Display case fields line by line
+        if not case_fields_data:
+            environment.log("No case fields found.")
+        else:
+            environment.log(f"Found {len(case_fields_data)} case field(s):")
+            environment.log("")
+
+            for field in case_fields_data:
+                field_id = field.get("id", "N/A")
+                label = field.get("label", "N/A")
+                name = field.get("name", "N/A")
+                system_name = field.get("system_name", "N/A")
+                type_id = field.get("type_id", 0)
+                type_name = FIELD_TYPE_NAMES.get(type_id, f"Unknown ({type_id})")
+                is_active = field.get("is_active", True)
+
+                environment.log(f"Field ID: {field_id}")
+                environment.log(f"  Label: {label}")
+                environment.log(f"  Name: {name}")
+                environment.log(f"  System Name: {system_name}")
+                environment.log(f"  Type: {type_name} (ID: {type_id})")
+                environment.log(f"  Active: {'Yes' if is_active else 'No'}")
+
+                if show_all_fields:
+                    description = field.get("description")
+                    if description:
+                        # Truncate long descriptions
+                        if len(description) > 100:
+                            description = description[:100] + "..."
+                        environment.log(f"  Description: {description}")
+
+                    display_order = field.get("display_order")
+                    if display_order is not None:
+                        environment.log(f"  Display Order: {display_order}")
+
+                    # Show configuration details
+                    configs = field.get("configs", [])
+                    if configs:
+                        environment.log(f"  Configurations ({len(configs)}):")
+                        for idx, config in enumerate(configs, 1):
+                            context_info = config.get("context", {})
+                            is_global = context_info.get("is_global", False)
+                            project_ids = context_info.get("project_ids")
+
+                            if is_global:
+                                environment.log(f"    Config {idx}: Global")
+                            elif project_ids:
+                                environment.log(f"    Config {idx}: Projects {project_ids}")
+                            else:
+                                environment.log(f"    Config {idx}: No context")
+
+                            options = config.get("options", {})
+                            if options:
+                                is_required = options.get("is_required", False)
+                                environment.log(f"      Required: {'Yes' if is_required else 'No'}")
+                                default_value = options.get("default_value")
+                                if default_value:
+                                    environment.log(f"      Default: {default_value}")
+
+                environment.log("")
+
+    environment.log("")
+    environment.log("Case field listing completed successfully.")

--- a/trcli/commands/cmd_milestones.py
+++ b/trcli/commands/cmd_milestones.py
@@ -1,0 +1,267 @@
+import builtins
+import click
+import json
+from datetime import datetime
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def print_config(env: Environment, action: str):
+    env.log(
+        f"Milestones {action} Execution Parameters"
+        f"\n> TestRail instance: {env.host} (user: {env.username})"
+        f"\n> Project: {env.project if env.project else env.project_id}"
+    )
+
+
+def format_timestamp(timestamp):
+    """Format Unix timestamp to readable date, returns 'N/A' if None"""
+    if timestamp:
+        return datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S")
+    return "N/A"
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.pass_context
+@pass_environment
+def cli(environment: Environment, context: click.Context, *args, **kwargs):
+    """Manage milestones in TestRail"""
+    environment.cmd = "milestones"
+    environment.set_parameters(context)
+
+
+@cli.command()
+@click.option("--milestone-id", type=click.IntRange(min=1), required=True, metavar="", help="Milestone ID to retrieve.")
+@click.option("--json-output", is_flag=True, help="Output milestone as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields including custom fields in detail.")
+@click.pass_context
+@pass_environment
+def get(
+    environment: Environment,
+    context: click.Context,
+    milestone_id: int,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """Get a single milestone by ID"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Get")
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    environment.log(f"Retrieving milestone ID {milestone_id}...")
+
+    # Retrieve the milestone using MilestoneHandler from ProjectBasedClient
+    milestone_data, error_message = project_client.api_request_handler.milestone_handler.get_milestone(milestone_id)
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve milestone: {error_message}")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        # Output prettified JSON response
+        print(json.dumps(milestone_data, indent=2))
+    else:
+        # Display milestone details
+        environment.log("")
+        environment.log(f"Milestone ID: {milestone_data.get('id', 'N/A')}")
+        environment.log(f"  Name: {milestone_data.get('name', 'N/A')}")
+
+        if milestone_data.get("description"):
+            description = milestone_data.get("description")
+            # Truncate long descriptions in non-show-all-fields mode
+            if not show_all_fields and len(description) > 100:
+                description = description[:100] + "..."
+            environment.log(f"  Description: {description}")
+        else:
+            environment.log("  Description: (none)")
+
+        environment.log(f"  Project ID: {milestone_data.get('project_id', 'N/A')}")
+
+        # Status information
+        is_completed = milestone_data.get("is_completed", False)
+        environment.log(f"  Status: {'Completed' if is_completed else 'Active'}")
+
+        # Due date
+        due_on = milestone_data.get("due_on")
+        if due_on:
+            environment.log(f"  Due On: {format_timestamp(due_on)}")
+        else:
+            environment.log("  Due On: (not set)")
+
+        if show_all_fields:
+            # Show additional fields
+            if milestone_data.get("refs"):
+                environment.log(f"  References: {milestone_data.get('refs')}")
+
+            completed_on = milestone_data.get("completed_on")
+            if completed_on:
+                environment.log(f"  Completed On: {format_timestamp(completed_on)}")
+
+            if milestone_data.get("url"):
+                environment.log(f"  URL: {milestone_data.get('url')}")
+
+            # Show all other fields (custom fields)
+            standard_fields = [
+                "id",
+                "name",
+                "description",
+                "project_id",
+                "is_completed",
+                "due_on",
+                "completed_on",
+                "refs",
+                "url",
+            ]
+            custom_fields = {k: v for k, v in milestone_data.items() if k not in standard_fields}
+            if custom_fields:
+                environment.log("  Custom Fields:")
+                for key, value in sorted(custom_fields.items()):
+                    environment.log(f"    {key}: {value}")
+
+    environment.log("")
+    environment.log("Milestone retrieval completed successfully.")
+
+
+@cli.command()
+@click.option(
+    "--offset",
+    type=click.IntRange(min=0),
+    default=0,
+    metavar="",
+    help="Offset for pagination (default: 0).",
+)
+@click.option(
+    "--limit",
+    type=click.IntRange(min=1, max=250),
+    default=250,
+    metavar="",
+    help="Maximum number of milestones to return (default: 250, max: 250).",
+)
+@click.option("--json-output", is_flag=True, help="Output milestones as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields including custom fields for each milestone.")
+@click.pass_context
+@pass_environment
+def list(
+    environment: Environment,
+    context: click.Context,
+    offset: int,
+    limit: int,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """List milestones from TestRail"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "List")
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    environment.log(
+        f"Retrieving milestones for project ID {project_client.project.project_id} (offset: {offset}, limit: {limit})..."
+    )
+
+    # Retrieve milestones using MilestoneHandler
+    milestones_data, error_message = project_client.api_request_handler.milestone_handler.get_milestones(
+        project_id=project_client.project.project_id, limit=limit, offset=offset
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve milestones: {error_message}")
+        raise SystemExit(1)
+
+    milestones = milestones_data.get("milestones", [])
+    total_count = milestones_data.get("size", 0)
+    returned_count = len(milestones)
+
+    if json_output:
+        # Output prettified JSON response
+        print(json.dumps(milestones_data, indent=2))
+    else:
+        environment.log(f"Found {total_count} milestone(s), displaying {returned_count}.")
+        environment.log("")
+
+        if not milestones:
+            environment.log("No milestones found.")
+        else:
+            for milestone in milestones:
+                # Compact format by default
+                status = "✓ Completed" if milestone.get("is_completed") else "○ Active"
+                due_on = format_timestamp(milestone.get("due_on")) if milestone.get("due_on") else "No due date"
+
+                environment.log(f"Milestone ID: {milestone.get('id')}")
+                environment.log(f"  Name: {milestone.get('name')}")
+
+                # Show description if present
+                if milestone.get("description"):
+                    description = milestone.get("description")
+                    if not show_all_fields and len(description) > 80:
+                        description = description[:80] + "..."
+                    environment.log(f"  Description: {description}")
+
+                environment.log(f"  Status: {status}")
+                environment.log(f"  Due On: {due_on}")
+                environment.log(f"  Project ID: {milestone.get('project_id', 'N/A')}")
+
+                if show_all_fields:
+                    # Show additional fields in detailed view
+                    if milestone.get("refs"):
+                        environment.log(f"  References: {milestone.get('refs')}")
+
+                    completed_on = milestone.get("completed_on")
+                    if completed_on:
+                        environment.log(f"  Completed On: {format_timestamp(completed_on)}")
+
+                    if milestone.get("url"):
+                        environment.log(f"  URL: {milestone.get('url')}")
+
+                    # Show custom fields
+                    standard_fields = [
+                        "id",
+                        "name",
+                        "description",
+                        "project_id",
+                        "is_completed",
+                        "due_on",
+                        "completed_on",
+                        "refs",
+                        "url",
+                    ]
+                    custom_fields = {k: v for k, v in milestone.items() if k not in standard_fields}
+                    if custom_fields:
+                        environment.log("  Custom Fields:")
+                        for key, value in sorted(custom_fields.items()):
+                            environment.log(f"    {key}: {value}")
+
+                environment.log("")
+
+        # Pagination info
+        next_link = milestones_data.get("_links", {}).get("next")
+        if next_link:
+            next_offset = offset + limit
+            environment.log(f"More results available. Use --offset {next_offset} to retrieve next page.")
+
+    environment.log("")
+    environment.log("Milestone listing completed successfully.")

--- a/trcli/commands/cmd_runs.py
+++ b/trcli/commands/cmd_runs.py
@@ -1,0 +1,315 @@
+import builtins
+import click
+import json
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def print_config(env: Environment, action: str):
+    env.log(
+        f"Runs {action} Execution Parameters"
+        f"\n> TestRail instance: {env.host} (user: {env.username})"
+        f"\n> Project: {env.project if env.project else env.project_id}"
+    )
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.pass_context
+@pass_environment
+def cli(environment: Environment, context: click.Context, *args, **kwargs):
+    """Manage test runs in TestRail"""
+    environment.cmd = "runs"
+    environment.set_parameters(context)
+
+
+@cli.command()
+@click.option("--run-id", type=click.IntRange(min=1), required=True, metavar="", help="Run ID to retrieve.")
+@click.option("--json-output", is_flag=True, help="Output run as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields including custom fields in detail.")
+@click.pass_context
+@pass_environment
+def get(
+    environment: Environment,
+    context: click.Context,
+    run_id: int,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """Get a single test run by ID"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Get")
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    environment.log(f"Retrieving run ID {run_id}...")
+
+    # Retrieve the run using RunHandler from ProjectBasedClient
+    run_data, error_message = project_client.api_request_handler.run_handler.get_run(run_id)
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve run: {error_message}")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        # Output prettified JSON response
+        print(json.dumps(run_data, indent=2))
+    else:
+        # Display run details
+        environment.log("")
+        environment.log(f"Run ID: {run_data.get('id', 'N/A')}")
+        environment.log(f"  Name: {run_data.get('name', 'N/A')}")
+
+        if run_data.get("description"):
+            description = run_data.get("description")
+            # Truncate long descriptions in non-show-all-fields mode
+            if not show_all_fields and len(description) > 100:
+                description = description[:100] + "..."
+            environment.log(f"  Description: {description}")
+        else:
+            environment.log("  Description: (none)")
+
+        environment.log(f"  Suite ID: {run_data.get('suite_id', 'N/A')}")
+        environment.log(f"  Project ID: {run_data.get('project_id', 'N/A')}")
+
+        # Status information
+        is_completed = run_data.get("is_completed", False)
+        environment.log(f"  Status: {'Completed' if is_completed else 'Active'}")
+
+        if is_completed and run_data.get("completed_on"):
+            environment.log(f"  Completed On: {run_data.get('completed_on')}")
+
+        # Test counts
+        environment.log("  Test Status Counts:")
+        environment.log(f"    Passed: {run_data.get('passed_count', 0)}")
+        environment.log(f"    Failed: {run_data.get('failed_count', 0)}")
+        environment.log(f"    Blocked: {run_data.get('blocked_count', 0)}")
+        environment.log(f"    Retest: {run_data.get('retest_count', 0)}")
+        environment.log(f"    Untested: {run_data.get('untested_count', 0)}")
+
+        if show_all_fields:
+            # Show additional fields
+            if run_data.get("config"):
+                environment.log(f"  Configuration: {run_data.get('config')}")
+
+            if run_data.get("config_ids"):
+                environment.log(f"  Configuration IDs: {run_data.get('config_ids')}")
+
+            if run_data.get("milestone_id"):
+                environment.log(f"  Milestone ID: {run_data.get('milestone_id')}")
+
+            if run_data.get("plan_id"):
+                environment.log(f"  Plan ID: {run_data.get('plan_id')}")
+
+            if run_data.get("assignedto_id"):
+                environment.log(f"  Assigned To ID: {run_data.get('assignedto_id')}")
+
+            if run_data.get("refs"):
+                environment.log(f"  References: {run_data.get('refs')}")
+
+            environment.log(f"  Include All: {'Yes' if run_data.get('include_all') else 'No'}")
+            environment.log(f"  Created By: {run_data.get('created_by', 'N/A')}")
+            environment.log(f"  Created On: {run_data.get('created_on', 'N/A')}")
+
+            if run_data.get("updated_on"):
+                environment.log(f"  Updated On: {run_data.get('updated_on')}")
+
+            if run_data.get("url"):
+                environment.log(f"  URL: {run_data.get('url')}")
+
+            # Show custom status counts
+            custom_counts = {
+                k: v for k, v in run_data.items() if k.startswith("custom_status") and k.endswith("_count")
+            }
+            if any(v > 0 for v in custom_counts.values()):
+                environment.log("  Custom Status Counts:")
+                for key, value in custom_counts.items():
+                    if value > 0:
+                        status_num = key.replace("custom_status", "").replace("_count", "")
+                        environment.log(f"    Custom Status {status_num}: {value}")
+
+            # Show all other fields
+            standard_fields = [
+                "id",
+                "name",
+                "description",
+                "suite_id",
+                "project_id",
+                "is_completed",
+                "completed_on",
+                "passed_count",
+                "failed_count",
+                "blocked_count",
+                "retest_count",
+                "untested_count",
+                "config",
+                "config_ids",
+                "milestone_id",
+                "plan_id",
+                "assignedto_id",
+                "refs",
+                "include_all",
+                "created_by",
+                "created_on",
+                "updated_on",
+                "url",
+                "custom_status1_count",
+                "custom_status2_count",
+                "custom_status3_count",
+                "custom_status4_count",
+                "custom_status5_count",
+                "custom_status6_count",
+                "custom_status7_count",
+            ]
+            other_fields = {k: v for k, v in run_data.items() if k not in standard_fields}
+            if other_fields:
+                environment.log(f"\n  Additional Fields ({len(other_fields)}):")
+                for key, value in other_fields.items():
+                    display_name = key.replace("_", " ").title()
+                    if value is None:
+                        display_value = "N/A"
+                    elif isinstance(value, builtins.list):
+                        if value:
+                            display_value = f"{len(value)} item(s): {value}"
+                        else:
+                            display_value = "[]"
+                    else:
+                        display_value = value
+                    environment.log(f"    {display_name}: {display_value}")
+
+
+@cli.command()
+@click.option("--offset", type=int, default=0, metavar="", help="Offset for pagination (default: 0).")
+@click.option("--limit", type=int, default=250, metavar="", help="Limit for pagination (default: 250).")
+@click.option("--json-output", is_flag=True, help="Output runs as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields including custom fields in detail.")
+@click.pass_context
+@pass_environment
+def list(
+    environment: Environment,
+    context: click.Context,
+    offset: int,
+    limit: int,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """List test runs from TestRail"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "List")
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    environment.log(f"Retrieving runs for project ID {project_client.project.project_id}...")
+    environment.log("(Note: Only returns runs not part of test plans)")
+
+    # Retrieve runs using RunHandler from ProjectBasedClient
+    response_data, error_message = project_client.api_request_handler.run_handler.get_runs(
+        project_id=project_client.project.project_id,
+        limit=limit,
+        offset=offset,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve runs: {error_message}")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        # Output prettified JSON response
+        print(json.dumps(response_data, indent=2))
+    else:
+        # Display runs line by line
+        runs = response_data.get("runs", [])
+        response_offset = response_data.get("offset", 0)
+        response_limit = response_data.get("limit", 250)
+        response_size = response_data.get("size", 0)
+        next_link = response_data.get("_links", {}).get("next")
+
+        if not runs:
+            environment.log("No runs found.")
+        else:
+            environment.log(
+                f"Found {response_size} run(s) (showing {response_offset + 1}-{response_offset + len(runs)}):"
+            )
+            if next_link:
+                environment.log("  (More results available - use --offset and --limit for pagination)")
+            environment.log("")
+
+            for run in runs:
+                if show_all_fields:
+                    # Show all fields from API response
+                    environment.log(f"  Run ID: {run.get('id', 'N/A')}")
+
+                    # Iterate through all fields in the run
+                    for key, value in run.items():
+                        if key == "id":
+                            continue  # Already displayed as Run ID
+
+                        # Format field name for display
+                        display_name = key.replace("_", " ").title()
+
+                        # Handle None values
+                        if value is None:
+                            display_value = "N/A"
+                        elif isinstance(value, bool):
+                            display_value = "Yes" if value else "No"
+                        elif isinstance(value, builtins.list):
+                            if value:
+                                display_value = f"{len(value)} item(s): {value}"
+                            else:
+                                display_value = "[]"
+                        else:
+                            display_value = value
+
+                        environment.log(f"    {display_name}: {display_value}")
+
+                    environment.log("")
+                else:
+                    # Display compact format
+                    environment.log(f"  Run ID: {run.get('id', 'N/A')}")
+                    environment.log(f"    Name: {run.get('name', 'N/A')}")
+
+                    if run.get("description"):
+                        description = run.get("description")
+                        # Truncate long descriptions in compact mode
+                        if len(description) > 80:
+                            description = description[:80] + "..."
+                        environment.log(f"    Description: {description}")
+
+                    is_completed = run.get("is_completed", False)
+                    environment.log(f"    Status: {'Completed' if is_completed else 'Active'}")
+
+                    # Show test counts
+                    passed = run.get("passed_count", 0)
+                    failed = run.get("failed_count", 0)
+                    blocked = run.get("blocked_count", 0)
+                    untested = run.get("untested_count", 0)
+                    environment.log(
+                        f"    Tests: Passed={passed}, Failed={failed}, Blocked={blocked}, Untested={untested}"
+                    )
+
+                    environment.log(f"    Suite ID: {run.get('suite_id', 'N/A')}")
+
+                    environment.log("")

--- a/trcli/commands/cmd_statuses.py
+++ b/trcli/commands/cmd_statuses.py
@@ -1,0 +1,174 @@
+import click
+import json
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def print_config(env: Environment, action: str):
+    env.log(
+        f"Statuses {action} Execution Parameters"
+        f"\n> TestRail instance: {env.host} (user: {env.username})"
+        f"\n> Project: {env.project if env.project else env.project_id}"
+    )
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.pass_context
+@pass_environment
+def cli(environment: Environment, context: click.Context, *args, **kwargs):
+    """Manage test statuses in TestRail"""
+    environment.cmd = "statuses"
+    environment.set_parameters(context)
+
+
+@cli.command()
+@click.option("--json-output", is_flag=True, help="Output statuses as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields for each status.")
+@click.pass_context
+@pass_environment
+def all(
+    environment: Environment,
+    context: click.Context,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """List all test result statuses from TestRail"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "List (Test Result Statuses)")
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    environment.log(f"Retrieving test result statuses for project ID {project_client.project.project_id}...")
+
+    # Retrieve statuses using StatusHandler from ProjectBasedClient
+    statuses_data, error_message = project_client.api_request_handler.status_handler.get_statuses(
+        project_id=project_client.project.project_id
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve statuses: {error_message}")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        # Output prettified JSON response
+        print(json.dumps(statuses_data, indent=2))
+    else:
+        # Display statuses line by line
+        if not statuses_data:
+            environment.log("No statuses found.")
+        else:
+            environment.log(f"Found {len(statuses_data)} test result status(es):")
+            environment.log("")
+
+            for status in statuses_data:
+                status_id = status.get("id", "N/A")
+                name = status.get("name", "N/A")
+                label = status.get("label", "N/A")
+                is_system = status.get("is_system", False)
+                is_untested = status.get("is_untested", False)
+                is_final = status.get("is_final", False)
+
+                environment.log(f"Status ID: {status_id}")
+                environment.log(f"  Name: {name}")
+                environment.log(f"  Label: {label}")
+                environment.log(f"  System Status: {'Yes' if is_system else 'No'}")
+                environment.log(f"  Is Untested: {'Yes' if is_untested else 'No'}")
+                environment.log(f"  Is Final: {'Yes' if is_final else 'No'}")
+
+                if show_all_fields:
+                    color_dark = status.get("color_dark", "N/A")
+                    color_medium = status.get("color_medium", "N/A")
+                    color_bright = status.get("color_bright", "N/A")
+                    environment.log(f"  Colors: Dark={color_dark}, Medium={color_medium}, Bright={color_bright}")
+
+                environment.log("")
+
+    environment.log("")
+    environment.log("Status listing completed successfully.")
+
+
+@cli.command()
+@click.option("--json-output", is_flag=True, help="Output case statuses as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields for each case status.")
+@click.pass_context
+@pass_environment
+def case(
+    environment: Environment,
+    context: click.Context,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """List all case statuses from TestRail (Enterprise 7.3+)"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "List (Case Statuses)")
+
+    # Create ProjectBasedClient (no need to resolve project for case statuses)
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    environment.log("Retrieving case statuses...")
+    environment.log("Note: This command requires TestRail Enterprise 7.3 or later.")
+
+    # Retrieve case statuses using StatusHandler from ProjectBasedClient
+    case_statuses_data, error_message = project_client.api_request_handler.status_handler.get_case_statuses()
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve case statuses: {error_message}")
+        environment.elog(
+            "Note: get_case_statuses requires TestRail Enterprise 7.3+. "
+            "If you have an older version, this endpoint may not be available."
+        )
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        # Output prettified JSON response
+        print(json.dumps(case_statuses_data, indent=2))
+    else:
+        # Display case statuses line by line
+        if not case_statuses_data:
+            environment.log("No case statuses found.")
+        else:
+            environment.log(f"Found {len(case_statuses_data)} case status(es):")
+            environment.log("")
+
+            for case_status in case_statuses_data:
+                case_status_id = case_status.get("case_status_id", "N/A")
+                name = case_status.get("name", "N/A")
+                is_default = case_status.get("is_default", False)
+                is_approved = case_status.get("is_approved", False)
+
+                environment.log(f"Case Status ID: {case_status_id}")
+                environment.log(f"  Name: {name}")
+                environment.log(f"  Is Default: {'Yes' if is_default else 'No'}")
+                environment.log(f"  Is Approved: {'Yes' if is_approved else 'No'}")
+
+                if show_all_fields:
+                    abbreviation = case_status.get("abbreviation")
+                    if abbreviation:
+                        environment.log(f"  Abbreviation: {abbreviation}")
+                    else:
+                        environment.log("  Abbreviation: (none)")
+
+                environment.log("")
+
+    environment.log("")
+    environment.log("Case status listing completed successfully.")

--- a/trcli/constants.py
+++ b/trcli/constants.py
@@ -97,6 +97,7 @@ COMMAND_FAULT_MAPPING = dict(
     runs=dict(**FAULT_MAPPING),
     milestones=dict(**FAULT_MAPPING),
     statuses=dict(**FAULT_MAPPING),
+    casefields=dict(**FAULT_MAPPING),
 )
 
 PROMPT_MESSAGES = dict(
@@ -130,6 +131,7 @@ TOOL_USAGE = f"""Supported and loaded modules:
     - runs: Query test runs
     - milestones: Query milestones
     - statuses: Query test statuses
+    - casefields: Query test case custom fields
     - results: Query and update test results"""
 
 MISSING_COMMAND_SLOGAN = """Usage: trcli [OPTIONS] COMMAND [ARGS]...\nTry 'trcli --help' for help.

--- a/trcli/constants.py
+++ b/trcli/constants.py
@@ -96,6 +96,7 @@ COMMAND_FAULT_MAPPING = dict(
     sections=dict(**FAULT_MAPPING),
     runs=dict(**FAULT_MAPPING),
     milestones=dict(**FAULT_MAPPING),
+    statuses=dict(**FAULT_MAPPING),
 )
 
 PROMPT_MESSAGES = dict(
@@ -128,6 +129,7 @@ TOOL_USAGE = f"""Supported and loaded modules:
     - plans: Query test plans
     - runs: Query test runs
     - milestones: Query milestones
+    - statuses: Query test statuses
     - results: Query and update test results"""
 
 MISSING_COMMAND_SLOGAN = """Usage: trcli [OPTIONS] COMMAND [ARGS]...\nTry 'trcli --help' for help.

--- a/trcli/constants.py
+++ b/trcli/constants.py
@@ -94,6 +94,7 @@ COMMAND_FAULT_MAPPING = dict(
     suites=dict(**FAULT_MAPPING),
     plans=dict(**FAULT_MAPPING),
     sections=dict(**FAULT_MAPPING),
+    runs=dict(**FAULT_MAPPING),
 )
 
 PROMPT_MESSAGES = dict(
@@ -119,7 +120,13 @@ TOOL_USAGE = f"""Supported and loaded modules:
     - parse_openapi: OpenAPI YML Files
     - add_run: Create a new test run
     - labels: Manage labels (projects, cases, and tests)
-    - references: Manage references (cases and runs)"""
+    - references: Manage references (cases and runs)
+    - cases: Query test cases
+    - suites: Query test suites
+    - sections: Query test sections
+    - plans: Query test plans
+    - runs: Query test runs
+    - results: Query and update test results"""
 
 MISSING_COMMAND_SLOGAN = """Usage: trcli [OPTIONS] COMMAND [ARGS]...\nTry 'trcli --help' for help.
 \nError: Missing command."""

--- a/trcli/constants.py
+++ b/trcli/constants.py
@@ -95,6 +95,7 @@ COMMAND_FAULT_MAPPING = dict(
     plans=dict(**FAULT_MAPPING),
     sections=dict(**FAULT_MAPPING),
     runs=dict(**FAULT_MAPPING),
+    milestones=dict(**FAULT_MAPPING),
 )
 
 PROMPT_MESSAGES = dict(
@@ -126,6 +127,7 @@ TOOL_USAGE = f"""Supported and loaded modules:
     - sections: Query test sections
     - plans: Query test plans
     - runs: Query test runs
+    - milestones: Query milestones
     - results: Query and update test results"""
 
 MISSING_COMMAND_SLOGAN = """Usage: trcli [OPTIONS] COMMAND [ARGS]...\nTry 'trcli --help' for help.


### PR DESCRIPTION
### Solution description
Allow users to get custom case field attributes and metadata from TestRail for processing or automation workflows.

### Changes
Implemented a **casefields** command that will automatically fetch custom case field data from a selected project.

### Potential impacts
None.

### Steps to test
See updated README: 2342 - 2374

### PR Tasks
- [x] PR reference added to issue
- [x] README updated
- [x] Unit tests added/updated
