### PR TITLE
TRCLI-292: Add subcommand for plans (Test Plans)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Commands:
   statuses       Manage test statuses in TestRail
   casefields     List case fields in TestRail
   resultfields   List result fields in TestRail
+  priorities     List test case priorities in TestRail
   update         Update TRCLI to the latest version from PyPI.
 ```
 
@@ -2394,156 +2395,57 @@ Case Status ID: 2
 Case status listing completed successfully.
 ```
 
-### Statuses Command
+### Priorities Command
 
-The TestRail CLI provides the `statuses` command for retrieving status information from TestRail. This includes both test result statuses (Passed, Failed, Blocked, etc.) and case statuses (Approved, Draft, etc.). These statuses are crucial for mapping test results correctly and managing test case workflows.
-
-#### Statuses Command Overview
-
-The `statuses` command supports two subcommands:
-
-| Subcommand | Purpose | API Endpoint |
-|------------|---------|--------------|
-| `all` | List all test result statuses | Retrieve available test result statuses (Passed, Failed, Blocked, etc.) |
-| `case` | List all case statuses (Enterprise 7.3+) | Retrieve test case statuses (Approved, Draft, etc.) for case workflows |
+The TestRail CLI provides the `priorities` command for retrieving all available test case priorities from TestRail. This command helps you understand the priority levels configured in your TestRail instance, including their IDs, names, short names, display order, and which priority is set as the default.
 
 #### Reference
 
 ```shell
-$ trcli statuses --help
+$ trcli priorities --help
 
-Usage: trcli statuses [OPTIONS] COMMAND [ARGS]...
-  Manage test statuses in TestRail
+Usage: trcli priorities [OPTIONS] COMMAND [ARGS]...
+  Manage test case priorities in TestRail
 
 Options:
   --help  Show this message and exit.
 
 Commands:
-  all   List all test result statuses from TestRail
-  case  List all case statuses from TestRail (Enterprise 7.3+)
+  list  List all test case priorities from TestRail
 ```
 
-##### Listing Test Result Statuses
-
-List all test result statuses available for a project:
+#### Listing Priorities
 
 ```shell
-# List all test result statuses (using config file)
-$ trcli -c config.yml statuses all
+# List all priorities
+$ trcli priorities list -h https://yourinstance.testrail.io -u user@example.com -p password
 
-# List all statuses with all parameters
-$ trcli statuses all \
-  --host https://yourinstance.testrail.io \
-  --username <your_username> \
-  --password <your_password> \
-  --project "Your Project"
+# Show all fields including priority order
+$ trcli priorities list -c config.yml --show-all-fields
 
-# Show all fields including color values
-$ trcli -c config.yml statuses all --show-all-fields
-
-# JSON output for integration with other tools
-$ trcli -c config.yml statuses all --json-output | jq '.[].name'
+# JSON output
+$ trcli priorities list -c config.yml --json-output
 ```
 
-**Example Output:**
+#### Example Output
 
 ```shell
-$ trcli -c config.yml statuses all
+$ trcli priorities list -c config.yml
 
-Statuses List (Test Result Statuses) Execution Parameters
-> TestRail instance: https://yourinstance.testrail.io (user: test@example.com)
-> Project: Your Project
+Priorities List Execution Parameters
+> TestRail instance: https://yourinstance.testrail.io (user: your@email.com)
+Retrieving priorities...
+Found 4 priority level(s).
 
-Retrieving test result statuses for project ID 1...
-Found 5 test result status(es):
+ID: 1 | Name: 1 - Don't Test | Short: 1 - Don't
+ID: 2 | Name: 2 - Low | Short: 2 - Low
+ID: 3 | Name: 3 - Medium | Short: 3 - Med
+ID: 4 | Name: 4 - Must Test | Short: 4 - Must [DEFAULT]
 
-Status ID: 1
-  Name: passed
-  Label: Passed
-  System Status: Yes
-  Is Untested: No
-  Is Final: Yes
-
-Status ID: 2
-  Name: blocked
-  Label: Blocked
-  System Status: Yes
-  Is Untested: No
-  Is Final: No
-
-Status ID: 3
-  Name: untested
-  Label: Untested
-  System Status: Yes
-  Is Untested: Yes
-  Is Final: No
-
-Status ID: 4
-  Name: retest
-  Label: Retest
-  System Status: Yes
-  Is Untested: No
-  Is Final: No
-
-Status ID: 5
-  Name: failed
-  Label: Failed
-  System Status: Yes
-  Is Untested: No
-  Is Final: Yes
-
-
-Status listing completed successfully.
+Priority listing completed successfully.
 ```
 
-##### Listing Case Statuses
-
-List all case statuses (requires TestRail Enterprise 7.3+):
-
-```shell
-# List all case statuses (using config file)
-$ trcli -c config.yml statuses case
-
-# List case statuses with all parameters
-$ trcli statuses case \
-  --host https://yourinstance.testrail.io \
-  --username <your_username> \
-  --password <your_password> \
-  --project "Your Project"
-
-# Show all fields including abbreviations
-$ trcli -c config.yml statuses case --show-all-fields
-
-# JSON output for integration
-$ trcli -c config.yml statuses case --json-output | jq '.[].name'
-```
-
-**Example Output:**
-
-```shell
-$ trcli -c config.yml statuses case
-
-Statuses List (Case Statuses) Execution Parameters
-> TestRail instance: https://yourinstance.testrail.io (user: test@example.com)
-> Project: Your Project
-
-Retrieving case statuses...
-Note: This command requires TestRail Enterprise 7.3 or later.
-Found 2 case status(es):
-
-Case Status ID: 1
-  Name: Approved
-  Is Default: No
-  Is Approved: Yes
-
-Case Status ID: 2
-  Name: Draft
-  Is Default: Yes
-  Is Approved: No
-
-
-Case status listing completed successfully.
-```
+**Note:** The `[DEFAULT]` marker indicates which priority is set as the default for new test cases in TestRail. Priorities are global settings and apply across all projects in your TestRail instance.
 
 ### Case Fields Command
 

--- a/README.md
+++ b/README.md
@@ -2567,6 +2567,58 @@ $ trcli -c config.yml users list --json-output
 - Enterprise-specific fields (SSO, assigned projects) are only available in TestRail Enterprise
 - The `--show-all-fields` option displays additional information including admin status, groups, MFA requirements, and enterprise fields
 
+### Projects Command
+
+The `projects` command provides functionality to query and retrieve project information from TestRail. This command allows you to get details about specific projects or list all projects in your TestRail instance.
+
+The `projects` command supports two subcommands:
+- **get**: Retrieve detailed information about a specific project by ID
+- **list**: List all projects or filter by completion status with pagination support
+
+#### Getting a Specific Project
+
+The `get` subcommand retrieves detailed information about a single project using its project ID.
+
+```shell
+# Get a specific project by ID
+$ trcli -c config.yml projects get --project-id 1
+
+# Get project with all fields (includes users, groups, announcement)
+$ trcli -c config.yml projects get --project-id 1 --show-all-fields
+
+# JSON output
+$ trcli -c config.yml projects get --project-id 1 --json-output
+```
+
+#### Listing Projects
+
+The `list` subcommand retrieves multiple projects. You can list all projects or filter by completion status, and use pagination to manage large numbers of projects.
+
+```shell
+# List all projects
+$ trcli -c config.yml projects list
+
+# List only active projects
+$ trcli -c config.yml projects list --is-completed 0
+
+# List only completed projects  
+$ trcli -c config.yml projects list --is-completed 1
+
+# List with pagination
+$ trcli -c config.yml projects list --limit 10 --offset 0
+
+# Show all fields for each project
+$ trcli -c config.yml projects list --show-all-fields
+
+# JSON output
+$ trcli -c config.yml projects list --json-output
+```
+
+**Note:**
+- The `--is-completed` filter accepts 0 for active projects or 1 for completed projects
+- Pagination parameters `--limit` and `--offset` allow you to retrieve projects in manageable batches
+- The `--show-all-fields` option displays additional information including announcement, users, groups, and default role
+
 ### Case Fields Command
 
 The TestRail CLI provides the `casefields` command for retrieving all available test case custom fields from TestRail. This command helps you understand what custom fields are available for test cases, their types, configurations, and which projects they apply to.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Commands:
   resultfields   List result fields in TestRail
   priorities     List test case priorities in TestRail
   casetypes      List test case types in TestRail
+  users          Query users in TestRail
   update         Update TRCLI to the latest version from PyPI.
 ```
 
@@ -2499,6 +2500,72 @@ Case type listing completed successfully.
 ```
 
 **Note:** The `[DEFAULT]` marker indicates which case type is set as the default for new test cases in TestRail. Case types are global settings and apply across all projects in your TestRail instance.
+
+### Users Command
+
+The TestRail CLI provides the `users` command for retrieving user information from TestRail. This command supports getting individual users by ID or email, retrieving the current authenticated user, and listing all users or users with access to a specific project.
+
+#### Reference
+
+```shell
+$ trcli users --help
+
+Usage: trcli users [OPTIONS] COMMAND [ARGS]...
+  Manage users in TestRail
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  get   Get a specific user from TestRail
+  list  List all users from TestRail
+```
+
+#### Getting a Specific User
+
+The `get` subcommand retrieves information about a single user using one of three mutually exclusive options:
+
+```shell
+# Get the current authenticated user
+$ trcli -c config.yml users get --current
+
+# Get user by ID
+$ trcli -c config.yml users get --user-id 5
+
+# Get user by email
+$ trcli -c config.yml users get --email john.doe@example.com
+
+# Show all fields including admin status and enterprise fields
+$ trcli -c config.yml users get --user-id 1 --show-all-fields
+
+# JSON output
+$ trcli -c config.yml users get --current --json-output
+```
+
+#### Listing Users
+
+The `list` subcommand retrieves multiple users. Without `--project-id`, it lists all users (requires administrator privileges). With `--project-id`, it lists only users with access to that specific project.
+
+```shell
+# List all users (admin only)
+$ trcli -c config.yml users list
+
+# List users for a specific project
+$ trcli -c config.yml users list --project-id 5
+
+# Show all fields for each user
+$ trcli -c config.yml users list --project-id 3 --show-all-fields
+
+# JSON output
+$ trcli -c config.yml users list --json-output
+```
+
+**Note:**
+- The `get` subcommand requires one of `--current`, `--user-id`, or `--email` (mutually exclusive)
+- Listing all users without `--project-id` requires administrator privileges (TestRail 6.6+)
+- When using `--project-id`, only users with explicit project access are returned (inactive users and users without project access are excluded)
+- Enterprise-specific fields (SSO, assigned projects) are only available in TestRail Enterprise
+- The `--show-all-fields` option displays additional information including admin status, groups, MFA requirements, and enterprise fields
 
 ### Case Fields Command
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Commands:
   casefields     List case fields in TestRail
   resultfields   List result fields in TestRail
   priorities     List test case priorities in TestRail
+  casetypes      List test case types in TestRail
   update         Update TRCLI to the latest version from PyPI.
 ```
 
@@ -2446,6 +2447,58 @@ Priority listing completed successfully.
 ```
 
 **Note:** The `[DEFAULT]` marker indicates which priority is set as the default for new test cases in TestRail. Priorities are global settings and apply across all projects in your TestRail instance.
+
+### Case Types Command
+
+The TestRail CLI provides the `casetypes` command for retrieving all available test case types from TestRail. This command helps you understand the different case type classifications configured in your TestRail instance, such as Automated, Functionality, Performance, and others, including which type is set as the default.
+
+#### Reference
+
+```shell
+$ trcli casetypes --help
+
+Usage: trcli casetypes [OPTIONS] COMMAND [ARGS]...
+  Manage test case types in TestRail
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  list  List all test case types from TestRail
+```
+
+#### Listing Case Types
+
+```shell
+# List all case types
+$ trcli -h https://yourinstance.testrail.io -u user@example.com -p password casetypes list
+
+# With config file
+$ trcli casetypes list -c config.yml
+
+# JSON output
+$ trcli casetypes list -c config.yml --json-output
+```
+
+#### Example Output
+
+```shell
+$ trcli casetypes list -c config.yml
+
+Case Types List Execution Parameters
+> TestRail instance: https://yourinstance.testrail.io (user: your@email.com)
+Retrieving case types...
+Found 4 case type(s).
+
+ID: 1 | Name: Automated
+ID: 2 | Name: Functionality
+ID: 3 | Name: Performance
+ID: 6 | Name: Other [DEFAULT]
+
+Case type listing completed successfully.
+```
+
+**Note:** The `[DEFAULT]` marker indicates which case type is set as the default for new test cases in TestRail. Case types are global settings and apply across all projects in your TestRail instance.
 
 ### Case Fields Command
 

--- a/README.md
+++ b/README.md
@@ -1838,12 +1838,13 @@ The TestRail CLI provides the `plans` command for retrieving and listing test pl
 
 ##### Plans Command Overview
 
-The `plans` command supports two subcommands:
+The `plans` command supports three subcommands:
 
 | Subcommand | Purpose | Use Case |
 |------------|---------|----------|
 | `plans get` | Retrieve a single test plan by ID | Get detailed information about a plan including all entries and runs |
 | `plans list` | List test plans in a project | Discover plans, monitor progress, export plan data with pagination |
+| `plans add` | Create a new test plan | Create plans with entries, milestones, and scheduled dates |
 
 ##### Reference
 
@@ -1857,6 +1858,7 @@ Options:
   --help  Show this message and exit.
 
 Commands:
+  add   Create a new test plan
   get   Get a single test plan by ID
   list  List test plans from TestRail
 ```
@@ -1909,6 +1911,123 @@ $ trcli -c config.yml plans list --json-output | jq '.plans[].name'
 $ trcli -c config.yml plans list --show-all-fields
 ```
 
+##### Creating a Test Plan
+
+Create a new test plan in TestRail with optional entries, milestones, and scheduled dates:
+
+```shell
+# Create a basic test plan
+$ trcli plans add \
+  --host https://yourinstance.testrail.io \
+  --username <your_username> \
+  --password <your_password> \
+  --project "Your Project" \
+  --name "Release 2.0 Testing"
+
+# Create a plan with description and milestone
+$ trcli -c config.yml plans add \
+  --name "Q4 Regression Testing" \
+  --description "Comprehensive regression tests for Q4 release" \
+  --milestone-id 5
+
+# Create a plan with scheduled dates (MM/DD/YYYY format)
+$ trcli -c config.yml plans add \
+  --name "Sprint 10 Testing" \
+  --start-on "01/01/2022" \
+  --due-on "01/15/2022"
+
+# Create a plan with entries (test runs) from JSON string
+# Use --entries for simple, inline entries (good for scripting)
+# Note: Each entry must specify either "include_all": true or provide "case_ids"
+$ trcli -c config.yml plans add \
+  --name "Multi-Suite Testing" \
+  --entries '[{"suite_id": 1, "name": "API Tests", "include_all": true}, {"suite_id": 2, "name": "UI Tests", "include_all": true}]'
+
+# Create a plan with entries from a JSON file
+# Use --entries-file for complex entries with multiple runs/configs (more readable)
+$ trcli -c config.yml plans add \
+  --name "Complex Test Plan" \
+  --entries-file entries.json
+
+# Get JSON output for programmatic use
+$ trcli -c config.yml plans add \
+  --name "Automated Plan" \
+  --json-output
+```
+
+**Example entries.json file:**
+
+Each entry represents a test run (or group of runs for multi-config scenarios). TestRail requires you to specify which test cases to include using one of these methods:
+
+1. **Include all cases**: Set `"include_all": true`
+2. **Specific cases**: Provide `"case_ids": [1, 2, 3]`
+3. **Using runs array**: For multi-configuration plans, use `"runs"` with case specifications
+
+```json
+[
+  {
+    "suite_id": 1,
+    "name": "Smoke Tests",
+    "description": "Critical path tests",
+    "assignedto_id": 5,
+    "include_all": true
+  },
+  {
+    "suite_id": 2,
+    "name": "Regression Tests - Specific Cases",
+    "description": "Selected regression test cases",
+    "case_ids": [1, 2, 3, 4, 5]
+  },
+  {
+    "suite_id": 3,
+    "name": "Multi-Configuration Tests",
+    "description": "Cross-browser testing",
+    "config_ids": [1, 2],
+    "runs": [
+      {
+        "config_ids": [1, 2],
+        "case_ids": [10, 11, 12]
+      }
+    ]
+  }
+]
+```
+
+**Entry Field Reference:**
+- `suite_id` (required): ID of the test suite
+- `name` (optional): Name for the test run(s)
+- `description` (optional): Description for the test run(s)
+- `include_all` (optional): Include all test cases from the suite (default: false)
+- `case_ids` (optional): Array of specific test case IDs to include
+- `assignedto_id` (optional): User ID to assign the run to
+- `config_ids` (optional): Configuration IDs for multi-config runs
+- `runs` (optional): Array of run configurations (required when using `config_ids`)
+
+**Important Notes for Multi-Configuration Entries:**
+
+When using `config_ids` for multi-configuration testing (e.g., different browsers, platforms):
+
+1. **The `runs` array is REQUIRED** when you specify `config_ids`
+2. **Each run object must include `config_ids`** - repeat the same config_ids from the entry level
+3. **Specify test cases** in the run object using either `case_ids` or `include_all: true`
+
+Example for cross-browser testing:
+```json
+{
+  "suite_id": 3,
+  "name": "Browser Tests",
+  "config_ids": [16, 15],        // Chrome (16), Firefox (15)
+  "runs": [
+    {
+      "config_ids": [16, 15],    // Must repeat config_ids here
+      "case_ids": [100, 101, 102]
+    }
+  ]
+}
+```
+
+This creates one run that tests cases 100, 101, 102 across Chrome and Firefox configurations.
+
 ##### Configuration File Support
 
 The `plans` command supports configuration files, allowing you to specify connection details and project information once:
@@ -1950,6 +2069,28 @@ Options:
   --help             Show this message and exit.
 ```
 
+**Add Command:**
+```shell
+$ trcli plans add --help
+Options:
+  --name <name>             Name of the test plan.  [required]
+  --description <description>
+                            Description of the test plan.
+  --milestone-id <id>       ID of the milestone to link.  [x>=1]
+  --entries <json>          JSON array of plan entries inline. Use this for
+                            simple entries or scripting. Mutually exclusive
+                            with --entries-file.
+  --entries-file <path>     Path to JSON file containing plan entries. Use this
+                            for complex entries with multiple runs/configs.
+                            Mutually exclusive with --entries.
+  --start-on                The scheduled start date of this test plan in
+                            MM/DD/YYYY format
+  --due-on                  The scheduled due date of this test plan in
+                            MM/DD/YYYY format
+  --json-output             Output created plan as raw JSON from API.
+  --help                    Show this message and exit.
+```
+
 ##### Use Cases
 
 **1. Monitor release testing progress:**
@@ -1960,6 +2101,15 @@ $ trcli -c config.yml plans get --plan-id 10
 **2. Export plan data for reporting:**
 ```shell
 $ trcli -c config.yml plans list --json-output > plans_report.json
+```
+
+**3. Create a test plan for a new release:**
+```shell
+$ trcli -c config.yml plans add \
+  --name "Release 3.0 Testing" \
+  --description "Full regression and feature testing for v3.0" \
+  --milestone-id 8 \
+  --entries-file release_plan_entries.json
 ```
 
 ### Managing Sections

--- a/README.md
+++ b/README.md
@@ -2643,6 +2643,71 @@ $ trcli -c config.yml templates list --project-id 1 --json-output
 - Each template has a unique ID, name, and indicates whether it's the default template for the project
 - Templates control which fields are available when creating test cases
 
+### Tests Command
+
+The `tests` command provides functionality to query test instances in TestRail. Tests are the actual instances of test cases within a test run, containing execution status, assignments, and results. This is different from test cases (which are templates) and test results (which are the outcomes).
+
+The `tests` command supports two subcommands:
+- **get**: Retrieve detailed information about a specific test by ID
+- **list**: List all tests for a specific test run with filtering and pagination support
+
+#### Getting a Specific Test
+
+The `get` subcommand retrieves detailed information about a single test using its test ID.
+
+```shell
+# Get a specific test by ID
+$ trcli -c config.yml tests get --test-id 100
+
+# Get test with all fields (includes custom fields and labels)
+$ trcli -c config.yml tests get --test-id 100 --show-all-fields
+
+# Get test with results and attachments
+$ trcli -c config.yml tests get --test-id 100 --with-data 1
+
+# Get test with results and show all details
+$ trcli -c config.yml tests get --test-id 100 --with-data 1 --show-all-fields
+
+# JSON output
+$ trcli -c config.yml tests get --test-id 100 --json-output
+```
+
+#### Listing Tests
+
+The `list` subcommand retrieves all tests for a specific test run. You can filter by status ID, labels ID, and use pagination to manage large numbers of tests.
+
+```shell
+# List all tests for a run
+$ trcli -c config.yml tests list --run-id 1
+
+# List only failed and retest tests
+$ trcli -c config.yml tests list --run-id 1 --status-id 4,5
+
+# List tests with specific labels
+$ trcli -c config.yml tests list --run-id 1 --label-id 1,2
+
+# List with pagination
+$ trcli -c config.yml tests list --run-id 1 --limit 30 --offset 0
+
+# Show all fields for each test
+$ trcli -c config.yml tests list --run-id 1 --show-all-fields
+
+# JSON output
+$ trcli -c config.yml tests list --run-id 1 --json-output
+
+# Combine filters
+$ trcli -c config.yml tests list --run-id 1 --status-id 4,5 --limit 30 --offset 0
+```
+
+**Note:**
+- The `--test-id` parameter for get and `--run-id` parameter for list are required and must be valid IDs (x>=1)
+- The `--with-data` parameter (0 or 1) controls whether to include test results and attachments in the response (only for get command)
+- The `--status-id` filter accepts a comma-separated list of status IDs (e.g., "1,5" for Passed and Failed)
+- The `--label-id` filter accepts a comma-separated list of label IDs
+- Pagination parameters `--limit` and `--offset` allow you to retrieve tests in manageable batches (default limit: 250)
+- The `--show-all-fields` option displays additional information including custom fields, labels, estimates, and assignments
+- Tests are different from test cases: tests are instances of test cases within a specific run
+
 ### Case Fields Command
 
 The TestRail CLI provides the `casefields` command for retrieving all available test case custom fields from TestRail. This command helps you understand what custom fields are available for test cases, their types, configurations, and which projects they apply to.

--- a/README.md
+++ b/README.md
@@ -2619,6 +2619,30 @@ $ trcli -c config.yml projects list --json-output
 - Pagination parameters `--limit` and `--offset` allow you to retrieve projects in manageable batches
 - The `--show-all-fields` option displays additional information including announcement, users, groups, and default role
 
+### Templates Command
+
+The `templates` command provides functionality to query available templates (field layouts) for test cases in a TestRail project. Templates define which fields are available when creating or editing test cases, such as "Test Case (Text)", "Test Case (Steps)", "Exploratory Session", "Behaviour Driven Development", or "AI Evaluation".
+
+The `templates` command supports one subcommand:
+- **list**: List all templates available for a specific project
+
+#### Listing Templates
+
+The `list` subcommand retrieves all templates (field layouts) for a specific project.
+
+```shell
+# List all templates for a project
+$ trcli -c config.yml templates list --project-id 1
+
+# JSON output
+$ trcli -c config.yml templates list --project-id 1 --json-output
+```
+
+**Note:**
+- The `--project-id` parameter is required and must be a valid project ID (x>=1)
+- Each template has a unique ID, name, and indicates whether it's the default template for the project
+- Templates control which fields are available when creating test cases
+
 ### Case Fields Command
 
 The TestRail CLI provides the `casefields` command for retrieving all available test case custom fields from TestRail. This command helps you understand what custom fields are available for test cases, their types, configurations, and which projects they apply to.

--- a/README.md
+++ b/README.md
@@ -1955,13 +1955,12 @@ $ trcli -c config.yml plans add \
   --json-output
 ```
 
-**Example entries.json file:**
+**JSON File Formats:**
 
-Each entry represents a test run (or group of runs for multi-config scenarios). TestRail requires you to specify which test cases to include using one of these methods:
+TRCLI supports **two JSON formats** for entries files, making it easy to migrate from Bruno/Postman or reuse API request bodies:
 
-1. **Include all cases**: Set `"include_all": true`
-2. **Specific cases**: Provide `"case_ids": [1, 2, 3]`
-3. **Using runs array**: For multi-configuration plans, use `"runs"` with case specifications
+**Format 1: Entries Array (Original)**
+Just the entries array - plan-level fields come from command-line arguments:
 
 ```json
 [
@@ -1992,6 +1991,55 @@ Each entry represents a test run (or group of runs for multi-config scenarios). 
   }
 ]
 ```
+
+**Format 2: Full Plan Object**
+Complete plan structure with plan-level fields - can be copied directly from API tools:
+
+```json
+{
+  "name": "Release 3.0 Testing",
+  "description": "Full regression and feature testing",
+  "milestone_id": 5,
+  "entries": [
+    {
+      "suite_id": 1,
+      "name": "Smoke Tests",
+      "include_all": true
+    },
+    {
+      "suite_id": 2,
+      "name": "Regression Tests",
+      "case_ids": [1, 2, 3, 4, 5]
+    }
+  ]
+}
+```
+
+**Usage:**
+```bash
+# Format 1: Requires --name on command line
+$ trcli plans add --name "Release 3.0" --entries-file entries.json
+
+# Format 2: Name comes from JSON file (command-line args override if provided)
+$ trcli plans add --entries-file full_plan.json
+
+# Command-line arguments always take precedence
+$ trcli plans add --name "CLI Name" --entries-file full_plan.json
+# Note: Using --name 'CLI Name' instead of JSON name 'Release 3.0 Testing'
+```
+
+**Field Priority:**
+- Command-line arguments **always override** JSON file values
+- If no command-line argument provided, value from JSON is used
+- Warnings are shown when command-line overrides JSON values
+
+**Entry Requirements:**
+
+Each entry represents a test run (or group of runs for multi-config scenarios). TestRail requires you to specify which test cases to include:
+
+1. **Include all cases**: Set `"include_all": true`
+2. **Specific cases**: Provide `"case_ids": [1, 2, 3]`
+3. **Using runs array**: For multi-configuration plans, specify cases in the runs array
 
 **Entry Field Reference:**
 - `suite_id` (required): ID of the test suite

--- a/tests/test_cmd_casetypes.py
+++ b/tests/test_cmd_casetypes.py
@@ -1,0 +1,119 @@
+import pytest
+from unittest import mock
+from unittest.mock import MagicMock, patch
+from click.testing import CliRunner
+
+from trcli.cli import Environment
+from trcli.commands import cmd_casetypes
+
+
+class TestCmdCaseTypes:
+    """Test class for casetypes command functionality"""
+
+    def setup_method(self):
+        """Set up test environment"""
+        self.runner = CliRunner()
+        self.environment = Environment(cmd="casetypes")
+        self.environment.host = "https://test.testrail.com"
+        self.environment.username = "test@example.com"
+        self.environment.password = "password"
+        self.environment.api_key = None
+
+    def _setup_project_client_mock(self, mock_project_client):
+        """Helper to setup ProjectBasedClient mock"""
+        mock_client_instance = MagicMock()
+        mock_project_client.return_value = mock_client_instance
+        return mock_client_instance
+
+    @mock.patch("trcli.commands.cmd_casetypes.ProjectBasedClient")
+    def test_list_case_types_success(self, mock_project_client):
+        """Test successful case types listing"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_type_handler.get_case_types.return_value = (
+            [
+                {"id": 1, "is_default": False, "name": "Automated"},
+                {"id": 2, "is_default": False, "name": "Functionality"},
+                {"id": 3, "is_default": False, "name": "Performance"},
+                {"id": 6, "is_default": True, "name": "Other"},
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_casetypes.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.case_type_handler.get_case_types.assert_called_once()
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_casetypes.ProjectBasedClient")
+    def test_list_case_types_json_output(self, mock_project_client):
+        """Test case types listing with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        case_types_data = [
+            {"id": 1, "is_default": False, "name": "Automated"},
+            {"id": 6, "is_default": True, "name": "Other"},
+        ]
+        mock_client.api_request_handler.case_type_handler.get_case_types.return_value = (case_types_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_casetypes.list, ["--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Check for prettified JSON
+            assert '"name": "Automated"' in result.output
+            assert "\n" in result.output
+
+    @mock.patch("trcli.commands.cmd_casetypes.ProjectBasedClient")
+    def test_list_case_types_empty_result(self, mock_project_client):
+        """Test case types listing with no case types (edge case)"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_type_handler.get_case_types.return_value = ([], "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_casetypes.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_casetypes.ProjectBasedClient")
+    def test_list_case_types_api_error(self, mock_project_client):
+        """Test case types listing with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_type_handler.get_case_types.return_value = ([], "Connection timeout")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_casetypes.list, [], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Failed to retrieve case types: Connection timeout")
+
+    @mock.patch("trcli.commands.cmd_casetypes.ProjectBasedClient")
+    def test_list_case_types_default_marked(self, mock_project_client):
+        """Test that default case type is properly marked"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.case_type_handler.get_case_types.return_value = (
+            [
+                {"id": 1, "is_default": False, "name": "Automated"},
+                {"id": 6, "is_default": True, "name": "Other"},
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_casetypes.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Verify DEFAULT marker appears for the default case type
+            log_calls = [str(call) for call in mock_log.call_args_list]
+            assert any("[DEFAULT]" in str(call) for call in log_calls)

--- a/tests/test_cmd_plans.py
+++ b/tests/test_cmd_plans.py
@@ -679,3 +679,81 @@ class TestCmdPlans:
             assert len(call_kwargs["entries"]) == 1
             assert call_kwargs["entries"][0]["config_ids"] == [1, 2]
             assert call_kwargs["entries"][0]["runs"][0]["config_ids"] == [1, 2]
+
+    @mock.patch("trcli.commands.cmd_plans.ProjectBasedClient")
+    def test_add_plan_with_plan_format_json(self, mock_project_client):
+        """Test plan creation with plan-format JSON (includes name, description in JSON)"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.plan_handler.add_plan.return_value = (
+            {
+                "id": 100,
+                "name": "Plan from JSON",
+                "description": "JSON Description",
+                "url": "https://test.testrail.com/index.php?/plans/view/100",
+                "project_id": 1,
+                "entries": [
+                    {
+                        "suite_id": 1,
+                        "name": "Test Run",
+                        "runs": [
+                            {
+                                "id": 1,
+                                "untested_count": 5,
+                                "passed_count": 0,
+                                "failed_count": 0,
+                                "blocked_count": 0,
+                                "retest_count": 0,
+                            }
+                        ],
+                    }
+                ],
+            },
+            "",
+        )
+
+        # Plan format JSON with name, description, entries
+        plan_json = '{"name": "Plan from JSON", "description": "JSON Description", "entries": [{"suite_id": 1, "include_all": true}]}'
+
+        with patch.object(self.environment, "log"), patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_plans.add, ["--entries", plan_json], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Verify that add_plan was called with values from JSON
+            call_kwargs = mock_client.api_request_handler.plan_handler.add_plan.call_args[1]
+            assert call_kwargs["name"] == "Plan from JSON"
+            assert call_kwargs["description"] == "JSON Description"
+            assert call_kwargs["entries"] is not None
+
+    @mock.patch("trcli.commands.cmd_plans.ProjectBasedClient")
+    def test_add_plan_cli_overrides_json(self, mock_project_client):
+        """Test that CLI arguments override JSON values"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.plan_handler.add_plan.return_value = (
+            {
+                "id": 100,
+                "name": "CLI Plan Name",
+                "url": "https://test.testrail.com/index.php?/plans/view/100",
+                "project_id": 1,
+                "entries": [],
+            },
+            "",
+        )
+
+        # JSON with name, but CLI also provides name
+        plan_json = '{"name": "JSON Plan Name", "entries": [{"suite_id": 1, "include_all": true}]}'
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_plans.add, ["--name", "CLI Plan Name", "--entries", plan_json], obj=self.environment
+            )
+
+            assert result.exit_code == 0
+            # Verify CLI name was used
+            call_kwargs = mock_client.api_request_handler.plan_handler.add_plan.call_args[1]
+            assert call_kwargs["name"] == "CLI Plan Name"
+            # Verify warning was logged
+            mock_log.assert_any_call("Note: Using --name 'CLI Plan Name' instead of JSON name 'JSON Plan Name'")

--- a/tests/test_cmd_plans.py
+++ b/tests/test_cmd_plans.py
@@ -422,3 +422,260 @@ class TestCmdPlans:
             mock_client.api_request_handler.plan_handler.get_plans.assert_called_once_with(
                 project_id=99, limit=250, offset=0
             )
+
+    @mock.patch("trcli.commands.cmd_plans.ProjectBasedClient")
+    def test_add_plan_success(self, mock_project_client):
+        """Test successful plan creation"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.plan_handler.add_plan.return_value = (
+            {
+                "id": 100,
+                "name": "Test Plan",
+                "description": "Test Description",
+                "url": "https://test.testrail.com/index.php?/plans/view/100",
+                "project_id": 1,
+                "entries": [],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_plans.add, ["--name", "Test Plan"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.resolve_project.assert_called_once()
+            mock_client.api_request_handler.plan_handler.add_plan.assert_called_once()
+
+    @mock.patch("trcli.commands.cmd_plans.ProjectBasedClient")
+    def test_add_plan_with_description(self, mock_project_client):
+        """Test plan creation with description"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.plan_handler.add_plan.return_value = (
+            {
+                "id": 100,
+                "name": "Test Plan",
+                "description": "Test Description",
+                "url": "https://test.testrail.com/index.php?/plans/view/100",
+                "project_id": 1,
+                "entries": [],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log"), patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(
+                cmd_plans.add, ["--name", "Test Plan", "--description", "Test Description"], obj=self.environment
+            )
+
+            assert result.exit_code == 0
+
+    @mock.patch("trcli.commands.cmd_plans.ProjectBasedClient")
+    def test_add_plan_with_entries_json(self, mock_project_client):
+        """Test plan creation with entries as JSON string"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.plan_handler.add_plan.return_value = (
+            {
+                "id": 100,
+                "name": "Test Plan",
+                "url": "https://test.testrail.com/index.php?/plans/view/100",
+                "project_id": 1,
+                "entries": [
+                    {
+                        "suite_id": 1,
+                        "name": "Test Run",
+                        "runs": [
+                            {
+                                "id": 1,
+                                "untested_count": 5,
+                                "passed_count": 0,
+                                "failed_count": 0,
+                                "blocked_count": 0,
+                                "retest_count": 0,
+                            }
+                        ],
+                    }
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log"), patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(
+                cmd_plans.add, ["--name", "Test Plan", "--entries", '[{"suite_id": 1}]'], obj=self.environment
+            )
+
+            assert result.exit_code == 0
+
+    @mock.patch("trcli.commands.cmd_plans.ProjectBasedClient")
+    def test_add_plan_api_error(self, mock_project_client):
+        """Test handling of API errors when creating plan"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.plan_handler.add_plan.return_value = ({}, "API Error")
+
+        with patch.object(self.environment, "log"), patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ), patch.object(self.environment, "elog") as mock_elog:
+            result = self.runner.invoke(cmd_plans.add, ["--name", "Test Plan"], obj=self.environment)
+
+            assert result.exit_code == 1
+            assert mock_elog.called
+
+    @mock.patch("trcli.commands.cmd_plans.ProjectBasedClient")
+    def test_add_plan_json_output(self, mock_project_client):
+        """Test plan creation with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.plan_handler.add_plan.return_value = (
+            {
+                "id": 100,
+                "name": "Test Plan",
+                "url": "https://test.testrail.com/index.php?/plans/view/100",
+                "project_id": 1,
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log"), patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_plans.add, ["--name", "Test Plan", "--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert '"id": 100' in result.output
+            assert '"name": "Test Plan"' in result.output
+
+    def test_add_plan_invalid_entries_json(self):
+        """Test validation of invalid JSON in entries parameter"""
+        result = self.runner.invoke(
+            cmd_plans.add, ["--name", "Test Plan", "--entries", "invalid json"], obj=self.environment
+        )
+
+        assert result.exit_code == 1
+
+    @mock.patch("trcli.commands.cmd_plans.ProjectBasedClient")
+    def test_add_plan_with_dates(self, mock_project_client):
+        """Test plan creation with start and due dates in MM/DD/YYYY format"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.plan_handler.add_plan.return_value = (
+            {
+                "id": 100,
+                "name": "Test Plan",
+                "url": "https://test.testrail.com/index.php?/plans/view/100",
+                "project_id": 1,
+                "entries": [],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log"), patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(
+                cmd_plans.add,
+                ["--name", "Test Plan", "--start-on", "01/15/2022", "--due-on", "02/15/2022"],
+                obj=self.environment,
+            )
+
+            assert result.exit_code == 0
+            # Verify that add_plan was called with converted timestamps
+            call_kwargs = mock_client.api_request_handler.plan_handler.add_plan.call_args[1]
+            assert call_kwargs["start_on"] is not None
+            assert call_kwargs["due_on"] is not None
+            # Verify timestamps are integers
+            assert isinstance(call_kwargs["start_on"], int)
+            assert isinstance(call_kwargs["due_on"], int)
+
+    def test_add_plan_mutually_exclusive_entries(self):
+        """Test validation of mutually exclusive --entries and --entries-file"""
+        import tempfile
+        import os
+
+        # Create a temporary file for entries-file parameter
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("[]")
+            temp_file = f.name
+
+        try:
+            with patch.object(self.environment, "check_for_required_parameters"), patch.object(
+                self.environment, "elog"
+            ) as mock_elog:
+                result = self.runner.invoke(
+                    cmd_plans.add,
+                    ["--name", "Test Plan", "--entries", "[]", "--entries-file", temp_file],
+                    obj=self.environment,
+                )
+
+                assert result.exit_code == 1
+                assert mock_elog.called
+                assert "cannot be used together" in str(mock_elog.call_args)
+        finally:
+            # Clean up temp file
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)
+
+    @mock.patch("trcli.commands.cmd_plans.ProjectBasedClient")
+    def test_add_plan_with_multi_config_entries(self, mock_project_client):
+        """Test plan creation with multi-configuration entries"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.plan_handler.add_plan.return_value = (
+            {
+                "id": 100,
+                "name": "Multi-Config Plan",
+                "url": "https://test.testrail.com/index.php?/plans/view/100",
+                "project_id": 1,
+                "entries": [
+                    {
+                        "suite_id": 1,
+                        "name": "Browser Tests",
+                        "config_ids": [1, 2],
+                        "runs": [
+                            {
+                                "id": 1,
+                                "name": "Browser Tests - Chrome",
+                                "config": "Chrome",
+                                "untested_count": 5,
+                                "passed_count": 0,
+                                "failed_count": 0,
+                                "blocked_count": 0,
+                                "retest_count": 0,
+                            },
+                            {
+                                "id": 2,
+                                "name": "Browser Tests - Firefox",
+                                "config": "Firefox",
+                                "untested_count": 5,
+                                "passed_count": 0,
+                                "failed_count": 0,
+                                "blocked_count": 0,
+                                "retest_count": 0,
+                            },
+                        ],
+                    }
+                ],
+            },
+            "",
+        )
+
+        entries_json = '[{"suite_id": 1, "name": "Browser Tests", "config_ids": [1, 2], "runs": [{"config_ids": [1, 2], "case_ids": [10, 11, 12]}]}]'
+
+        with patch.object(self.environment, "log"), patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(
+                cmd_plans.add, ["--name", "Multi-Config Plan", "--entries", entries_json], obj=self.environment
+            )
+
+            assert result.exit_code == 0
+            # Verify that add_plan was called
+            mock_client.api_request_handler.plan_handler.add_plan.assert_called_once()
+            # Verify the entries structure was passed correctly
+            call_kwargs = mock_client.api_request_handler.plan_handler.add_plan.call_args[1]
+            assert call_kwargs["entries"] is not None
+            assert len(call_kwargs["entries"]) == 1
+            assert call_kwargs["entries"][0]["config_ids"] == [1, 2]
+            assert call_kwargs["entries"][0]["runs"][0]["config_ids"] == [1, 2]

--- a/tests/test_cmd_priorities.py
+++ b/tests/test_cmd_priorities.py
@@ -1,0 +1,199 @@
+import pytest
+from unittest import mock
+from unittest.mock import MagicMock, patch
+from click.testing import CliRunner
+
+from trcli.cli import Environment
+from trcli.commands import cmd_priorities
+
+
+class TestCmdPriorities:
+    """Test class for priorities command functionality"""
+
+    def setup_method(self):
+        """Set up test environment"""
+        self.runner = CliRunner()
+        self.environment = Environment(cmd="priorities")
+        self.environment.host = "https://test.testrail.com"
+        self.environment.username = "test@example.com"
+        self.environment.password = "password"
+        self.environment.api_key = None
+
+    def _setup_project_client_mock(self, mock_project_client):
+        """Helper to setup ProjectBasedClient mock"""
+        mock_client_instance = MagicMock()
+        mock_project_client.return_value = mock_client_instance
+        return mock_client_instance
+
+    @mock.patch("trcli.commands.cmd_priorities.ProjectBasedClient")
+    def test_list_priorities_success(self, mock_project_client):
+        """Test successful priorities listing"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.priority_handler.get_priorities.return_value = (
+            [
+                {
+                    "id": 1,
+                    "is_default": False,
+                    "name": "1 - Don't Test",
+                    "priority": 1,
+                    "short_name": "1 - Don't",
+                },
+                {
+                    "id": 2,
+                    "is_default": False,
+                    "name": "2 - Low",
+                    "priority": 2,
+                    "short_name": "2 - Low",
+                },
+                {
+                    "id": 3,
+                    "is_default": False,
+                    "name": "3 - Medium",
+                    "priority": 3,
+                    "short_name": "3 - Med",
+                },
+                {
+                    "id": 4,
+                    "is_default": True,
+                    "name": "4 - Must Test",
+                    "priority": 4,
+                    "short_name": "4 - Must",
+                },
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_priorities.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.priority_handler.get_priorities.assert_called_once()
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_priorities.ProjectBasedClient")
+    def test_list_priorities_json_output(self, mock_project_client):
+        """Test priorities listing with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        priorities_data = [
+            {
+                "id": 1,
+                "is_default": False,
+                "name": "1 - Don't Test",
+                "priority": 1,
+                "short_name": "1 - Don't",
+            },
+            {
+                "id": 4,
+                "is_default": True,
+                "name": "4 - Must Test",
+                "priority": 4,
+                "short_name": "4 - Must",
+            },
+        ]
+        mock_client.api_request_handler.priority_handler.get_priorities.return_value = (priorities_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_priorities.list, ["--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Check for prettified JSON
+            assert '"name": "4 - Must Test"' in result.output
+            assert "\n" in result.output
+
+    @mock.patch("trcli.commands.cmd_priorities.ProjectBasedClient")
+    def test_list_priorities_show_all_fields(self, mock_project_client):
+        """Test priorities listing with show all fields"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.priority_handler.get_priorities.return_value = (
+            [
+                {
+                    "id": 1,
+                    "is_default": False,
+                    "name": "1 - Don't Test",
+                    "priority": 1,
+                    "short_name": "1 - Don't",
+                },
+                {
+                    "id": 4,
+                    "is_default": True,
+                    "name": "4 - Must Test",
+                    "priority": 4,
+                    "short_name": "4 - Must",
+                },
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_priorities.list, ["--show-all-fields"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_priorities.ProjectBasedClient")
+    def test_list_priorities_empty_result(self, mock_project_client):
+        """Test priorities listing with no priorities (edge case)"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.priority_handler.get_priorities.return_value = ([], "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_priorities.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_priorities.ProjectBasedClient")
+    def test_list_priorities_api_error(self, mock_project_client):
+        """Test priorities listing with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.priority_handler.get_priorities.return_value = ([], "Connection timeout")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_priorities.list, [], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Failed to retrieve priorities: Connection timeout")
+
+    @mock.patch("trcli.commands.cmd_priorities.ProjectBasedClient")
+    def test_list_priorities_default_marked(self, mock_project_client):
+        """Test that default priority is properly marked"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.priority_handler.get_priorities.return_value = (
+            [
+                {
+                    "id": 2,
+                    "is_default": False,
+                    "name": "2 - Low",
+                    "priority": 2,
+                    "short_name": "2 - Low",
+                },
+                {
+                    "id": 3,
+                    "is_default": True,
+                    "name": "3 - Medium",
+                    "priority": 3,
+                    "short_name": "3 - Med",
+                },
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_priorities.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Verify DEFAULT marker appears for the default priority
+            log_calls = [str(call) for call in mock_log.call_args_list]
+            assert any("[DEFAULT]" in str(call) for call in log_calls)

--- a/tests/test_cmd_projects.py
+++ b/tests/test_cmd_projects.py
@@ -1,0 +1,255 @@
+import pytest
+from unittest import mock
+from unittest.mock import MagicMock, patch
+from click.testing import CliRunner
+
+from trcli.cli import Environment
+from trcli.commands import cmd_projects
+
+
+class TestCmdProjects:
+    """Test suite for the projects command."""
+
+    def setup_method(self):
+        """Set up test environment"""
+        self.runner = CliRunner()
+        self.environment = Environment(cmd="projects")
+        self.environment.host = "https://test.testrail.com"
+        self.environment.username = "test@example.com"
+        self.environment.password = "password"
+        self.environment.api_key = None
+
+    def _setup_project_client_mock(self, mock_project_client):
+        """Helper to setup ProjectBasedClient mock"""
+        mock_client_instance = MagicMock()
+        mock_project_client.return_value = mock_client_instance
+        return mock_client_instance
+
+    @mock.patch("trcli.commands.cmd_projects.ProjectBasedClient")
+    def test_get_project_success(self, mock_project_client):
+        """Test successful project retrieval by ID."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.project_handler.get_project.return_value = (
+            {"id": 1, "name": "Test Project", "is_completed": False, "suite_mode": 3},
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_projects.get, ["--project-id", "1"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+            mock_client.api_request_handler.project_handler.get_project.assert_called_once_with(1)
+
+    @mock.patch("trcli.commands.cmd_projects.ProjectBasedClient")
+    def test_get_project_with_all_fields(self, mock_project_client):
+        """Test project retrieval with all fields displayed."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.project_handler.get_project.return_value = (
+            {
+                "id": 1,
+                "name": "Test Project",
+                "announcement": "Welcome!",
+                "completed_on": 1389968184,
+                "default_role_id": 3,
+                "default_role": "Tester",
+                "is_completed": False,
+                "show_announcement": True,
+                "suite_mode": 3,
+                "url": "https://test.testrail.io/projects/1",
+                "users": [{"id": 5}],
+                "groups": [],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_projects.get, ["--project-id", "1", "--show-all-fields"], obj=self.environment
+            )
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_projects.ProjectBasedClient")
+    def test_get_project_json_output(self, mock_project_client):
+        """Test project retrieval with JSON output."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.project_handler.get_project.return_value = (
+            {"id": 1, "name": "Test Project", "is_completed": False, "suite_mode": 3},
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_projects.get, ["--project-id", "1", "--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert '"id": 1' in result.output
+            assert '"name": "Test Project"' in result.output
+
+    @mock.patch("trcli.commands.cmd_projects.ProjectBasedClient")
+    def test_get_project_api_error(self, mock_project_client):
+        """Test handling of API errors when getting a project."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.project_handler.get_project.return_value = (
+            None,
+            "Project not found",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"), patch.object(
+            self.environment, "elog"
+        ) as mock_elog:
+            result = self.runner.invoke(cmd_projects.get, ["--project-id", "999"], obj=self.environment)
+
+            assert result.exit_code == 1
+            assert mock_elog.called
+
+    @mock.patch("trcli.commands.cmd_projects.ProjectBasedClient")
+    def test_list_projects_success(self, mock_project_client):
+        """Test successful listing of all projects."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.project_handler.get_projects.return_value = (
+            [
+                {"id": 1, "name": "Project A", "is_completed": False, "suite_mode": 1},
+                {"id": 2, "name": "Project B", "is_completed": True, "suite_mode": 3},
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_projects.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+            mock_client.api_request_handler.project_handler.get_projects.assert_called_once_with(
+                is_completed=None, limit=None, offset=None
+            )
+
+    @mock.patch("trcli.commands.cmd_projects.ProjectBasedClient")
+    def test_list_projects_with_filters(self, mock_project_client):
+        """Test listing projects with filters (is_completed, limit, offset)."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.project_handler.get_projects.return_value = (
+            [{"id": 1, "name": "Active Project", "is_completed": False, "suite_mode": 1}],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_projects.list, ["--is-completed", "0", "--limit", "10", "--offset", "5"], obj=self.environment
+            )
+
+            assert result.exit_code == 0
+            assert mock_log.called
+            mock_client.api_request_handler.project_handler.get_projects.assert_called_once_with(
+                is_completed=0, limit=10, offset=5
+            )
+
+    @mock.patch("trcli.commands.cmd_projects.ProjectBasedClient")
+    def test_list_projects_completed_only(self, mock_project_client):
+        """Test listing only completed projects."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.project_handler.get_projects.return_value = (
+            [{"id": 2, "name": "Completed Project", "is_completed": True, "suite_mode": 2}],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_projects.list, ["--is-completed", "1"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+            mock_client.api_request_handler.project_handler.get_projects.assert_called_once_with(
+                is_completed=1, limit=None, offset=None
+            )
+
+    @mock.patch("trcli.commands.cmd_projects.ProjectBasedClient")
+    def test_list_projects_json_output(self, mock_project_client):
+        """Test listing projects with JSON output."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.project_handler.get_projects.return_value = (
+            [
+                {"id": 1, "name": "Project A", "is_completed": False, "suite_mode": 1},
+                {"id": 2, "name": "Project B", "is_completed": True, "suite_mode": 3},
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_projects.list, ["--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert '"id": 1' in result.output
+            assert '"name": "Project A"' in result.output
+
+    @mock.patch("trcli.commands.cmd_projects.ProjectBasedClient")
+    def test_list_projects_empty_result(self, mock_project_client):
+        """Test listing projects when no results are found."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.project_handler.get_projects.return_value = ([], "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_projects.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_projects.ProjectBasedClient")
+    def test_list_projects_api_error(self, mock_project_client):
+        """Test handling of API errors when listing projects."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.project_handler.get_projects.return_value = (
+            [],
+            "Connection error",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"), patch.object(
+            self.environment, "elog"
+        ) as mock_elog:
+            result = self.runner.invoke(cmd_projects.list, [], obj=self.environment)
+
+            assert result.exit_code == 1
+            assert mock_elog.called
+
+    @mock.patch("trcli.commands.cmd_projects.ProjectBasedClient")
+    def test_list_projects_with_pagination(self, mock_project_client):
+        """Test listing projects with pagination parameters."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.project_handler.get_projects.return_value = (
+            [
+                {"id": 11, "name": "Project 11", "is_completed": False, "suite_mode": 1},
+                {"id": 12, "name": "Project 12", "is_completed": False, "suite_mode": 1},
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_projects.list, ["--limit", "2", "--offset", "10"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+            mock_client.api_request_handler.project_handler.get_projects.assert_called_once_with(
+                is_completed=None, limit=2, offset=10
+            )

--- a/tests/test_cmd_projects.py
+++ b/tests/test_cmd_projects.py
@@ -253,3 +253,50 @@ class TestCmdProjects:
             mock_client.api_request_handler.project_handler.get_projects.assert_called_once_with(
                 is_completed=None, limit=2, offset=10
             )
+
+    def test_get_project_invalid_id_zero(self):
+        """Test validation rejects project ID of 0."""
+        result = self.runner.invoke(cmd_projects.get, ["--project-id", "0"], obj=self.environment)
+
+        assert result.exit_code != 0
+        assert "0 is not in the range x>=1" in result.output
+
+    def test_get_project_invalid_id_negative(self):
+        """Test validation rejects negative project ID."""
+        result = self.runner.invoke(cmd_projects.get, ["--project-id", "-1"], obj=self.environment)
+
+        assert result.exit_code != 0
+        assert "-1 is not in the range x>=1" in result.output
+
+    @mock.patch("trcli.commands.cmd_projects.ProjectBasedClient")
+    def test_get_project_with_groups(self, mock_project_client):
+        """Test project retrieval with groups displayed."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.project_handler.get_project.return_value = (
+            {
+                "id": 1,
+                "name": "Test Project",
+                "is_completed": False,
+                "suite_mode": 3,
+                "users": [{"user_id": 2, "global_role": "Tester", "project_role": "Tester"}],
+                "groups": [
+                    {"id": 1, "role": "Tester", "role_id": 3},
+                    {"id": 2, "role": "Designer", "role_id": 2},
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_projects.get, ["--project-id", "1", "--show-all-fields"], obj=self.environment
+            )
+
+            assert result.exit_code == 0
+            assert mock_log.called
+            # Verify groups are mentioned in logs
+            log_calls = [str(call) for call in mock_log.call_args_list]
+            groups_mentioned = any("Groups: 2 group(s)" in str(call) for call in log_calls)
+            assert groups_mentioned

--- a/tests/test_cmd_templates.py
+++ b/tests/test_cmd_templates.py
@@ -1,0 +1,152 @@
+import pytest
+from unittest import mock
+from unittest.mock import MagicMock, patch
+from click.testing import CliRunner
+
+from trcli.cli import Environment
+from trcli.commands import cmd_templates
+
+
+class TestCmdTemplates:
+    """Test suite for the templates command."""
+
+    def setup_method(self):
+        """Set up test environment"""
+        self.runner = CliRunner()
+        self.environment = Environment(cmd="templates")
+        self.environment.host = "https://test.testrail.com"
+        self.environment.username = "test@example.com"
+        self.environment.password = "password"
+        self.environment.api_key = None
+
+    def _setup_project_client_mock(self, mock_project_client):
+        """Helper to setup ProjectBasedClient mock"""
+        mock_client_instance = MagicMock()
+        mock_project_client.return_value = mock_client_instance
+        return mock_client_instance
+
+    @mock.patch("trcli.commands.cmd_templates.ProjectBasedClient")
+    def test_list_templates_success(self, mock_project_client):
+        """Test successful listing of templates."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.template_handler.get_templates.return_value = (
+            [
+                {"id": 1, "name": "Test Case (Text)", "i18n_custom_id": "templates_test_case_text", "is_default": True},
+                {
+                    "id": 2,
+                    "name": "Test Case (Steps)",
+                    "i18n_custom_id": "templates_test_case_steps",
+                    "is_default": False,
+                },
+                {"id": 5, "name": "AI Evaluation", "i18n_custom_id": "templates_ai_evaluation", "is_default": False},
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_templates.list, ["--project-id", "1"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+            mock_client.api_request_handler.template_handler.get_templates.assert_called_once_with(1)
+
+    @mock.patch("trcli.commands.cmd_templates.ProjectBasedClient")
+    def test_list_templates_json_output(self, mock_project_client):
+        """Test listing templates with JSON output."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.template_handler.get_templates.return_value = (
+            [
+                {"id": 1, "name": "Test Case (Text)", "i18n_custom_id": "templates_test_case_text", "is_default": True},
+                {
+                    "id": 2,
+                    "name": "Test Case (Steps)",
+                    "i18n_custom_id": "templates_test_case_steps",
+                    "is_default": False,
+                },
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_templates.list, ["--project-id", "1", "--json-output"], obj=self.environment
+            )
+
+            assert result.exit_code == 0
+            assert '"id": 1' in result.output
+            assert '"name": "Test Case (Text)"' in result.output
+
+    @mock.patch("trcli.commands.cmd_templates.ProjectBasedClient")
+    def test_list_templates_empty_result(self, mock_project_client):
+        """Test listing templates when no results are found."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.template_handler.get_templates.return_value = ([], "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_templates.list, ["--project-id", "1"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_templates.ProjectBasedClient")
+    def test_list_templates_api_error(self, mock_project_client):
+        """Test handling of API errors when listing templates."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.template_handler.get_templates.return_value = (
+            [],
+            "Project not found",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"), patch.object(
+            self.environment, "elog"
+        ) as mock_elog:
+            result = self.runner.invoke(cmd_templates.list, ["--project-id", "999"], obj=self.environment)
+
+            assert result.exit_code == 1
+            assert mock_elog.called
+
+    def test_list_templates_invalid_id_zero(self):
+        """Test validation rejects project ID of 0."""
+        result = self.runner.invoke(cmd_templates.list, ["--project-id", "0"], obj=self.environment)
+
+        assert result.exit_code != 0
+        assert "0 is not in the range x>=1" in result.output
+
+    def test_list_templates_invalid_id_negative(self):
+        """Test validation rejects negative project ID."""
+        result = self.runner.invoke(cmd_templates.list, ["--project-id", "-1"], obj=self.environment)
+
+        assert result.exit_code != 0
+        assert "-1 is not in the range x>=1" in result.output
+
+    @mock.patch("trcli.commands.cmd_templates.ProjectBasedClient")
+    def test_list_templates_displays_default_flag(self, mock_project_client):
+        """Test that templates correctly show default flag."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.template_handler.get_templates.return_value = (
+            [
+                {"id": 1, "name": "Test Case (Text)", "i18n_custom_id": "templates_test_case_text", "is_default": True},
+                {"id": 5, "name": "AI Evaluation", "i18n_custom_id": "templates_ai_evaluation", "is_default": False},
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_templates.list, ["--project-id", "1"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Verify default flag is mentioned in logs
+            log_calls = [str(call) for call in mock_log.call_args_list]
+            default_yes = any("Default: Yes" in str(call) for call in log_calls)
+            default_no = any("Default: No" in str(call) for call in log_calls)
+            assert default_yes and default_no

--- a/tests/test_cmd_tests.py
+++ b/tests/test_cmd_tests.py
@@ -1,0 +1,289 @@
+import pytest
+from unittest import mock
+from unittest.mock import MagicMock, patch
+from click.testing import CliRunner
+
+from trcli.cli import Environment
+from trcli.commands import cmd_tests
+
+
+class TestCmdTests:
+    """Test suite for the tests command."""
+
+    def setup_method(self):
+        """Set up test environment"""
+        self.runner = CliRunner()
+        self.environment = Environment(cmd="tests")
+        self.environment.host = "https://test.testrail.com"
+        self.environment.username = "test@example.com"
+        self.environment.password = "password"
+        self.environment.api_key = None
+
+    def _setup_project_client_mock(self, mock_project_client):
+        """Helper to setup ProjectBasedClient mock"""
+        mock_client_instance = MagicMock()
+        mock_project_client.return_value = mock_client_instance
+        return mock_client_instance
+
+    @mock.patch("trcli.commands.cmd_tests.ProjectBasedClient")
+    def test_get_test_success(self, mock_project_client):
+        """Test successful test retrieval by ID."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.test_handler.get_test.return_value = (
+            {
+                "id": 100,
+                "title": "Verify line spacing",
+                "case_id": 1,
+                "run_id": 1,
+                "status_id": 5,
+                "assignedto_id": 1,
+                "priority_id": 2,
+                "type_id": 4,
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_tests.get, ["--test-id", "100"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+            mock_client.api_request_handler.test_handler.get_test.assert_called_once_with(100, None)
+
+    @mock.patch("trcli.commands.cmd_tests.ProjectBasedClient")
+    def test_get_test_json_output(self, mock_project_client):
+        """Test test retrieval with JSON output."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.test_handler.get_test.return_value = (
+            {"id": 100, "title": "Verify line spacing", "case_id": 1, "run_id": 1, "status_id": 5},
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_tests.get, ["--test-id", "100", "--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert '"id": 100' in result.output
+            assert '"title": "Verify line spacing"' in result.output
+
+    @mock.patch("trcli.commands.cmd_tests.ProjectBasedClient")
+    def test_get_test_api_error(self, mock_project_client):
+        """Test handling of API errors when getting a test."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.test_handler.get_test.return_value = (None, "Test not found")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"), patch.object(
+            self.environment, "elog"
+        ) as mock_elog:
+            result = self.runner.invoke(cmd_tests.get, ["--test-id", "999"], obj=self.environment)
+
+            assert result.exit_code == 1
+            assert mock_elog.called
+
+    @mock.patch("trcli.commands.cmd_tests.ProjectBasedClient")
+    def test_list_tests_success(self, mock_project_client):
+        """Test successful listing of all tests."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.test_handler.get_tests.return_value = (
+            [
+                {"id": 1, "title": "Test 1", "case_id": 1, "run_id": 1, "status_id": 1},
+                {"id": 2, "title": "Test 2", "case_id": 2, "run_id": 1, "status_id": 5},
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_tests.list, ["--run-id", "1"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+            mock_client.api_request_handler.test_handler.get_tests.assert_called_once_with(
+                run_id=1, status_id=None, limit=None, offset=None, label_id=None
+            )
+
+    @mock.patch("trcli.commands.cmd_tests.ProjectBasedClient")
+    def test_list_tests_with_filters(self, mock_project_client):
+        """Test listing tests with filters (status_id, limit, offset)."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.test_handler.get_tests.return_value = (
+            [{"id": 1, "title": "Failed Test", "case_id": 1, "run_id": 1, "status_id": 5}],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_tests.list,
+                ["--run-id", "1", "--status-id", "4,5", "--limit", "10", "--offset", "5"],
+                obj=self.environment,
+            )
+
+            assert result.exit_code == 0
+            assert mock_log.called
+            mock_client.api_request_handler.test_handler.get_tests.assert_called_once_with(
+                run_id=1, status_id="4,5", limit=10, offset=5, label_id=None
+            )
+
+    @mock.patch("trcli.commands.cmd_tests.ProjectBasedClient")
+    def test_list_tests_with_label_filter(self, mock_project_client):
+        """Test listing tests with label filter."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.test_handler.get_tests.return_value = (
+            [{"id": 1, "title": "Labeled Test", "case_id": 1, "run_id": 1, "status_id": 1}],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_tests.list, ["--run-id", "1", "--label-id", "1,2"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+            mock_client.api_request_handler.test_handler.get_tests.assert_called_once_with(
+                run_id=1, status_id=None, limit=None, offset=None, label_id="1,2"
+            )
+
+    @mock.patch("trcli.commands.cmd_tests.ProjectBasedClient")
+    def test_list_tests_json_output(self, mock_project_client):
+        """Test listing tests with JSON output."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.test_handler.get_tests.return_value = (
+            [
+                {"id": 1, "title": "Test 1", "case_id": 1, "run_id": 1, "status_id": 1},
+                {"id": 2, "title": "Test 2", "case_id": 2, "run_id": 1, "status_id": 5},
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_tests.list, ["--run-id", "1", "--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert '"id": 1' in result.output
+            assert '"title": "Test 1"' in result.output
+
+    @mock.patch("trcli.commands.cmd_tests.ProjectBasedClient")
+    def test_list_tests_empty_result(self, mock_project_client):
+        """Test listing tests when no results are found."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.test_handler.get_tests.return_value = ([], "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_tests.list, ["--run-id", "1"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_tests.ProjectBasedClient")
+    def test_list_tests_api_error(self, mock_project_client):
+        """Test handling of API errors when listing tests."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.test_handler.get_tests.return_value = ([], "Run not found")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"), patch.object(
+            self.environment, "elog"
+        ) as mock_elog:
+            result = self.runner.invoke(cmd_tests.list, ["--run-id", "999"], obj=self.environment)
+
+            assert result.exit_code == 1
+            assert mock_elog.called
+
+    @mock.patch("trcli.commands.cmd_tests.ProjectBasedClient")
+    def test_list_tests_with_pagination(self, mock_project_client):
+        """Test listing tests with pagination parameters."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.test_handler.get_tests.return_value = (
+            [
+                {"id": 11, "title": "Test 11", "case_id": 11, "run_id": 1, "status_id": 1},
+                {"id": 12, "title": "Test 12", "case_id": 12, "run_id": 1, "status_id": 1},
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_tests.list, ["--run-id", "1", "--limit", "2", "--offset", "10"], obj=self.environment
+            )
+
+            assert result.exit_code == 0
+            assert mock_log.called
+            mock_client.api_request_handler.test_handler.get_tests.assert_called_once_with(
+                run_id=1, status_id=None, limit=2, offset=10, label_id=None
+            )
+
+    def test_get_test_invalid_id_zero(self):
+        """Test validation rejects test ID of 0."""
+        result = self.runner.invoke(cmd_tests.get, ["--test-id", "0"], obj=self.environment)
+
+        assert result.exit_code != 0
+        assert "0 is not in the range x>=1" in result.output
+
+    def test_get_test_invalid_id_negative(self):
+        """Test validation rejects negative test ID."""
+        result = self.runner.invoke(cmd_tests.get, ["--test-id", "-1"], obj=self.environment)
+
+        assert result.exit_code != 0
+        assert "-1 is not in the range x>=1" in result.output
+
+    def test_list_tests_invalid_run_id_zero(self):
+        """Test validation rejects run ID of 0."""
+        result = self.runner.invoke(cmd_tests.list, ["--run-id", "0"], obj=self.environment)
+
+        assert result.exit_code != 0
+        assert "0 is not in the range x>=1" in result.output
+
+    def test_list_tests_invalid_run_id_negative(self):
+        """Test validation rejects negative run ID."""
+        result = self.runner.invoke(cmd_tests.list, ["--run-id", "-1"], obj=self.environment)
+
+        assert result.exit_code != 0
+        assert "-1 is not in the range x>=1" in result.output
+
+    @mock.patch("trcli.commands.cmd_tests.ProjectBasedClient")
+    def test_get_test_with_labels(self, mock_project_client):
+        """Test test retrieval with labels displayed."""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.test_handler.get_test.return_value = (
+            {
+                "id": 100,
+                "title": "Test with labels",
+                "case_id": 1,
+                "run_id": 1,
+                "status_id": 5,
+                "labels": [
+                    {"id": 1, "title": "label1"},
+                    {"id": 2, "title": "label2"},
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_tests.get, ["--test-id", "100", "--show-all-fields"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+            # Verify labels are mentioned in logs
+            log_calls = [str(call) for call in mock_log.call_args_list]
+            labels_mentioned = any("Labels: 2 label(s)" in str(call) for call in log_calls)
+            assert labels_mentioned

--- a/tests/test_cmd_users.py
+++ b/tests/test_cmd_users.py
@@ -1,0 +1,262 @@
+import pytest
+from unittest import mock
+from unittest.mock import MagicMock, patch
+from click.testing import CliRunner
+
+from trcli.cli import Environment
+from trcli.commands import cmd_users
+
+
+class TestCmdUsers:
+    """Test class for users command functionality"""
+
+    def setup_method(self):
+        """Set up test environment"""
+        self.runner = CliRunner()
+        self.environment = Environment(cmd="users")
+        self.environment.host = "https://test.testrail.com"
+        self.environment.username = "test@example.com"
+        self.environment.password = "password"
+        self.environment.api_key = None
+
+    def _setup_project_client_mock(self, mock_project_client):
+        """Helper to setup ProjectBasedClient mock"""
+        mock_client_instance = MagicMock()
+        mock_project_client.return_value = mock_client_instance
+        return mock_client_instance
+
+    # GET subcommand tests
+
+    @mock.patch("trcli.commands.cmd_users.ProjectBasedClient")
+    def test_get_current_user_success(self, mock_project_client):
+        """Test getting current authenticated user"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.user_handler.get_current_user.return_value = (
+            {
+                "id": 1,
+                "email": "test@example.com",
+                "is_active": True,
+                "name": "Test User",
+                "role_id": 3,
+                "role": "Tester",
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_users.get, ["--current"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.user_handler.get_current_user.assert_called_once()
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_users.ProjectBasedClient")
+    def test_get_user_by_id_success(self, mock_project_client):
+        """Test getting user by ID"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.user_handler.get_user.return_value = (
+            {"id": 5, "email": "john.doe@example.com", "name": "John Doe", "role": "Tester", "is_active": True},
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_users.get, ["--user-id", "5"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.user_handler.get_user.assert_called_once_with(5)
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_users.ProjectBasedClient")
+    def test_get_user_by_email_success(self, mock_project_client):
+        """Test getting user by email"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.user_handler.get_user_by_email.return_value = (
+            {"id": 3, "email": "jane@example.com", "name": "Jane Smith", "role": "Lead", "is_active": True},
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_users.get, ["--email", "jane@example.com"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.user_handler.get_user_by_email.assert_called_once_with("jane@example.com")
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_users.ProjectBasedClient")
+    def test_get_user_with_all_fields(self, mock_project_client):
+        """Test getting user with all fields displayed"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.user_handler.get_user.return_value = (
+            {
+                "id": 1,
+                "email": "admin@example.com",
+                "name": "Admin User",
+                "role": "Administrator",
+                "role_id": 1,
+                "is_active": True,
+                "is_admin": True,
+                "group_ids": [1, 2, 3],
+                "mfa_required": True,
+                "email_notifications": True,
+                "sso_enabled": False,
+                "assigned_projects": [1, 3, 5],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_users.get, ["--user-id", "1", "--show-all-fields"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_users.ProjectBasedClient")
+    def test_get_user_json_output(self, mock_project_client):
+        """Test getting user with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        user_data = {"id": 2, "email": "user@example.com", "name": "Test User", "role": "Tester"}
+        mock_client.api_request_handler.user_handler.get_user.return_value = (user_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_users.get, ["--user-id", "2", "--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert '"email": "user@example.com"' in result.output
+
+    @mock.patch("trcli.commands.cmd_users.ProjectBasedClient")
+    def test_get_user_no_option_error(self, mock_project_client):
+        """Test error when no option is provided"""
+        self._setup_project_client_mock(mock_project_client)
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_users.get, [], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Must specify one of --current, --user-id, or --email")
+
+    @mock.patch("trcli.commands.cmd_users.ProjectBasedClient")
+    def test_get_user_multiple_options_error(self, mock_project_client):
+        """Test error when multiple exclusive options are provided"""
+        self._setup_project_client_mock(mock_project_client)
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_users.get, ["--current", "--user-id", "5"], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Options --current, --user-id, and --email are mutually exclusive")
+
+    @mock.patch("trcli.commands.cmd_users.ProjectBasedClient")
+    def test_get_user_api_error(self, mock_project_client):
+        """Test getting user with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.user_handler.get_user.return_value = (None, "User not found")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_users.get, ["--user-id", "999"], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Failed to retrieve user: User not found")
+
+    # LIST subcommand tests
+
+    @mock.patch("trcli.commands.cmd_users.ProjectBasedClient")
+    def test_list_all_users_success(self, mock_project_client):
+        """Test listing all users"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.user_handler.get_users.return_value = (
+            [
+                {"id": 1, "name": "John Doe", "email": "john@example.com"},
+                {"id": 2, "name": "Jane Smith", "email": "jane@example.com"},
+                {"id": 3, "name": "Bob Johnson", "email": "bob@example.com"},
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_users.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.user_handler.get_users.assert_called_once_with(None)
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_users.ProjectBasedClient")
+    def test_list_users_by_project_success(self, mock_project_client):
+        """Test listing users filtered by project"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.user_handler.get_users.return_value = (
+            [
+                {"id": 1, "name": "John Doe", "role": "Tester", "role_id": 3},
+                {"id": 2, "name": "Jane Smith", "role": "Lead", "role_id": 2},
+            ],
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_users.list, ["--project-id", "5"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.user_handler.get_users.assert_called_once_with(5)
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_users.ProjectBasedClient")
+    def test_list_users_json_output(self, mock_project_client):
+        """Test listing users with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        users_data = [{"id": 1, "name": "John Doe"}, {"id": 2, "name": "Jane Smith"}]
+        mock_client.api_request_handler.user_handler.get_users.return_value = (users_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_users.list, ["--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert '"name": "John Doe"' in result.output
+
+    @mock.patch("trcli.commands.cmd_users.ProjectBasedClient")
+    def test_list_users_empty_result(self, mock_project_client):
+        """Test listing users with empty result"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.user_handler.get_users.return_value = ([], "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_users.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_users.ProjectBasedClient")
+    def test_list_users_api_error(self, mock_project_client):
+        """Test listing users with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.user_handler.get_users.return_value = ([], "Permission denied")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_users.list, [], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Failed to retrieve users: Permission denied")

--- a/tests/test_data/cli_test_data.py
+++ b/tests/test_data/cli_test_data.py
@@ -86,6 +86,7 @@ trcli_description = (
     "    - priorities: Query test case priorities\n"
     "    - casetypes: Query test case types\n"
     "    - users: Query users (get and list)\n"
+    "    - projects: Query projects (get and list)\n"
     "    - results: Query and update test results (list, update)\n"
 )
 

--- a/tests/test_data/cli_test_data.py
+++ b/tests/test_data/cli_test_data.py
@@ -83,6 +83,7 @@ trcli_description = (
     "    - statuses: Query test statuses\n"
     "    - casefields: Query test case custom fields\n"
     "    - resultfields: Query test result custom fields\n"
+    "    - priorities: Query test case priorities\n"
     "    - results: Query and update test results (list, update)\n"
 )
 

--- a/tests/test_data/cli_test_data.py
+++ b/tests/test_data/cli_test_data.py
@@ -84,6 +84,7 @@ trcli_description = (
     "    - casefields: Query test case custom fields\n"
     "    - resultfields: Query test result custom fields\n"
     "    - priorities: Query test case priorities\n"
+    "    - casetypes: Query test case types\n"
     "    - results: Query and update test results (list, update)\n"
 )
 

--- a/tests/test_data/cli_test_data.py
+++ b/tests/test_data/cli_test_data.py
@@ -85,6 +85,7 @@ trcli_description = (
     "    - resultfields: Query test result custom fields\n"
     "    - priorities: Query test case priorities\n"
     "    - casetypes: Query test case types\n"
+    "    - users: Query users (get and list)\n"
     "    - results: Query and update test results (list, update)\n"
 )
 

--- a/tests/test_data/cli_test_data.py
+++ b/tests/test_data/cli_test_data.py
@@ -88,6 +88,7 @@ trcli_description = (
     "    - users: Query users (get and list)\n"
     "    - projects: Query projects (get and list)\n"
     "    - templates: Query templates (list)\n"
+    "    - tests: Query tests (get and list)\n"
     "    - results: Query and update test results (list, update)\n"
 )
 

--- a/tests/test_data/cli_test_data.py
+++ b/tests/test_data/cli_test_data.py
@@ -87,6 +87,7 @@ trcli_description = (
     "    - casetypes: Query test case types\n"
     "    - users: Query users (get and list)\n"
     "    - projects: Query projects (get and list)\n"
+    "    - templates: Query templates (list)\n"
     "    - results: Query and update test results (list, update)\n"
 )
 

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -23,6 +23,7 @@ from trcli.api.case_field_handler import CaseFieldHandler
 from trcli.api.result_field_handler import ResultFieldHandler
 from trcli.api.priority_handler import PriorityHandler
 from trcli.api.case_type_handler import CaseTypeHandler
+from trcli.api.user_handler import UserHandler
 from trcli.cli import Environment
 from trcli.constants import (
     ProjectErrors,
@@ -100,6 +101,7 @@ class ApiRequestHandler:
         self.result_field_handler = ResultFieldHandler(api_client)
         self.priority_handler = PriorityHandler(api_client)
         self.case_type_handler = CaseTypeHandler(api_client)
+        self.user_handler = UserHandler(api_client)
 
         # BDD case cache for feature name matching (shared by CucumberParser and JunitParser)
         # Structure: {"{project_id}_{suite_id}": {normalized_name: [case_dict, case_dict, ...]}}

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -21,6 +21,7 @@ from trcli.api.configuration_handler import ConfigurationHandler
 from trcli.api.status_handler import StatusHandler
 from trcli.api.case_field_handler import CaseFieldHandler
 from trcli.api.result_field_handler import ResultFieldHandler
+from trcli.api.priority_handler import PriorityHandler
 from trcli.cli import Environment
 from trcli.constants import (
     ProjectErrors,
@@ -96,6 +97,7 @@ class ApiRequestHandler:
         self.status_handler = StatusHandler(api_client)
         self.case_field_handler = CaseFieldHandler(api_client)
         self.result_field_handler = ResultFieldHandler(api_client)
+        self.priority_handler = PriorityHandler(api_client)
 
         # BDD case cache for feature name matching (shared by CucumberParser and JunitParser)
         # Structure: {"{project_id}_{suite_id}": {normalized_name: [case_dict, case_dict, ...]}}

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -24,6 +24,7 @@ from trcli.api.result_field_handler import ResultFieldHandler
 from trcli.api.priority_handler import PriorityHandler
 from trcli.api.case_type_handler import CaseTypeHandler
 from trcli.api.user_handler import UserHandler
+from trcli.api.project_handler import ProjectHandler
 from trcli.cli import Environment
 from trcli.constants import (
     ProjectErrors,
@@ -102,6 +103,7 @@ class ApiRequestHandler:
         self.priority_handler = PriorityHandler(api_client)
         self.case_type_handler = CaseTypeHandler(api_client)
         self.user_handler = UserHandler(api_client)
+        self.project_handler = ProjectHandler(api_client)
 
         # BDD case cache for feature name matching (shared by CucumberParser and JunitParser)
         # Structure: {"{project_id}_{suite_id}": {normalized_name: [case_dict, case_dict, ...]}}

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -22,6 +22,7 @@ from trcli.api.status_handler import StatusHandler
 from trcli.api.case_field_handler import CaseFieldHandler
 from trcli.api.result_field_handler import ResultFieldHandler
 from trcli.api.priority_handler import PriorityHandler
+from trcli.api.case_type_handler import CaseTypeHandler
 from trcli.cli import Environment
 from trcli.constants import (
     ProjectErrors,
@@ -98,6 +99,7 @@ class ApiRequestHandler:
         self.case_field_handler = CaseFieldHandler(api_client)
         self.result_field_handler = ResultFieldHandler(api_client)
         self.priority_handler = PriorityHandler(api_client)
+        self.case_type_handler = CaseTypeHandler(api_client)
 
         # BDD case cache for feature name matching (shared by CucumberParser and JunitParser)
         # Structure: {"{project_id}_{suite_id}": {normalized_name: [case_dict, case_dict, ...]}}

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -26,6 +26,7 @@ from trcli.api.case_type_handler import CaseTypeHandler
 from trcli.api.user_handler import UserHandler
 from trcli.api.project_handler import ProjectHandler
 from trcli.api.template_handler import TemplateHandler
+from trcli.api.test_handler import TestHandler
 from trcli.cli import Environment
 from trcli.constants import (
     ProjectErrors,
@@ -106,6 +107,7 @@ class ApiRequestHandler:
         self.user_handler = UserHandler(api_client)
         self.project_handler = ProjectHandler(api_client)
         self.template_handler = TemplateHandler(api_client)
+        self.test_handler = TestHandler(api_client)
 
         # BDD case cache for feature name matching (shared by CucumberParser and JunitParser)
         # Structure: {"{project_id}_{suite_id}": {normalized_name: [case_dict, case_dict, ...]}}

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -25,6 +25,7 @@ from trcli.api.priority_handler import PriorityHandler
 from trcli.api.case_type_handler import CaseTypeHandler
 from trcli.api.user_handler import UserHandler
 from trcli.api.project_handler import ProjectHandler
+from trcli.api.template_handler import TemplateHandler
 from trcli.cli import Environment
 from trcli.constants import (
     ProjectErrors,
@@ -104,6 +105,7 @@ class ApiRequestHandler:
         self.case_type_handler = CaseTypeHandler(api_client)
         self.user_handler = UserHandler(api_client)
         self.project_handler = ProjectHandler(api_client)
+        self.template_handler = TemplateHandler(api_client)
 
         # BDD case cache for feature name matching (shared by CucumberParser and JunitParser)
         # Structure: {"{project_id}_{suite_id}": {normalized_name: [case_dict, case_dict, ...]}}

--- a/trcli/api/case_type_handler.py
+++ b/trcli/api/case_type_handler.py
@@ -1,0 +1,38 @@
+"""
+Handler for TestRail case type operations.
+Provides methods to retrieve test case type information.
+"""
+
+from typing import List, Tuple
+
+
+class CaseTypeHandler:
+    """Handles case type-related API operations."""
+
+    def __init__(self, api_client):
+        """
+        Initialize CaseTypeHandler.
+
+        Args:
+            api_client: APIClient instance for making API calls
+        """
+        self.api_client = api_client
+
+    def get_case_types(self) -> Tuple[List[dict], str]:
+        """
+        Get all available test case types.
+
+        Returns:
+            Tuple of (list of case type dictionaries, error message)
+            Case type dict contains: id, name, is_default
+        """
+        response = self.api_client.send_get("get_case_types")
+
+        if response.error_message:
+            return [], response.error_message
+
+        case_types = response.response_text
+        if not isinstance(case_types, list):
+            return [], "Invalid response format: expected list of case types"
+
+        return case_types, ""

--- a/trcli/api/plan_handler.py
+++ b/trcli/api/plan_handler.py
@@ -4,9 +4,10 @@ PlanHandler - Handles all plan-related operations for TestRail
 It manages all plan operations including:
 - Retrieving individual plans
 - Listing plans with pagination
+- Creating new plans
 """
 
-from beartype.typing import Tuple
+from beartype.typing import Tuple, Optional, Dict, Any
 
 from trcli.api.api_client import APIClient
 from trcli.cli import Environment
@@ -70,6 +71,46 @@ class PlanHandler:
             url = f"{url}&{query_string}"
 
         response = self.client.send_get(url)
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""
+
+    def add_plan(
+        self,
+        project_id: int,
+        name: str,
+        description: Optional[str] = None,
+        milestone_id: Optional[int] = None,
+        entries: Optional[list] = None,
+        start_on: Optional[int] = None,
+        due_on: Optional[int] = None,
+    ) -> Tuple[Dict[str, Any], str]:
+        """
+        Create a new test plan
+
+        :param project_id: TestRail project ID
+        :param name: Name of the test plan (required)
+        :param description: Description of the test plan
+        :param milestone_id: ID of the milestone to link to the plan
+        :param entries: Array of test run entries (see add_plan API documentation)
+        :param start_on: Start date as UNIX timestamp
+        :param due_on: Due date as UNIX timestamp
+        :returns: Tuple with (created_plan_dict, error_message)
+        """
+        payload = {"name": name}
+
+        if description is not None:
+            payload["description"] = description
+        if milestone_id is not None:
+            payload["milestone_id"] = milestone_id
+        if entries is not None:
+            payload["entries"] = entries
+        if start_on is not None:
+            payload["start_on"] = start_on
+        if due_on is not None:
+            payload["due_on"] = due_on
+
+        response = self.client.send_post(f"add_plan/{project_id}", payload)
         if response.error_message:
             return {}, response.error_message
         return response.response_text, ""

--- a/trcli/api/priority_handler.py
+++ b/trcli/api/priority_handler.py
@@ -1,0 +1,38 @@
+"""
+Handler for TestRail priority operations.
+Provides methods to retrieve test case priority information.
+"""
+
+from typing import List, Tuple
+
+
+class PriorityHandler:
+    """Handles priority-related API operations."""
+
+    def __init__(self, api_client):
+        """
+        Initialize PriorityHandler.
+
+        Args:
+            api_client: APIClient instance for making API calls
+        """
+        self.api_client = api_client
+
+    def get_priorities(self) -> Tuple[List[dict], str]:
+        """
+        Get all available test case priorities.
+
+        Returns:
+            Tuple of (list of priority dictionaries, error message)
+            Priority dict contains: id, name, short_name, priority, is_default
+        """
+        response = self.api_client.send_get("get_priorities")
+
+        if response.error_message:
+            return [], response.error_message
+
+        priorities = response.response_text
+        if not isinstance(priorities, list):
+            return [], "Invalid response format: expected list of priorities"
+
+        return priorities, ""

--- a/trcli/api/project_handler.py
+++ b/trcli/api/project_handler.py
@@ -1,0 +1,87 @@
+"""
+Handler for TestRail project operations.
+Provides methods to retrieve project information.
+"""
+
+from typing import List, Tuple, Dict, Optional
+
+
+class ProjectHandler:
+    """Handles project-related API operations."""
+
+    def __init__(self, api_client):
+        """
+        Initialize ProjectHandler.
+
+        Args:
+            api_client: APIClient instance for making API calls
+        """
+        self.api_client = api_client
+
+    def get_project(self, project_id: int) -> Tuple[Optional[Dict], str]:
+        """
+        Get a specific project by ID.
+
+        Args:
+            project_id: The ID of the project
+
+        Returns:
+            Tuple of (project dictionary, error message)
+            Project dict contains: id, name, announcement, completed_on, is_completed,
+            suite_mode, show_announcement, url, users, groups, default_role_id, default_role
+        """
+        response = self.api_client.send_get(f"get_project/{project_id}")
+
+        if response.error_message:
+            return None, response.error_message
+
+        project = response.response_text
+        if not isinstance(project, dict):
+            return None, "Invalid response format: expected project dictionary"
+
+        return project, ""
+
+    def get_projects(
+        self, is_completed: Optional[int] = None, limit: Optional[int] = None, offset: Optional[int] = None
+    ) -> Tuple[List[Dict], str]:
+        """
+        Get all projects with optional filters.
+
+        Args:
+            is_completed: Optional filter - 1 for completed projects, 0 for active projects
+            limit: Optional limit for pagination (default: 250)
+            offset: Optional offset for pagination (default: 0)
+
+        Returns:
+            Tuple of (list of project dictionaries, error message)
+            Project dict contains: id, name, announcement, is_completed, suite_mode, etc.
+        """
+        # Build endpoint with query parameters
+        params = []
+        if is_completed is not None:
+            params.append(f"is_completed={is_completed}")
+        if limit is not None:
+            params.append(f"limit={limit}")
+        if offset is not None:
+            params.append(f"offset={offset}")
+
+        endpoint = "get_projects"
+        if params:
+            endpoint += "&" + "&".join(params)
+
+        response = self.api_client.send_get(endpoint)
+
+        if response.error_message:
+            return [], response.error_message
+
+        response_data = response.response_text
+
+        # Handle paginated response format (with 'projects' key) or direct list
+        if isinstance(response_data, dict) and "projects" in response_data:
+            projects = response_data["projects"]
+        elif isinstance(response_data, list):
+            projects = response_data
+        else:
+            return [], "Invalid response format: expected list of projects or paginated response"
+
+        return projects, ""

--- a/trcli/api/template_handler.py
+++ b/trcli/api/template_handler.py
@@ -1,0 +1,42 @@
+"""
+Handler for TestRail template operations.
+Provides methods to retrieve template information.
+"""
+
+from typing import List, Tuple, Dict
+
+
+class TemplateHandler:
+    """Handles template-related API operations."""
+
+    def __init__(self, api_client):
+        """
+        Initialize TemplateHandler.
+
+        Args:
+            api_client: APIClient instance for making API calls
+        """
+        self.api_client = api_client
+
+    def get_templates(self, project_id: int) -> Tuple[List[Dict], str]:
+        """
+        Get all templates (field layouts) for a project.
+
+        Args:
+            project_id: The ID of the project
+
+        Returns:
+            Tuple of (list of template dictionaries, error message)
+            Template dict contains: id, name, i18n_custom_id, is_default
+        """
+        response = self.api_client.send_get(f"get_templates/{project_id}")
+
+        if response.error_message:
+            return [], response.error_message
+
+        templates = response.response_text
+
+        if not isinstance(templates, list):
+            return [], "Invalid response format: expected list of templates"
+
+        return templates, ""

--- a/trcli/api/test_handler.py
+++ b/trcli/api/test_handler.py
@@ -1,0 +1,113 @@
+"""
+Handler for TestRail test operations.
+Provides methods to retrieve test information.
+"""
+
+from typing import List, Tuple, Dict, Optional
+
+
+class TestHandler:
+    """Handles test-related API operations."""
+
+    def __init__(self, api_client):
+        """
+        Initialize TestHandler.
+
+        Args:
+            api_client: APIClient instance for making API calls
+        """
+        self.api_client = api_client
+
+    def get_test(self, test_id: int, with_data: Optional[str] = None) -> Tuple[Optional[Dict], str]:
+        """
+        Get a specific test by ID.
+
+        Args:
+            test_id: The ID of the test
+            with_data: Optional parameter to get additional data (0 or 1)
+                       When 1, returns test data with results and attachments
+
+        Returns:
+            Tuple of (test dictionary, error message)
+            Test dict contains: id, title, assignedto_id, case_id, run_id, status_id,
+            priority_id, type_id, estimate, estimate_forecast, custom fields, labels
+            When with_data=1, also includes: results (list), attachments (list)
+        """
+        endpoint = f"get_test/{test_id}"
+        if with_data:
+            endpoint += f"&with_data={with_data}"
+
+        response = self.api_client.send_get(endpoint)
+
+        if response.error_message:
+            return None, response.error_message
+
+        response_data = response.response_text
+        if not isinstance(response_data, dict):
+            return None, "Invalid response format: expected test dictionary"
+
+        # When with_data=1, TestRail wraps the test in a 'test' key and includes
+        # additional 'results' and 'attachments' keys. We need to extract the test
+        # and merge the additional data.
+        if with_data == "1" and "test" in response_data:
+            test = response_data["test"]
+            # Add the additional data to the test object
+            test["results"] = response_data.get("results", [])
+            test["attachments"] = response_data.get("attachments", [])
+            return test, ""
+
+        return response_data, ""
+
+    def get_tests(
+        self,
+        run_id: int,
+        status_id: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        label_id: Optional[str] = None,
+    ) -> Tuple[List[Dict], str]:
+        """
+        Get all tests for a test run with optional filters.
+
+        Args:
+            run_id: The ID of the test run
+            status_id: Optional comma-separated list of status IDs to filter by
+            limit: Optional limit for pagination (default: 250)
+            offset: Optional offset for pagination (default: 0)
+            label_id: Optional comma-separated list of label IDs to filter by
+
+        Returns:
+            Tuple of (list of test dictionaries, error message)
+            Test dict contains: id, title, assignedto_id, case_id, run_id, status_id, etc.
+        """
+        # Build endpoint with query parameters
+        params = []
+        if status_id is not None:
+            params.append(f"status_id={status_id}")
+        if limit is not None:
+            params.append(f"limit={limit}")
+        if offset is not None:
+            params.append(f"offset={offset}")
+        if label_id is not None:
+            params.append(f"label_id={label_id}")
+
+        endpoint = f"get_tests/{run_id}"
+        if params:
+            endpoint += "&" + "&".join(params)
+
+        response = self.api_client.send_get(endpoint)
+
+        if response.error_message:
+            return [], response.error_message
+
+        response_data = response.response_text
+
+        # Handle paginated response format (with 'tests' key) or direct list
+        if isinstance(response_data, dict) and "tests" in response_data:
+            tests = response_data["tests"]
+        elif isinstance(response_data, list):
+            tests = response_data
+        else:
+            return [], "Invalid response format: expected list of tests or paginated response"
+
+        return tests, ""

--- a/trcli/api/user_handler.py
+++ b/trcli/api/user_handler.py
@@ -1,0 +1,115 @@
+"""
+Handler for TestRail user operations.
+Provides methods to retrieve user information.
+"""
+
+from typing import List, Tuple, Dict, Union, Optional
+
+
+class UserHandler:
+    """Handles user-related API operations."""
+
+    def __init__(self, api_client):
+        """
+        Initialize UserHandler.
+
+        Args:
+            api_client: APIClient instance for making API calls
+        """
+        self.api_client = api_client
+
+    def get_user(self, user_id: int) -> Tuple[Optional[Dict], str]:
+        """
+        Get a specific user by ID.
+
+        Args:
+            user_id: The ID of the user
+
+        Returns:
+            Tuple of (user dictionary, error message)
+            User dict contains: id, email, name, role, role_id, is_active, is_admin, etc.
+        """
+        response = self.api_client.send_get(f"get_user/{user_id}")
+
+        if response.error_message:
+            return None, response.error_message
+
+        user = response.response_text
+        if not isinstance(user, dict):
+            return None, "Invalid response format: expected user dictionary"
+
+        return user, ""
+
+    def get_current_user(self) -> Tuple[Optional[Dict], str]:
+        """
+        Get the current authenticated user.
+
+        Returns:
+            Tuple of (user dictionary, error message)
+            User dict contains: id, email, name, role, role_id, is_active
+        """
+        response = self.api_client.send_get("get_current_user")
+
+        if response.error_message:
+            return None, response.error_message
+
+        user = response.response_text
+        if not isinstance(user, dict):
+            return None, "Invalid response format: expected user dictionary"
+
+        return user, ""
+
+    def get_user_by_email(self, email: str) -> Tuple[Optional[Dict], str]:
+        """
+        Get a specific user by email address.
+
+        Args:
+            email: The email address of the user
+
+        Returns:
+            Tuple of (user dictionary, error message)
+            User dict contains: id, email, name, role, role_id, is_active, is_admin, etc.
+        """
+        response = self.api_client.send_get(f"get_user_by_email&email={email}")
+
+        if response.error_message:
+            return None, response.error_message
+
+        user = response.response_text
+        if not isinstance(user, dict):
+            return None, "Invalid response format: expected user dictionary"
+
+        return user, ""
+
+    def get_users(self, project_id: Optional[int] = None) -> Tuple[List[Dict], str]:
+        """
+        Get all users or users for a specific project.
+
+        Args:
+            project_id: Optional project ID to filter users by project access
+
+        Returns:
+            Tuple of (list of user dictionaries, error message)
+            User dict contains: id, name, email (if no project), role, role_id (if project specified)
+        """
+        if project_id:
+            endpoint = f"get_users/{project_id}"
+        else:
+            endpoint = "get_users"
+
+        response = self.api_client.send_get(endpoint)
+
+        if response.error_message:
+            return [], response.error_message
+
+        response_data = response.response_text
+
+        # Handle paginated response format (with 'users' key) or direct list
+        if isinstance(response_data, dict) and "users" in response_data:
+            users = response_data["users"]
+        elif isinstance(response_data, list):
+            users = response_data
+        else:
+            return [], "Invalid response format: expected list of users or paginated response"
+
+        return users, ""

--- a/trcli/commands/cmd_casetypes.py
+++ b/trcli/commands/cmd_casetypes.py
@@ -1,0 +1,75 @@
+import builtins
+import click
+import json
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def print_config(env: Environment, action: str):
+    env.log(f"Case Types {action} Execution Parameters" f"\n> TestRail instance: {env.host} (user: {env.username})")
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.pass_context
+@pass_environment
+def cli(environment: Environment, context: click.Context, *args, **kwargs):
+    """Manage test case types in TestRail"""
+    environment.cmd = "casetypes"
+    environment.set_parameters(context)
+
+
+@cli.command()
+@click.option("--json-output", is_flag=True, help="Output case types as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def list(
+    environment: Environment,
+    context: click.Context,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """List all test case types from TestRail"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "List")
+
+    # Create ProjectBasedClient (case types are global, but we use this for consistent API access)
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    environment.log("Retrieving case types...")
+
+    # Retrieve case types using CaseTypeHandler
+    case_types, error_message = project_client.api_request_handler.case_type_handler.get_case_types()
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve case types: {error_message}")
+        raise SystemExit(1)
+
+    if json_output:
+        # Output prettified JSON response
+        print(json.dumps(case_types, indent=2))
+    else:
+        environment.log(f"Found {len(case_types)} case type(s).")
+        environment.log("")
+
+        if not case_types:
+            environment.log("No case types found.")
+        else:
+            # Display case types in a simple format
+            for case_type in case_types:
+                case_type_id = case_type.get("id")
+                name = case_type.get("name", "N/A")
+                is_default = case_type.get("is_default", False)
+
+                default_marker = " [DEFAULT]" if is_default else ""
+                environment.log(f"ID: {case_type_id} | Name: {name}{default_marker}")
+
+        environment.log("")
+
+    environment.log("Case type listing completed successfully.")

--- a/trcli/commands/cmd_plans.py
+++ b/trcli/commands/cmd_plans.py
@@ -343,8 +343,13 @@ def list(
 
 
 @cli.command()
-@click.option("--name", type=str, required=True, metavar="<name>", help="Name of the test plan.")
-@click.option("--description", type=str, metavar="<description>", help="Description of the test plan.")
+@click.option("--name", type=str, metavar="<name>", help="Name of the test plan (can also be provided in JSON file).")
+@click.option(
+    "--description",
+    type=str,
+    metavar="<description>",
+    help="Description of the test plan (can also be provided in JSON file).",
+)
 @click.option("--milestone-id", type=click.IntRange(min=1), metavar="<id>", help="ID of the milestone to link.")
 @click.option(
     "--entries",
@@ -415,38 +420,103 @@ def add(
     due_timestamp = convert_date_to_timestamp(due_on) if due_on else None
 
     # Parse entries from JSON string or file
+    # Support two formats:
+    # 1. Array format: [{"suite_id": 1, ...}]
+    # 2. Plan format: {"name": "...", "entries": [...]}
     parsed_entries = None
+    json_plan_name = None
+    json_description = None
+    json_milestone_id = None
+
     if entries_file:
         try:
             with open(entries_file, "r") as f:
-                parsed_entries = json.load(f)
-            if not isinstance(parsed_entries, builtins.list):
-                environment.elog("Error: Entries file must contain a JSON array")
+                json_data = json.load(f)
+
+            # Detect format: dict with "entries" key OR array
+            if isinstance(json_data, dict) and "entries" in json_data:
+                # Plan format - extract plan-level fields
+                parsed_entries = json_data.get("entries")
+                json_plan_name = json_data.get("name")
+                json_description = json_data.get("description")
+                json_milestone_id = json_data.get("milestone_id")
+
+                # Warn if command-line args will override JSON fields
+                if json_plan_name and name and name != json_plan_name:
+                    environment.log(f"Note: Using --name '{name}' instead of JSON name '{json_plan_name}'")
+                if json_description and description and description != json_description:
+                    environment.log(f"Note: Using --description from command line instead of JSON description")
+                if json_milestone_id and milestone_id and milestone_id != json_milestone_id:
+                    environment.log(
+                        f"Note: Using --milestone-id {milestone_id} instead of JSON milestone_id {json_milestone_id}"
+                    )
+
+            elif isinstance(json_data, builtins.list):
+                # Array format - just entries
+                parsed_entries = json_data
+            else:
+                environment.elog(
+                    "Error: Entries file must contain either a JSON array or an object with 'entries' field"
+                )
                 raise SystemExit(1)
+
         except json.JSONDecodeError as e:
             environment.elog(f"Error: Invalid JSON in entries file: {e}")
             raise SystemExit(1)
         except Exception as e:
             environment.elog(f"Error: Failed to read entries file: {e}")
             raise SystemExit(1)
+
     elif entries:
         try:
-            parsed_entries = json.loads(entries)
-            if not isinstance(parsed_entries, builtins.list):
-                environment.elog("Error: Entries must be a JSON array")
+            json_data = json.loads(entries)
+
+            # Detect format: dict with "entries" key OR array
+            if isinstance(json_data, dict) and "entries" in json_data:
+                # Plan format - extract plan-level fields
+                parsed_entries = json_data.get("entries")
+                json_plan_name = json_data.get("name")
+                json_description = json_data.get("description")
+                json_milestone_id = json_data.get("milestone_id")
+
+                # Warn if command-line args will override JSON fields
+                if json_plan_name and name and name != json_plan_name:
+                    environment.log(f"Note: Using --name '{name}' instead of JSON name '{json_plan_name}'")
+                if json_description and description and description != json_description:
+                    environment.log(f"Note: Using --description from command line instead of JSON description")
+                if json_milestone_id and milestone_id and milestone_id != json_milestone_id:
+                    environment.log(
+                        f"Note: Using --milestone-id {milestone_id} instead of JSON milestone_id {json_milestone_id}"
+                    )
+
+            elif isinstance(json_data, builtins.list):
+                # Array format - just entries
+                parsed_entries = json_data
+            else:
+                environment.elog("Error: Entries must be either a JSON array or an object with 'entries' field")
                 raise SystemExit(1)
+
         except json.JSONDecodeError as e:
             environment.elog(f"Error: Invalid JSON in entries parameter: {e}")
             raise SystemExit(1)
 
-    environment.log(f"Creating plan '{name}' in project ID {project_client.project.project_id}...")
+    # Use JSON fields as fallback if command-line args not provided
+    final_name = name if name else json_plan_name
+    final_description = description if description else json_description
+    final_milestone_id = milestone_id if milestone_id else json_milestone_id
+
+    if not final_name:
+        environment.elog("Error: Plan name is required (use --name or provide 'name' in JSON)")
+        raise SystemExit(1)
+
+    environment.log(f"Creating plan '{final_name}' in project ID {project_client.project.project_id}...")
 
     # Create the plan
     plan, error_message = project_client.api_request_handler.plan_handler.add_plan(
         project_id=project_client.project.project_id,
-        name=name,
-        description=description,
-        milestone_id=milestone_id,
+        name=final_name,
+        description=final_description,
+        milestone_id=final_milestone_id,
         entries=parsed_entries,
         start_on=start_timestamp,
         due_on=due_timestamp,

--- a/trcli/commands/cmd_plans.py
+++ b/trcli/commands/cmd_plans.py
@@ -1,10 +1,29 @@
 import builtins
 import click
 import json
+from datetime import datetime, timezone
 
 from trcli.api.project_based_client import ProjectBasedClient
 from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
 from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def convert_date_to_timestamp(date_list):
+    """
+    Convert a date list [MM, DD, YYYY] to UNIX timestamp.
+
+    :param date_list: List of [month, day, year]
+    :returns: UNIX timestamp (int) or None if conversion fails
+    """
+    if not date_list:
+        return None
+    if not hasattr(date_list, "__len__") or len(date_list) != 3:
+        return None
+    try:
+        dt = datetime(date_list[2], date_list[0], date_list[1], tzinfo=timezone.utc)
+        return int(dt.timestamp())
+    except (ValueError, IndexError, TypeError):
+        return None
 
 
 def print_config(env: Environment, action: str):
@@ -321,3 +340,150 @@ def list(
                         environment.log(f"    Milestone ID: {plan.get('milestone_id')}")
 
                     environment.log("")
+
+
+@cli.command()
+@click.option("--name", type=str, required=True, metavar="<name>", help="Name of the test plan.")
+@click.option("--description", type=str, metavar="<description>", help="Description of the test plan.")
+@click.option("--milestone-id", type=click.IntRange(min=1), metavar="<id>", help="ID of the milestone to link.")
+@click.option(
+    "--entries",
+    type=str,
+    metavar="<json>",
+    help="JSON array of plan entries inline. Use this for simple entries or scripting. Mutually exclusive with --entries-file.",
+)
+@click.option(
+    "--entries-file",
+    type=click.Path(exists=True),
+    metavar="<path>",
+    help="Path to JSON file containing plan entries. Use this for complex entries with multiple runs/configs. Mutually exclusive with --entries.",
+)
+@click.option(
+    "--start-on",
+    metavar="",
+    default=None,
+    type=lambda x: [int(i) for i in x.split("/") if len(x.split("/")) == 3],
+    help="The scheduled start date of this test plan in MM/DD/YYYY format",
+)
+@click.option(
+    "--due-on",
+    metavar="",
+    default=None,
+    type=lambda x: [int(i) for i in x.split("/") if len(x.split("/")) == 3],
+    help="The scheduled due date of this test plan in MM/DD/YYYY format",
+)
+@click.option("--json-output", is_flag=True, help="Output created plan as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def add(
+    environment: Environment,
+    context: click.Context,
+    name: str,
+    description: str,
+    milestone_id: int,
+    entries: str,
+    entries_file: str,
+    start_on: list,
+    due_on: list,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """Create a new test plan"""
+    environment.check_for_required_parameters()
+
+    # Validation: mutually exclusive entries flags
+    if entries and entries_file:
+        environment.elog(
+            "Error: --entries and --entries-file cannot be used together. Choose one method to provide entries."
+        )
+        raise SystemExit(1)
+
+    print_config(environment, "Add")
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    # Convert dates from MM/DD/YYYY to UNIX timestamps
+    start_timestamp = convert_date_to_timestamp(start_on) if start_on else None
+    due_timestamp = convert_date_to_timestamp(due_on) if due_on else None
+
+    # Parse entries from JSON string or file
+    parsed_entries = None
+    if entries_file:
+        try:
+            with open(entries_file, "r") as f:
+                parsed_entries = json.load(f)
+            if not isinstance(parsed_entries, builtins.list):
+                environment.elog("Error: Entries file must contain a JSON array")
+                raise SystemExit(1)
+        except json.JSONDecodeError as e:
+            environment.elog(f"Error: Invalid JSON in entries file: {e}")
+            raise SystemExit(1)
+        except Exception as e:
+            environment.elog(f"Error: Failed to read entries file: {e}")
+            raise SystemExit(1)
+    elif entries:
+        try:
+            parsed_entries = json.loads(entries)
+            if not isinstance(parsed_entries, builtins.list):
+                environment.elog("Error: Entries must be a JSON array")
+                raise SystemExit(1)
+        except json.JSONDecodeError as e:
+            environment.elog(f"Error: Invalid JSON in entries parameter: {e}")
+            raise SystemExit(1)
+
+    environment.log(f"Creating plan '{name}' in project ID {project_client.project.project_id}...")
+
+    # Create the plan
+    plan, error_message = project_client.api_request_handler.plan_handler.add_plan(
+        project_id=project_client.project.project_id,
+        name=name,
+        description=description,
+        milestone_id=milestone_id,
+        entries=parsed_entries,
+        start_on=start_timestamp,
+        due_on=due_timestamp,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to create plan: {error_message}")
+        raise SystemExit(1)
+
+    if not plan or not plan.get("id"):
+        environment.elog("Error: Plan creation returned unexpected response")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        print(json.dumps(plan, indent=2))
+    else:
+        environment.log(f"\nPlan created successfully!")
+        environment.log(f"  Plan ID: {plan.get('id')}")
+        environment.log(f"  Name: {plan.get('name')}")
+        environment.log(f"  URL: {plan.get('url', 'N/A')}")
+        if plan.get("milestone_id"):
+            environment.log(f"  Milestone ID: {plan.get('milestone_id')}")
+        if plan.get("entries"):
+            environment.log(f"  Entries: {len(plan.get('entries'))} test run(s)")
+            for entry in plan.get("entries", []):
+                entry_name = entry.get("name", "N/A")
+                # Calculate total test count across all runs in this entry
+                total_tests = 0
+                for run in entry.get("runs", []):
+                    total_tests += (
+                        run.get("untested_count", 0)
+                        + run.get("passed_count", 0)
+                        + run.get("failed_count", 0)
+                        + run.get("blocked_count", 0)
+                        + run.get("retest_count", 0)
+                    )
+                environment.log(f"    - {entry_name}: {total_tests} test case(s)")
+
+    environment.log("\nPlan creation completed successfully.")

--- a/trcli/commands/cmd_priorities.py
+++ b/trcli/commands/cmd_priorities.py
@@ -1,0 +1,86 @@
+import builtins
+import click
+import json
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def print_config(env: Environment, action: str):
+    env.log(f"Priorities {action} Execution Parameters" f"\n> TestRail instance: {env.host} (user: {env.username})")
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.pass_context
+@pass_environment
+def cli(environment: Environment, context: click.Context, *args, **kwargs):
+    """Manage test case priorities in TestRail"""
+    environment.cmd = "priorities"
+    environment.set_parameters(context)
+
+
+@cli.command()
+@click.option("--json-output", is_flag=True, help="Output priorities as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields including priority order and default flag.")
+@click.pass_context
+@pass_environment
+def list(
+    environment: Environment,
+    context: click.Context,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """List all test case priorities from TestRail"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "List")
+
+    # Create ProjectBasedClient (priorities are global, but we use this for consistent API access)
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    environment.log("Retrieving priorities...")
+
+    # Retrieve priorities using PriorityHandler
+    priorities, error_message = project_client.api_request_handler.priority_handler.get_priorities()
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve priorities: {error_message}")
+        raise SystemExit(1)
+
+    if json_output:
+        # Output prettified JSON response
+        print(json.dumps(priorities, indent=2))
+    else:
+        environment.log(f"Found {len(priorities)} priority level(s).")
+        environment.log("")
+
+        if not priorities:
+            environment.log("No priorities found.")
+        else:
+            # Display priorities in a table-like format
+            for priority in priorities:
+                priority_id = priority.get("id")
+                name = priority.get("name", "N/A")
+                short_name = priority.get("short_name", "N/A")
+                is_default = priority.get("is_default", False)
+                priority_order = priority.get("priority", "N/A")
+
+                default_marker = " [DEFAULT]" if is_default else ""
+
+                if show_all_fields:
+                    environment.log(
+                        f"ID: {priority_id} | Name: {name} | Short: {short_name} | "
+                        f"Order: {priority_order}{default_marker}"
+                    )
+                else:
+                    environment.log(f"ID: {priority_id} | Name: {name} | Short: {short_name}{default_marker}")
+
+        environment.log("")
+
+    environment.log("Priority listing completed successfully.")

--- a/trcli/commands/cmd_projects.py
+++ b/trcli/commands/cmd_projects.py
@@ -1,0 +1,173 @@
+import builtins
+import click
+import json
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def print_config(env: Environment, action: str):
+    env.log(f"Projects {action} Execution Parameters" f"\n> TestRail instance: {env.host} (user: {env.username})")
+
+
+def display_project(env: Environment, project: dict, show_all_fields: bool = False):
+    """Helper function to display a single project's information."""
+    env.log(f"Project ID: {project.get('id')}")
+    env.log(f"  Name: {project.get('name', 'N/A')}")
+    env.log(f"  Completed: {'Yes' if project.get('is_completed') else 'No'}")
+    env.log(f"  Suite Mode: {project.get('suite_mode', 'N/A')}")
+
+    if show_all_fields:
+        env.log(f"  URL: {project.get('url', 'N/A')}")
+        env.log(f"  Show Announcement: {'Yes' if project.get('show_announcement') else 'No'}")
+        if project.get("announcement"):
+            env.log(f"  Announcement: {project.get('announcement')}")
+        if project.get("completed_on"):
+            env.log(f"  Completed On: {project.get('completed_on')}")
+        env.log(f"  Default Role: {project.get('default_role', 'N/A')} (ID: {project.get('default_role_id', 'N/A')})")
+
+        # Display users if available
+        users = project.get("users", [])
+        if users:
+            env.log(f"  Users: {len(users)} user(s)")
+            for user in users[:5]:  # Show first 5 users
+                user_id = user.get("user_id")
+                global_role = user.get("global_role", "N/A")
+                project_role = user.get("project_role", "N/A")
+                env.log(f"    - User ID: {user_id}, Global Role: {global_role}, Project Role: {project_role}")
+            if len(users) > 5:
+                env.log(f"    ... and {len(users) - 5} more")
+
+        # Display groups if available
+        groups = project.get("groups", [])
+        if groups:
+            env.log(f"  Groups: {len(groups)} group(s)")
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.pass_context
+@pass_environment
+def cli(environment: Environment, context: click.Context, *args, **kwargs):
+    """Manage projects in TestRail"""
+    environment.cmd = "projects"
+    environment.set_parameters(context)
+
+
+@cli.command()
+@click.option("--project-id", type=int, metavar="<id>", required=True, help="Get project by project ID.")
+@click.option("--json-output", is_flag=True, help="Output project as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields including announcement, users, and groups.")
+@click.pass_context
+@pass_environment
+def get(
+    environment: Environment,
+    context: click.Context,
+    project_id: int,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """Get a specific project from TestRail"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Get")
+
+    # Create ProjectBasedClient for consistent API access
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Retrieve project
+    environment.log(f"Retrieving project with ID {project_id}...")
+    project, error_message = project_client.api_request_handler.project_handler.get_project(project_id)
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve project: {error_message}")
+        raise SystemExit(1)
+
+    if not project:
+        environment.log("No project found.")
+        return
+
+    if json_output:
+        print(json.dumps(project, indent=2))
+    else:
+        environment.log("")
+        display_project(environment, project, show_all_fields)
+        environment.log("")
+
+    environment.log("Project retrieval completed successfully.")
+
+
+@cli.command()
+@click.option(
+    "--is-completed",
+    type=int,
+    metavar="<0|1>",
+    help="Filter projects by completion status (0=active, 1=completed).",
+)
+@click.option("--limit", type=int, metavar="<limit>", help="Limit number of projects returned (default: 250).")
+@click.option("--offset", type=int, metavar="<offset>", help="Offset for pagination (default: 0).")
+@click.option("--json-output", is_flag=True, help="Output projects as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields for each project.")
+@click.pass_context
+@pass_environment
+def list(
+    environment: Environment,
+    context: click.Context,
+    is_completed: int,
+    limit: int,
+    offset: int,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """List all projects from TestRail"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "List")
+
+    # Create ProjectBasedClient for consistent API access
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Build description of filters
+    filters = []
+    if is_completed is not None:
+        filters.append(f"completed={is_completed}")
+    if limit is not None:
+        filters.append(f"limit={limit}")
+    if offset is not None:
+        filters.append(f"offset={offset}")
+
+    filter_desc = f" with filters: {', '.join(filters)}" if filters else ""
+    environment.log(f"Retrieving projects{filter_desc}...")
+
+    # Retrieve projects
+    projects, error_message = project_client.api_request_handler.project_handler.get_projects(
+        is_completed=is_completed, limit=limit, offset=offset
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve projects: {error_message}")
+        raise SystemExit(1)
+
+    if json_output:
+        print(json.dumps(projects, indent=2))
+        return
+
+    # Display results
+    environment.log(f"Found {len(projects)} project(s).")
+    environment.log("")
+
+    for project in projects:
+        display_project(environment, project, show_all_fields)
+        environment.log("")
+
+    environment.log("Project listing completed successfully.")

--- a/trcli/commands/cmd_projects.py
+++ b/trcli/commands/cmd_projects.py
@@ -43,6 +43,13 @@ def display_project(env: Environment, project: dict, show_all_fields: bool = Fal
         groups = project.get("groups", [])
         if groups:
             env.log(f"  Groups: {len(groups)} group(s)")
+            for group in groups[:5]:  # Show first 5 groups
+                group_id = group.get("id")
+                role = group.get("role", "N/A")
+                role_id = group.get("role_id", "N/A")
+                env.log(f"    - Group ID: {group_id}, Role: {role} (Role ID: {role_id})")
+            if len(groups) > 5:
+                env.log(f"    ... and {len(groups) - 5} more")
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
@@ -55,7 +62,9 @@ def cli(environment: Environment, context: click.Context, *args, **kwargs):
 
 
 @cli.command()
-@click.option("--project-id", type=int, metavar="<id>", required=True, help="Get project by project ID.")
+@click.option(
+    "--project-id", type=click.IntRange(min=1), metavar="<id>", required=True, help="Get project by project ID."
+)
 @click.option("--json-output", is_flag=True, help="Output project as raw JSON from API.")
 @click.option("--show-all-fields", is_flag=True, help="Show all fields including announcement, users, and groups.")
 @click.pass_context

--- a/trcli/commands/cmd_templates.py
+++ b/trcli/commands/cmd_templates.py
@@ -1,0 +1,77 @@
+import builtins
+import click
+import json
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def print_config(env: Environment, action: str):
+    env.log(f"Templates {action} Execution Parameters" f"\n> TestRail instance: {env.host} (user: {env.username})")
+
+
+def display_template(env: Environment, template: dict):
+    """Helper function to display a single template's information."""
+    env.log(f"Template ID: {template.get('id')}")
+    env.log(f"  Name: {template.get('name', 'N/A')}")
+    env.log(f"  Default: {'Yes' if template.get('is_default') else 'No'}")
+    env.log(f"  Custom ID: {template.get('i18n_custom_id', 'N/A')}")
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.pass_context
+@pass_environment
+def cli(environment: Environment, context: click.Context, *args, **kwargs):
+    """Manage templates in TestRail"""
+    environment.cmd = "templates"
+    environment.set_parameters(context)
+
+
+@cli.command()
+@click.option(
+    "--project-id", type=click.IntRange(min=1), metavar="<id>", required=True, help="Get templates for project ID."
+)
+@click.option("--json-output", is_flag=True, help="Output templates as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def list(
+    environment: Environment,
+    context: click.Context,
+    project_id: int,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """List all templates (field layouts) for a project"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "List")
+
+    # Create ProjectBasedClient for consistent API access
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Retrieve templates
+    environment.log(f"Retrieving templates for project ID {project_id}...")
+    templates, error_message = project_client.api_request_handler.template_handler.get_templates(project_id)
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve templates: {error_message}")
+        raise SystemExit(1)
+
+    if json_output:
+        print(json.dumps(templates, indent=2))
+        return
+
+    # Display results
+    environment.log(f"Found {len(templates)} template(s).")
+    environment.log("")
+
+    for template in templates:
+        display_template(environment, template)
+        environment.log("")
+
+    environment.log("Template listing completed successfully.")

--- a/trcli/commands/cmd_tests.py
+++ b/trcli/commands/cmd_tests.py
@@ -1,0 +1,206 @@
+import builtins
+import click
+import json
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def print_config(env: Environment, action: str):
+    env.log(f"Tests {action} Execution Parameters" f"\n> TestRail instance: {env.host} (user: {env.username})")
+
+
+def display_test(env: Environment, test: dict, show_all_fields: bool = False):
+    """Helper function to display a single test's information."""
+    env.log(f"Test ID: {test.get('id')}")
+    env.log(f"  Title: {test.get('title', 'N/A')}")
+    env.log(f"  Case ID: {test.get('case_id', 'N/A')}")
+    env.log(f"  Run ID: {test.get('run_id', 'N/A')}")
+    env.log(f"  Status ID: {test.get('status_id', 'N/A')}")
+
+    if show_all_fields:
+        env.log(f"  Assigned To ID: {test.get('assignedto_id', 'N/A')}")
+        env.log(f"  Priority ID: {test.get('priority_id', 'N/A')}")
+        env.log(f"  Type ID: {test.get('type_id', 'N/A')}")
+        env.log(f"  Estimate: {test.get('estimate', 'N/A')}")
+        env.log(f"  Estimate Forecast: {test.get('estimate_forecast', 'N/A')}")
+
+        # Display labels if available
+        labels = test.get("labels", [])
+        if labels:
+            env.log(f"  Labels: {len(labels)} label(s)")
+            for label in labels:
+                label_id = label.get("id")
+                label_title = label.get("title", "N/A")
+                env.log(f"    - Label ID: {label_id}, Title: {label_title}")
+
+        # Display custom fields
+        custom_fields = {k: v for k, v in test.items() if k.startswith("custom_")}
+        if custom_fields:
+            env.log(f"  Custom Fields: {len(custom_fields)} field(s)")
+            custom_items = [item for item in custom_fields.items()]
+            for field_name, field_value in custom_items:
+                # Handle list values (like custom_steps_separated)
+                if isinstance(field_value, builtins.list):
+                    env.log(f"    - {field_name}: {len(field_value)} item(s)")
+                else:
+                    # Truncate long values
+                    value_str = str(field_value)
+                    if len(value_str) > 50:
+                        value_str = value_str[:47] + "..."
+                    env.log(f"    - {field_name}: {value_str}")
+
+        # Display results if available (when using --with-data 1)
+        results = test.get("results", [])
+        if results:
+            env.log(f"  Results: {len(results)} result(s)")
+            for result in results:
+                result_id = result.get("id")
+                result_status = result.get("status_id")
+                env.log(f"    - Result ID: {result_id}, Status ID: {result_status}")
+
+        # Display attachments if available (when using --with-data 1)
+        attachments = test.get("attachments", [])
+        if attachments:
+            env.log(f"  Attachments: {len(attachments)} attachment(s)")
+            for attachment in attachments:
+                attachment_id = attachment.get("id")
+                attachment_name = attachment.get("name", "N/A")
+                env.log(f"    - Attachment ID: {attachment_id}, Name: {attachment_name}")
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.pass_context
+@pass_environment
+def cli(environment: Environment, context: click.Context, *args, **kwargs):
+    """Manage tests in TestRail"""
+    environment.cmd = "tests"
+    environment.set_parameters(context)
+
+
+@cli.command()
+@click.option("--test-id", type=click.IntRange(min=1), metavar="<id>", required=True, help="Get test by test ID.")
+@click.option(
+    "--with-data",
+    type=click.Choice(["0", "1"]),
+    metavar="<0|1>",
+    help="Include test results and attachments (0=no, 1=yes).",
+)
+@click.option("--json-output", is_flag=True, help="Output test as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields including custom fields and labels.")
+@click.pass_context
+@pass_environment
+def get(
+    environment: Environment,
+    context: click.Context,
+    test_id: int,
+    with_data: str,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """Get a specific test from TestRail"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Get")
+
+    # Create ProjectBasedClient for consistent API access
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Retrieve test
+    environment.log(f"Retrieving test with ID {test_id}...")
+    test, error_message = project_client.api_request_handler.test_handler.get_test(test_id, with_data)
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve test: {error_message}")
+        raise SystemExit(1)
+
+    if not test:
+        environment.log("No test found.")
+        return
+
+    if json_output:
+        print(json.dumps(test, indent=2))
+    else:
+        environment.log("")
+        display_test(environment, test, show_all_fields)
+        environment.log("")
+
+    environment.log("Test retrieval completed successfully.")
+
+
+@cli.command()
+@click.option("--run-id", type=click.IntRange(min=1), metavar="<id>", required=True, help="Get tests for run ID.")
+@click.option("--status-id", type=str, metavar="<ids>", help="Comma-separated list of status IDs to filter by.")
+@click.option("--limit", type=int, metavar="<limit>", help="Limit number of tests returned (default: 250).")
+@click.option("--offset", type=int, metavar="<offset>", help="Offset for pagination (default: 0).")
+@click.option("--label-id", type=str, metavar="<ids>", help="Comma-separated list of label IDs to filter by.")
+@click.option("--json-output", is_flag=True, help="Output tests as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields for each test.")
+@click.pass_context
+@pass_environment
+def list(
+    environment: Environment,
+    context: click.Context,
+    run_id: int,
+    status_id: str,
+    limit: int,
+    offset: int,
+    label_id: str,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """List all tests for a test run"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "List")
+
+    # Create ProjectBasedClient for consistent API access
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Build description of filters
+    filters = []
+    if status_id is not None:
+        filters.append(f"status_id={status_id}")
+    if limit is not None:
+        filters.append(f"limit={limit}")
+    if offset is not None:
+        filters.append(f"offset={offset}")
+    if label_id is not None:
+        filters.append(f"label_id={label_id}")
+
+    filter_desc = f" with filters: {', '.join(filters)}" if filters else ""
+    environment.log(f"Retrieving tests for run ID {run_id}{filter_desc}...")
+
+    # Retrieve tests
+    tests, error_message = project_client.api_request_handler.test_handler.get_tests(
+        run_id=run_id, status_id=status_id, limit=limit, offset=offset, label_id=label_id
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve tests: {error_message}")
+        raise SystemExit(1)
+
+    if json_output:
+        print(json.dumps(tests, indent=2))
+        return
+
+    # Display results
+    environment.log(f"Found {len(tests)} test(s).")
+    environment.log("")
+
+    for test in tests:
+        display_test(environment, test, show_all_fields)
+        environment.log("")
+
+    environment.log("Test listing completed successfully.")

--- a/trcli/commands/cmd_users.py
+++ b/trcli/commands/cmd_users.py
@@ -1,0 +1,184 @@
+import builtins
+import click
+import json
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def print_config(env: Environment, action: str):
+    env.log(f"Users {action} Execution Parameters" f"\n> TestRail instance: {env.host} (user: {env.username})")
+
+
+def display_user(env: Environment, user: dict, show_all_fields: bool = False):
+    """Helper function to display a single user's information."""
+    env.log(f"User ID: {user.get('id')}")
+    env.log(f"  Name: {user.get('name', 'N/A')}")
+    env.log(f"  Email: {user.get('email', 'N/A')}")
+
+    if show_all_fields:
+        env.log(f"  Role: {user.get('role', 'N/A')}")
+        env.log(f"  Role ID: {user.get('role_id', 'N/A')}")
+        env.log(f"  Active: {'Yes' if user.get('is_active') else 'No'}")
+        env.log(f"  Admin: {'Yes' if user.get('is_admin') else 'No'}")
+
+        # Enterprise-specific fields
+        if "sso_enabled" in user:
+            env.log(f"  SSO Enabled: {'Yes' if user.get('sso_enabled') else 'No'}")
+        if "assigned_projects" in user:
+            env.log(f"  Assigned Projects: {user.get('assigned_projects', [])}")
+        if "group_ids" in user:
+            env.log(f"  Group IDs: {user.get('group_ids', [])}")
+        if "mfa_required" in user:
+            env.log(f"  MFA Required: {'Yes' if user.get('mfa_required') else 'No'}")
+        if "email_notifications" in user:
+            env.log(f"  Email Notifications: {'Yes' if user.get('email_notifications') else 'No'}")
+    else:
+        # Basic display
+        if "role" in user:
+            env.log(f"  Role: {user.get('role', 'N/A')}")
+        if "is_active" in user:
+            env.log(f"  Active: {'Yes' if user.get('is_active') else 'No'}")
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.pass_context
+@pass_environment
+def cli(environment: Environment, context: click.Context, *args, **kwargs):
+    """Manage users in TestRail"""
+    environment.cmd = "users"
+    environment.set_parameters(context)
+
+
+@cli.command()
+@click.option("--current", is_flag=True, help="Get the current authenticated user.")
+@click.option("--user-id", type=int, metavar="<id>", help="Get user by user ID.")
+@click.option("--email", type=str, metavar="<email>", help="Get user by email address.")
+@click.option("--json-output", is_flag=True, help="Output user as raw JSON from API.")
+@click.option(
+    "--show-all-fields", is_flag=True, help="Show all fields including admin status, groups, and enterprise fields."
+)
+@click.pass_context
+@pass_environment
+def get(
+    environment: Environment,
+    context: click.Context,
+    current: bool,
+    user_id: int,
+    email: str,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """Get a specific user from TestRail"""
+    environment.check_for_required_parameters()
+
+    # Validate mutually exclusive options
+    options_provided = sum([current, user_id is not None, email is not None])
+    if options_provided == 0:
+        environment.elog("Error: Must specify one of --current, --user-id, or --email")
+        raise SystemExit(1)
+    if options_provided > 1:
+        environment.elog("Error: Options --current, --user-id, and --email are mutually exclusive")
+        raise SystemExit(1)
+
+    print_config(environment, "Get")
+
+    # Create ProjectBasedClient for consistent API access
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Retrieve user based on option
+    user = None
+    error_message = ""
+
+    if current:
+        environment.log("Retrieving current authenticated user...")
+        user, error_message = project_client.api_request_handler.user_handler.get_current_user()
+    elif user_id:
+        environment.log(f"Retrieving user with ID {user_id}...")
+        user, error_message = project_client.api_request_handler.user_handler.get_user(user_id)
+    elif email:
+        environment.log(f"Retrieving user with email {email}...")
+        user, error_message = project_client.api_request_handler.user_handler.get_user_by_email(email)
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve user: {error_message}")
+        raise SystemExit(1)
+
+    if not user:
+        environment.log("No user found.")
+        return
+
+    if json_output:
+        print(json.dumps(user, indent=2))
+    else:
+        environment.log("")
+        display_user(environment, user, show_all_fields)
+        environment.log("")
+
+    environment.log("User retrieval completed successfully.")
+
+
+@cli.command()
+@click.option(
+    "--project-id",
+    type=int,
+    metavar="<id>",
+    help="Filter users by project ID (returns only users with access to the project).",
+)
+@click.option("--json-output", is_flag=True, help="Output users as raw JSON from API.")
+@click.option("--show-all-fields", is_flag=True, help="Show all fields for each user.")
+@click.pass_context
+@pass_environment
+def list(
+    environment: Environment,
+    context: click.Context,
+    project_id: int,
+    json_output: bool,
+    show_all_fields: bool,
+    *args,
+    **kwargs,
+):
+    """List all users from TestRail"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "List")
+
+    # Create ProjectBasedClient for consistent API access
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    if project_id:
+        environment.log(f"Retrieving users for project ID {project_id}...")
+    else:
+        environment.log("Retrieving all users...")
+        environment.log("Note: Listing all users requires administrator privileges.")
+
+    # Retrieve users
+    users, error_message = project_client.api_request_handler.user_handler.get_users(project_id)
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve users: {error_message}")
+        raise SystemExit(1)
+
+    if json_output:
+        print(json.dumps(users, indent=2))
+    else:
+        environment.log(f"Found {len(users)} user(s).")
+        environment.log("")
+
+        if not users:
+            environment.log("No users found.")
+        else:
+            for user in users:
+                display_user(environment, user, show_all_fields)
+                environment.log("")
+
+    environment.log("User listing completed successfully.")

--- a/trcli/constants.py
+++ b/trcli/constants.py
@@ -100,6 +100,7 @@ COMMAND_FAULT_MAPPING = dict(
     statuses=dict(**FAULT_MAPPING),
     casefields=dict(**FAULT_MAPPING),
     resultfields=dict(**FAULT_MAPPING),
+    priorities=dict(**FAULT_MAPPING),
 )
 
 PROMPT_MESSAGES = dict(
@@ -136,6 +137,7 @@ TOOL_USAGE = f"""Supported and loaded modules:
     - statuses: Query test statuses
     - casefields: Query test case custom fields
     - resultfields: Query test result custom fields
+    - priorities: Query test case priorities
     - results: Query and update test results (list, update)"""
 
 MISSING_COMMAND_SLOGAN = """Usage: trcli [OPTIONS] COMMAND [ARGS]...\nTry 'trcli --help' for help.

--- a/trcli/constants.py
+++ b/trcli/constants.py
@@ -102,6 +102,7 @@ COMMAND_FAULT_MAPPING = dict(
     resultfields=dict(**FAULT_MAPPING),
     priorities=dict(**FAULT_MAPPING),
     casetypes=dict(**FAULT_MAPPING),
+    users=dict(**FAULT_MAPPING),
 )
 
 PROMPT_MESSAGES = dict(
@@ -140,6 +141,7 @@ TOOL_USAGE = f"""Supported and loaded modules:
     - resultfields: Query test result custom fields
     - priorities: Query test case priorities
     - casetypes: Query test case types
+    - users: Query users (get and list)
     - results: Query and update test results (list, update)"""
 
 MISSING_COMMAND_SLOGAN = """Usage: trcli [OPTIONS] COMMAND [ARGS]...\nTry 'trcli --help' for help.

--- a/trcli/constants.py
+++ b/trcli/constants.py
@@ -101,6 +101,7 @@ COMMAND_FAULT_MAPPING = dict(
     casefields=dict(**FAULT_MAPPING),
     resultfields=dict(**FAULT_MAPPING),
     priorities=dict(**FAULT_MAPPING),
+    casetypes=dict(**FAULT_MAPPING),
 )
 
 PROMPT_MESSAGES = dict(
@@ -138,6 +139,7 @@ TOOL_USAGE = f"""Supported and loaded modules:
     - casefields: Query test case custom fields
     - resultfields: Query test result custom fields
     - priorities: Query test case priorities
+    - casetypes: Query test case types
     - results: Query and update test results (list, update)"""
 
 MISSING_COMMAND_SLOGAN = """Usage: trcli [OPTIONS] COMMAND [ARGS]...\nTry 'trcli --help' for help.

--- a/trcli/constants.py
+++ b/trcli/constants.py
@@ -103,6 +103,7 @@ COMMAND_FAULT_MAPPING = dict(
     priorities=dict(**FAULT_MAPPING),
     casetypes=dict(**FAULT_MAPPING),
     users=dict(**FAULT_MAPPING),
+    projects=dict(**FAULT_MAPPING),
 )
 
 PROMPT_MESSAGES = dict(
@@ -142,6 +143,7 @@ TOOL_USAGE = f"""Supported and loaded modules:
     - priorities: Query test case priorities
     - casetypes: Query test case types
     - users: Query users (get and list)
+    - projects: Query projects (get and list)
     - results: Query and update test results (list, update)"""
 
 MISSING_COMMAND_SLOGAN = """Usage: trcli [OPTIONS] COMMAND [ARGS]...\nTry 'trcli --help' for help.

--- a/trcli/constants.py
+++ b/trcli/constants.py
@@ -105,6 +105,7 @@ COMMAND_FAULT_MAPPING = dict(
     users=dict(**FAULT_MAPPING),
     projects=dict(**FAULT_MAPPING),
     templates=dict(**FAULT_MAPPING),
+    tests=dict(**FAULT_MAPPING),
 )
 
 PROMPT_MESSAGES = dict(
@@ -146,6 +147,7 @@ TOOL_USAGE = f"""Supported and loaded modules:
     - users: Query users (get and list)
     - projects: Query projects (get and list)
     - templates: Query templates (list)
+    - tests: Query tests (get and list)
     - results: Query and update test results (list, update)"""
 
 MISSING_COMMAND_SLOGAN = """Usage: trcli [OPTIONS] COMMAND [ARGS]...\nTry 'trcli --help' for help.

--- a/trcli/constants.py
+++ b/trcli/constants.py
@@ -104,6 +104,7 @@ COMMAND_FAULT_MAPPING = dict(
     casetypes=dict(**FAULT_MAPPING),
     users=dict(**FAULT_MAPPING),
     projects=dict(**FAULT_MAPPING),
+    templates=dict(**FAULT_MAPPING),
 )
 
 PROMPT_MESSAGES = dict(
@@ -144,6 +145,7 @@ TOOL_USAGE = f"""Supported and loaded modules:
     - casetypes: Query test case types
     - users: Query users (get and list)
     - projects: Query projects (get and list)
+    - templates: Query templates (list)
     - results: Query and update test results (list, update)"""
 
 MISSING_COMMAND_SLOGAN = """Usage: trcli [OPTIONS] COMMAND [ARGS]...\nTry 'trcli --help' for help.


### PR DESCRIPTION
### Solution description
We implemented a new add subcommand for plans that will allow users to add test plans with custom configurations, entries (runs including specific test cases), milestones, scheduled dates.

### Changes
add subcommand is added in plans command with multiple options such as milestone-id, entries (inline JSON array of plan entries), entries-file (plan entries also in JSON format for more complex, multi config runs) and others.

### Potential impacts
None.

### Steps to test
See updated README file:  1839 - 2029

### PR Tasks
- [x] PR reference added to issue
- [x] README updated
- [x] Unit tests added/updated
