### PR TITLE
TR-20990: List/Get export command for Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -2618,13 +2618,16 @@ Commands:
 
 ```shell
 # List all priorities
-$ trcli priorities list -h https://yourinstance.testrail.io -u user@example.com -p password
+$ trcli -c config.yml priorities list
 
 # Show all fields including priority order
-$ trcli priorities list -c config.yml --show-all-fields
+$ trcli -c config.yml priorities list --show-all-fields
 
 # JSON output
-$ trcli priorities list -c config.yml --json-output
+$ trcli -c config.yml priorities list --json-output
+
+# Without config file (inline credentials)
+$ trcli -h https://yourinstance.testrail.io -u user@example.com -p password priorities list
 ```
 
 #### Example Output
@@ -2670,13 +2673,13 @@ Commands:
 
 ```shell
 # List all case types
-$ trcli -h https://yourinstance.testrail.io -u user@example.com -p password casetypes list
-
-# With config file
-$ trcli casetypes list -c config.yml
+$ trcli -c config.yml casetypes list
 
 # JSON output
-$ trcli casetypes list -c config.yml --json-output
+$ trcli -c config.yml casetypes list --json-output
+
+# Without config file (inline credentials)
+$ trcli -h https://yourinstance.testrail.io -u user@example.com -p password casetypes list
 ```
 
 #### Example Output
@@ -4056,6 +4059,223 @@ components:
           type: string
           example: Guru
 ```
+
+### Test Data Management using Variables and Datasets (NOTE: Supported for TestRail Enterprise 7.6 or later only)
+
+TestRail Enterprise provides **Test Data Management** functionality that allows you to define variables and datasets for your test cases. TRCLI provides commands to manage both variables and datasets programmatically.
+
+**Key Concepts:**
+- **Variables**: Reusable parameters that can be referenced in test cases (e.g., `browser`, `username`, `api_endpoint`)
+- **Datasets**: Collections of variable values representing different test scenarios (e.g., `Chrome_Dataset`, `Firefox_Dataset`)
+
+#### Naming Conventions and Validation Rules
+
+Both variables and datasets must follow these naming rules:
+
+| Rule | Description |
+|------|-------------|
+| **Characters** | Only letters (A-Z, a-z), numbers (0-9), and underscores (_) |
+| **No Spaces** | Spaces are not allowed in names |
+| **No Special Characters** | Cannot use special characters like -, ., /, %, @, etc. |
+| **Cannot Start with Underscore** | Names cannot begin with an underscore (_) |
+| **Maximum Length** | Maximum 50 characters |
+| **Uniqueness** | Must be unique within a project |
+| **Case-Sensitive** | Names are case-sensitive (e.g., `Chrome` and `chrome` are different) |
+
+#### Variables Command
+
+Manage test data variables for your project.
+
+##### Listing Variables
+
+```bash
+# List all variables for a project
+trcli -c config.yml variables list
+
+# With pagination
+trcli -c config.yml variables list --offset 250 --limit 100
+
+# JSON output for integration
+trcli -c config.yml variables list --json-output
+
+# Without config file (inline credentials)
+trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  variables list
+```
+
+##### Adding a Variable
+
+```bash
+# Create a new variable
+trcli -c config.yml variables add --name "browser"
+
+# JSON output
+trcli -c config.yml variables add --name "test_user" --json-output
+
+# Without config file (inline credentials)
+trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  variables add --name "api_endpoint"
+```
+
+##### Updating a Variable
+
+```bash
+# Update an existing variable
+trcli -c config.yml variables update --variable-id 123 --name "web_browser"
+
+# Without config file (inline credentials)
+trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  variables update --variable-id 456 --name "api_url"
+```
+
+##### Deleting a Variable
+
+```bash
+# Delete a variable (also deletes corresponding values from datasets)
+trcli -c config.yml variables delete --variable-id 123
+
+# Without config file (inline credentials)
+trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  variables delete --variable-id 456
+```
+
+**Note:** Deleting a variable will also delete the corresponding values from all datasets.
+
+#### Datasets Command
+
+Manage test data datasets for your project.
+
+##### Listing Datasets
+
+```bash
+# List all datasets for a project
+trcli -c config.yml datasets list
+
+# With pagination
+trcli -c config.yml datasets list --offset 250 --limit 100
+
+# JSON output
+trcli -c config.yml datasets list --json-output
+
+# Without config file (inline credentials)
+trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  datasets list
+```
+
+##### Viewing a Dataset
+
+```bash
+# Show a specific dataset with all variable values
+trcli -c config.yml datasets show --dataset-id 123
+
+# JSON output
+trcli -c config.yml datasets show --dataset-id 456 --json-output
+
+# Without config file (inline credentials)
+trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  datasets show --dataset-id 789
+```
+
+##### Adding a Dataset
+
+```bash
+# Create a new dataset with variables
+trcli -c config.yml datasets add \
+  --name "Chrome_Dataset" \
+  --variables '{"browser":"Chrome","version":"120.0"}'
+
+# Create a dataset without initial variables
+trcli -c config.yml datasets add --name "Firefox_Dataset"
+
+# JSON output
+trcli -c config.yml datasets add \
+  --name "Edge_Dataset" \
+  --variables '{"browser":"Edge","version":"119.0"}' \
+  --json-output
+
+# Without config file (inline credentials)
+trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  datasets add --name "Safari_Dataset" \
+  --variables '{"browser":"Safari","version":"17.0"}'
+```
+
+**Variables Format:**
+- Must be a JSON object with variable_name: value pairs
+- **Important:** Before adding a dataset with variables, ensure all variable names have been created in the project. If you reference a non-existent variable, the API will return an error.
+- All values must be strings
+- Example: `'{"browser":"Chrome","os":"Windows","version":"1.0"}'`
+
+##### Updating a Dataset
+
+```bash
+# Update dataset name only
+trcli -c config.yml datasets update \
+  --dataset-id 123 \
+  --name "Chrome_Latest"
+
+# Update variables only
+trcli -c config.yml datasets update \
+  --dataset-id 456 \
+  --variables '{"browser":"Chrome","version":"121.0"}'
+
+# Update both name and variables
+trcli -c config.yml datasets update \
+  --dataset-id 789 \
+  --name "Production_Environment" \
+  --variables '{"api_url":"https://api.prod.com","timeout":"30"}'
+
+# JSON output
+trcli -c config.yml datasets update \
+  --dataset-id 123 \
+  --name "Updated_Dataset" \
+  --json-output
+
+# Without config file (inline credentials)
+trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  datasets update --dataset-id 456 --name "New_Dataset_Name"
+```
+
+**Note:** At least one of `--name` or `--variables` must be provided for update.
+
+##### Deleting a Dataset
+
+```bash
+# Delete a dataset (cannot delete "Default" dataset)
+trcli -c config.yml datasets delete --dataset-id 123
+
+# Without config file (inline credentials)
+trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  datasets delete --dataset-id 456
+```
+
+**Note:** Cannot delete the "Default" dataset. Deleting a dataset will also remove the dataset's values.
 
 ### Generating test cases
 

--- a/README.md
+++ b/README.md
@@ -2768,6 +2768,67 @@ $ trcli -c config.yml users list --json-output
 - Enterprise-specific fields (SSO, assigned projects) are only available in TestRail Enterprise
 - The `--show-all-fields` option displays additional information including admin status, groups, MFA requirements, and enterprise fields
 
+### Groups Command
+
+The TestRail CLI provides the `groups` command for retrieving group information from TestRail. Groups allow you to organize users and manage permissions collectively. This command supports viewing individual groups with their member lists and listing all available groups.
+
+#### Reference
+
+```shell
+$ trcli groups --help
+
+Usage: trcli groups [OPTIONS] COMMAND [ARGS]...
+  Manage groups in TestRail
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  list  List all groups from TestRail
+  show  Get a specific group from TestRail
+```
+
+#### Viewing a Specific Group
+
+The `show` subcommand retrieves detailed information about a single group, including its name and list of member user IDs.
+
+```shell
+# Get a specific group by ID
+$ trcli -c config.yml groups show --group-id 1
+
+# JSON output
+$ trcli -c config.yml groups show --group-id 3 --json-output
+
+# Without config file (inline credentials)
+$ trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  groups show --group-id 5
+```
+
+#### Listing Groups
+
+The `list` subcommand retrieves all available groups in your TestRail instance with pagination support.
+
+```shell
+# List all groups
+$ trcli -c config.yml groups list
+
+# With pagination
+$ trcli -c config.yml groups list --limit 100 --offset 0
+
+# JSON output
+$ trcli -c config.yml groups list --json-output
+
+# Without config file (inline credentials)
+$ trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  groups list
+```
+
 ### Projects Command
 
 The `projects` command provides functionality to query and retrieve project information from TestRail. This command allows you to get details about specific projects or list all projects in your TestRail instance.

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,9 @@ setup(
     name="trcli",
     long_description="The TR CLI (trcli) is a command line tool for interacting with TestRail and uploading test automation results.",
     version=__version__,
+    setup_requires=[
+        "setuptools>=83.0.0",  # Updated to address PYSEC-2026-3447 (Unicode normalization bypass on macOS)
+    ],
     packages=[
         "trcli",
         "trcli.commands",
@@ -16,7 +19,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        "click>=8.1.0,<8.2.2",  # Note: click version 8.2.2 is yanked as of Aug 2, 2025!
+        "click>=8.3.3,<9.0.0",
         "pyyaml>=6.0.0,<7.0.0",
         "junitparser>=3.1.0,<4.0.0",
         "pyserde==0.12.*",

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,6 @@ setup(
     name="trcli",
     long_description="The TR CLI (trcli) is a command line tool for interacting with TestRail and uploading test automation results.",
     version=__version__,
-    setup_requires=[
-        "setuptools>=83.0.0",  # Updated to address PYSEC-2026-3447 (Unicode normalization bypass on macOS)
-    ],
     packages=[
         "trcli",
         "trcli.commands",

--- a/tests/requirements-tox.txt
+++ b/tests/requirements-tox.txt
@@ -1,4 +1,4 @@
-pytest==8.0.*
+pytest>=9.0.3
 pytest-md-report
 coverage
 allure-pytest

--- a/tests/test_cmd_groups.py
+++ b/tests/test_cmd_groups.py
@@ -1,0 +1,288 @@
+import pytest
+from unittest import mock
+from unittest.mock import MagicMock, patch
+from click.testing import CliRunner
+
+from trcli.cli import Environment
+from trcli.commands import cmd_groups
+
+
+class TestCmdGroups:
+    """Test class for groups command functionality"""
+
+    def setup_method(self):
+        """Set up test environment"""
+        self.runner = CliRunner()
+        self.environment = Environment(cmd="groups")
+        self.environment.host = "https://test.testrail.com"
+        self.environment.username = "test@example.com"
+        self.environment.password = "password"
+        self.environment.api_key = None
+
+    def _setup_project_client_mock(self, mock_project_client):
+        """Helper to setup ProjectBasedClient mock"""
+        mock_client_instance = MagicMock()
+        mock_project_client.return_value = mock_client_instance
+        return mock_client_instance
+
+    # SHOW subcommand tests
+
+    @mock.patch("trcli.commands.cmd_groups.ProjectBasedClient")
+    def test_show_group_success(self, mock_project_client):
+        """Test showing a specific group by ID"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.groups_handler.get_group.return_value = (
+            {"id": 1, "name": "QA Team", "user_ids": [1, 3, 5, 7]},
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_groups.show, ["--group-id", "1"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.groups_handler.get_group.assert_called_once_with(1)
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_groups.ProjectBasedClient")
+    def test_show_group_with_no_members(self, mock_project_client):
+        """Test showing a group with no members"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.groups_handler.get_group.return_value = (
+            {"id": 2, "name": "Empty Group", "user_ids": []},
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_groups.show, ["--group-id", "2"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.groups_handler.get_group.assert_called_once_with(2)
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_groups.ProjectBasedClient")
+    def test_show_group_json_output(self, mock_project_client):
+        """Test showing group with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        group_data = {"id": 3, "name": "Developers", "user_ids": [2, 4, 6]}
+        mock_client.api_request_handler.groups_handler.get_group.return_value = (group_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_groups.show, ["--group-id", "3", "--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert '"name": "Developers"' in result.output
+            assert '"user_ids"' in result.output
+
+    @mock.patch("trcli.commands.cmd_groups.ProjectBasedClient")
+    def test_show_group_api_error(self, mock_project_client):
+        """Test showing group with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.groups_handler.get_group.return_value = ({}, "Group not found")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"), patch.object(self.environment, "log"):
+            result = self.runner.invoke(cmd_groups.show, ["--group-id", "999"], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Failed to retrieve group: Group not found")
+
+    @mock.patch("trcli.commands.cmd_groups.ProjectBasedClient")
+    def test_show_group_not_found(self, mock_project_client):
+        """Test showing group when group is not found (empty response)"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.groups_handler.get_group.return_value = ({}, "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_groups.show, ["--group-id", "100"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Check that "No group found" message appears in logs
+            log_calls = [str(call) for call in mock_log.call_args_list]
+            assert any("No group found" in str(call) for call in log_calls)
+
+    # LIST subcommand tests
+
+    @mock.patch("trcli.commands.cmd_groups.ProjectBasedClient")
+    def test_list_groups_success(self, mock_project_client):
+        """Test listing groups successfully"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.groups_handler.get_groups.return_value = (
+            {
+                "offset": 0,
+                "limit": 250,
+                "size": 2,
+                "_links": {"next": None, "prev": None},
+                "groups": [
+                    {"id": 1, "name": "QA Team", "user_ids": [1, 3, 5]},
+                    {"id": 2, "name": "Developers", "user_ids": [2, 4, 6, 8]},
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_groups.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.groups_handler.get_groups.assert_called_once_with(limit=250, offset=0)
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_groups.ProjectBasedClient")
+    def test_list_groups_with_pagination(self, mock_project_client):
+        """Test listing groups with custom pagination"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.groups_handler.get_groups.return_value = (
+            {
+                "offset": 10,
+                "limit": 5,
+                "size": 15,
+                "_links": {"next": "/api/v2/get_groups?offset=15", "prev": "/api/v2/get_groups?offset=5"},
+                "groups": [{"id": i, "name": f"Group {i}", "user_ids": [i, i + 1]} for i in range(11, 16)],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_groups.list, ["--limit", "5", "--offset", "10"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.groups_handler.get_groups.assert_called_once_with(limit=5, offset=10)
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_groups.ProjectBasedClient")
+    def test_list_groups_json_output(self, mock_project_client):
+        """Test listing groups with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        response_data = {
+            "offset": 0,
+            "limit": 250,
+            "size": 1,
+            "_links": {"next": None, "prev": None},
+            "groups": [{"id": 1, "name": "Test Group", "user_ids": [1, 2]}],
+        }
+        mock_client.api_request_handler.groups_handler.get_groups.return_value = (response_data, "")
+
+        with patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_groups.list, ["--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            assert '"groups"' in result.output
+            assert '"Test Group"' in result.output
+
+    @mock.patch("trcli.commands.cmd_groups.ProjectBasedClient")
+    def test_list_groups_empty(self, mock_project_client):
+        """Test listing groups when no groups exist"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.groups_handler.get_groups.return_value = (
+            {"offset": 0, "limit": 250, "size": 0, "_links": {"next": None, "prev": None}, "groups": []},
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_groups.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Check that "No groups found" message appears in logs
+            log_calls = [str(call) for call in mock_log.call_args_list]
+            assert any("No groups found" in str(call) for call in log_calls)
+
+    @mock.patch("trcli.commands.cmd_groups.ProjectBasedClient")
+    def test_list_groups_api_error(self, mock_project_client):
+        """Test listing groups with API error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.groups_handler.get_groups.return_value = ({}, "API connection error")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"), patch.object(self.environment, "log"):
+            result = self.runner.invoke(cmd_groups.list, [], obj=self.environment)
+
+            assert result.exit_code == 1
+            mock_elog.assert_called_with("Error: Failed to retrieve groups: API connection error")
+
+    @mock.patch("trcli.commands.cmd_groups.ProjectBasedClient")
+    def test_list_groups_with_pagination_hint(self, mock_project_client):
+        """Test listing groups shows pagination hint when more results available"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.groups_handler.get_groups.return_value = (
+            {
+                "offset": 0,
+                "limit": 2,
+                "size": 10,
+                "_links": {"next": "/api/v2/get_groups?offset=2", "prev": None},
+                "groups": [
+                    {"id": 1, "name": "Group 1", "user_ids": [1]},
+                    {"id": 2, "name": "Group 2", "user_ids": [2]},
+                ],
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_groups.list, ["--limit", "2"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Check that pagination hint appears
+            log_calls = [str(call) for call in mock_log.call_args_list]
+            assert any("--offset 2" in str(call) for call in log_calls)
+
+    # Helper function tests
+
+    def test_display_group_with_members(self):
+        """Test display_group helper function with members"""
+        group = {"id": 1, "name": "Test Group", "user_ids": [1, 2, 3]}
+
+        with patch.object(self.environment, "log") as mock_log:
+            cmd_groups.display_group(self.environment, group)
+
+            # Verify all expected log calls
+            log_calls = [call[0][0] for call in mock_log.call_args_list]
+            assert "Group ID: 1" in log_calls
+            assert "  Name: Test Group" in log_calls
+            assert "  Members: 3 user(s)" in log_calls
+            assert "  User IDs: 1, 2, 3" in log_calls
+
+    def test_display_group_without_members(self):
+        """Test display_group helper function without members"""
+        group = {"id": 2, "name": "Empty Group", "user_ids": []}
+
+        with patch.object(self.environment, "log") as mock_log:
+            cmd_groups.display_group(self.environment, group)
+
+            # Verify all expected log calls
+            log_calls = [call[0][0] for call in mock_log.call_args_list]
+            assert "Group ID: 2" in log_calls
+            assert "  Name: Empty Group" in log_calls
+            assert "  Members: 0 user(s)" in log_calls
+
+    def test_display_group_missing_fields(self):
+        """Test display_group helper with missing fields"""
+        group = {"id": 3}  # Missing name and user_ids
+
+        with patch.object(self.environment, "log") as mock_log:
+            cmd_groups.display_group(self.environment, group)
+
+            # Verify it handles missing fields gracefully
+            log_calls = [call[0][0] for call in mock_log.call_args_list]
+            assert "Group ID: 3" in log_calls
+            assert "  Name: N/A" in log_calls
+            assert "  Members: 0 user(s)" in log_calls

--- a/tests/test_data/cli_test_data.py
+++ b/tests/test_data/cli_test_data.py
@@ -92,6 +92,7 @@ trcli_description = (
     "    - results: Query and update test results (list, update)\n"
     "    - variables: Manage test data variables (list, add, update, delete)\n"
     "    - datasets: Manage test data datasets (list, show, add, update, delete)\n"
+    "    - groups: Manage groups (list, show)\n"
 )
 
 trcli_help_description = "TestRail CLI"

--- a/tests/test_data/cli_test_data.py
+++ b/tests/test_data/cli_test_data.py
@@ -90,6 +90,8 @@ trcli_description = (
     "    - templates: Query templates (list)\n"
     "    - tests: Query tests (get and list)\n"
     "    - results: Query and update test results (list, update)\n"
+    "    - variables: Manage test data variables (list, add, update, delete)\n"
+    "    - datasets: Manage test data datasets (list, show, add, update, delete)\n"
 )
 
 trcli_help_description = "TestRail CLI"

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,30 @@
 [tox]
-env_list = 
-     unit-test, #click-pyyaml{60,latest}-junitparser{31,latest}-pyserde{12,latest}-requests{231,232,latest}-tqdm{465,latest}-humanfriendly{100,latest}-openapi{50,latest}-beartype{17,latest}-prance
+env_list =
+     unit-test, security-audit, #click-pyyaml{60,latest}-junitparser{31,latest}-pyserde{12,latest}-requests{231,232,latest}-tqdm{465,latest}-humanfriendly{100,latest}-openapi{50,latest}-beartype{17,latest}-prance
 
 [testenv:unit-test]
 description = run basic unit test based on latest version of dependencies
-commands = 
+commands =
     pip install -r tests/requirements-tox.txt
     pip install -r tests/requirements-variable-deps.txt
     pip list
     coverage run -m pytest -c tests/pytest.ini -W ignore::pytest.PytestCollectionWarning tests
     coverage report -m
 
-allowlist_externals = 
+allowlist_externals =
     cd
+
+[testenv:security-audit]
+description = run pip-audit to check for known security vulnerabilities in dependencies
+deps =
+    pip>=26.1.2
+    setuptools>=83.0.0
+    pip-audit
+skip_install = false
+commands =
+    pip install --upgrade pip>=26.1.2 setuptools>=83.0.0
+    pip install -e .
+    pip-audit --desc
 
 [testenv]
 description = Run dependencies matrix  + full unit test (NOTE: May take time as different versions of each dependencies are tested against each other!)

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -27,6 +27,8 @@ from trcli.api.user_handler import UserHandler
 from trcli.api.project_handler import ProjectHandler
 from trcli.api.template_handler import TemplateHandler
 from trcli.api.test_handler import TestHandler
+from trcli.api.variables_handler import VariablesHandler
+from trcli.api.datasets_handler import DatasetsHandler
 from trcli.cli import Environment
 from trcli.constants import (
     ProjectErrors,
@@ -108,6 +110,8 @@ class ApiRequestHandler:
         self.project_handler = ProjectHandler(api_client)
         self.template_handler = TemplateHandler(api_client)
         self.test_handler = TestHandler(api_client)
+        self.variables_handler = VariablesHandler(api_client, environment)
+        self.datasets_handler = DatasetsHandler(api_client, environment)
 
         # BDD case cache for feature name matching (shared by CucumberParser and JunitParser)
         # Structure: {"{project_id}_{suite_id}": {normalized_name: [case_dict, case_dict, ...]}}

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -29,6 +29,7 @@ from trcli.api.template_handler import TemplateHandler
 from trcli.api.test_handler import TestHandler
 from trcli.api.variables_handler import VariablesHandler
 from trcli.api.datasets_handler import DatasetsHandler
+from trcli.api.groups_handler import GroupsHandler
 from trcli.cli import Environment
 from trcli.constants import (
     ProjectErrors,
@@ -112,6 +113,7 @@ class ApiRequestHandler:
         self.test_handler = TestHandler(api_client)
         self.variables_handler = VariablesHandler(api_client, environment)
         self.datasets_handler = DatasetsHandler(api_client, environment)
+        self.groups_handler = GroupsHandler(api_client, environment)
 
         # BDD case cache for feature name matching (shared by CucumberParser and JunitParser)
         # Structure: {"{project_id}_{suite_id}": {normalized_name: [case_dict, case_dict, ...]}}

--- a/trcli/api/datasets_handler.py
+++ b/trcli/api/datasets_handler.py
@@ -1,0 +1,153 @@
+"""
+DatasetsHandler - Handles all datasets-related operations for TestRail
+
+It manages all dataset operations including:
+- Retrieving individual datasets
+- Listing all datasets
+- Adding new datasets
+- Updating existing datasets
+- Deleting datasets
+"""
+
+from beartype.typing import Tuple, Optional, Dict, Any
+
+from trcli.api.api_client import APIClient
+from trcli.cli import Environment
+
+
+class DatasetsHandler:
+    """Handles all datasets-related operations for TestRail"""
+
+    def __init__(
+        self,
+        client: APIClient,
+        environment: Environment,
+    ):
+        """
+        Initialize the DatasetsHandler
+
+        :param client: APIClient instance for making API calls
+        :param environment: Environment configuration
+        """
+        self.client = client
+        self.environment = environment
+
+    def get_dataset(self, dataset_id: int) -> Tuple[dict, str]:
+        """
+        Retrieve a single dataset by ID
+
+        :param dataset_id: TestRail dataset ID
+        :returns: Tuple with (dataset_data_dict, error_message)
+        """
+        response = self.client.send_get(f"get_dataset/{dataset_id}")
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""
+
+    def get_datasets(
+        self,
+        project_id: int,
+        limit: int = 250,
+        offset: int = 0,
+    ) -> Tuple[dict, str]:
+        """
+        Retrieve datasets for a project with pagination
+
+        :param project_id: TestRail project ID
+        :param limit: Maximum number of datasets to return (default: 250)
+        :param offset: Offset for pagination (default: 0)
+        :returns: Tuple with (paginated_response_dict, error_message)
+                  Response dict contains: datasets, offset, limit, size, _links
+        """
+        # Build query parameters
+        params = []
+        if limit != 250:
+            params.append(f"limit={limit}")
+        if offset > 0:
+            params.append(f"offset={offset}")
+
+        # Build URL
+        query_string = "&".join(params) if params else ""
+        url = f"get_datasets/{project_id}"
+        if query_string:
+            url = f"{url}&{query_string}"
+
+        response = self.client.send_get(url)
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""
+
+    def add_dataset(
+        self,
+        project_id: int,
+        name: str,
+        variables: Optional[Dict[str, str]] = None,
+    ) -> Tuple[Dict[str, Any], str]:
+        """
+        Create a new dataset
+
+        :param project_id: TestRail project ID
+        :param name: Name of the dataset (required)
+        :param variables: Dictionary of variable_name: value pairs (optional)
+        :returns: Tuple with (created_dataset_dict, error_message)
+        """
+        payload = {"name": name}
+
+        if variables:
+            payload["variables"] = variables
+
+        response = self.client.send_post(f"add_dataset/{project_id}", payload)
+        if response.error_message:
+            return {}, response.error_message
+
+        return response.response_text, ""
+
+    def update_dataset(
+        self,
+        dataset_id: int,
+        name: Optional[str] = None,
+        variables: Optional[Dict[str, str]] = None,
+    ) -> Tuple[Dict[str, Any], str]:
+        """
+        Update an existing dataset
+
+        :param dataset_id: TestRail dataset ID
+        :param name: New name for the dataset (optional)
+        :param variables: Dictionary of variable_name: value pairs (optional)
+        :returns: Tuple with (updated_dataset_dict, error_message)
+        """
+        payload = {}
+
+        if name is not None:
+            payload["name"] = name
+
+        if variables:
+            payload["variables"] = variables
+
+        if not payload:
+            return {}, "Error: At least one field (name or variables) must be provided for update"
+
+        response = self.client.send_post(f"update_dataset/{dataset_id}", payload)
+        if response.error_message:
+            return {}, response.error_message
+
+        return response.response_text, ""
+
+    def delete_dataset(
+        self,
+        dataset_id: int,
+    ) -> Tuple[dict, str]:
+        """
+        Delete an existing dataset
+
+        Note: Cannot delete the Default dataset.
+        Deleting a dataset also removes the dataset's values.
+
+        :param dataset_id: TestRail dataset ID
+        :returns: Tuple with (response_dict, error_message)
+        """
+        response = self.client.send_post(f"delete_dataset/{dataset_id}", {})
+        if response.error_message:
+            return {}, response.error_message
+
+        return response.response_text, ""

--- a/trcli/api/groups_handler.py
+++ b/trcli/api/groups_handler.py
@@ -1,0 +1,73 @@
+"""
+GroupsHandler - Handles all group-related operations for TestRail
+
+It manages all group operations including:
+- Retrieving individual groups
+- Listing groups with pagination
+"""
+
+from beartype.typing import Tuple, Dict, Any
+
+from trcli.api.api_client import APIClient
+from trcli.cli import Environment
+
+
+class GroupsHandler:
+    """Handles all group-related operations for TestRail"""
+
+    def __init__(
+        self,
+        client: APIClient,
+        environment: Environment,
+    ):
+        """
+        Initialize the GroupsHandler
+
+        :param client: APIClient instance for making API calls
+        :param environment: Environment configuration
+        """
+        self.client = client
+        self.environment = environment
+
+    def get_group(self, group_id: int) -> Tuple[dict, str]:
+        """
+        Retrieve a single group by ID
+
+        :param group_id: TestRail group ID
+        :returns: Tuple with (group_data_dict, error_message)
+        """
+        response = self.client.send_get(f"get_group/{group_id}")
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""
+
+    def get_groups(
+        self,
+        limit: int = 250,
+        offset: int = 0,
+    ) -> Tuple[dict, str]:
+        """
+        Retrieve groups with pagination
+
+        :param limit: Maximum number of groups to return (default: 250)
+        :param offset: Offset for pagination (default: 0)
+        :returns: Tuple with (paginated_response_dict, error_message)
+                  Response dict contains: groups, offset, limit, size, _links
+        """
+        # Build query parameters
+        params = []
+        if limit != 250:
+            params.append(f"limit={limit}")
+        if offset > 0:
+            params.append(f"offset={offset}")
+
+        # Build URL
+        query_string = "&".join(params) if params else ""
+        url = "get_groups"
+        if query_string:
+            url = f"{url}?{query_string}"
+
+        response = self.client.send_get(url)
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""

--- a/trcli/api/groups_handler.py
+++ b/trcli/api/groups_handler.py
@@ -56,16 +56,15 @@ class GroupsHandler:
         """
         # Build query parameters
         params = []
-        if limit != 250:
-            params.append(f"limit={limit}")
         if offset > 0:
             params.append(f"offset={offset}")
+        if limit != 250:
+            params.append(f"limit={limit}")
 
         # Build URL
-        query_string = "&".join(params) if params else ""
         url = "get_groups"
-        if query_string:
-            url = f"{url}?{query_string}"
+        if params:
+            url += "&" + "&".join(params)
 
         response = self.client.send_get(url)
         if response.error_message:

--- a/trcli/api/variables_handler.py
+++ b/trcli/api/variables_handler.py
@@ -1,0 +1,123 @@
+"""
+VariablesHandler - Handles all variables-related operations for TestRail
+
+It manages all variable operations including:
+- Retrieving variables
+- Adding new variables
+- Updating existing variables
+- Deleting variables
+"""
+
+from beartype.typing import Tuple, Optional, Dict, Any
+
+from trcli.api.api_client import APIClient
+from trcli.cli import Environment
+
+
+class VariablesHandler:
+    """Handles all variables-related operations for TestRail"""
+
+    def __init__(
+        self,
+        client: APIClient,
+        environment: Environment,
+    ):
+        """
+        Initialize the VariablesHandler
+
+        :param client: APIClient instance for making API calls
+        :param environment: Environment configuration
+        """
+        self.client = client
+        self.environment = environment
+
+    def get_variables(
+        self,
+        project_id: int,
+        limit: int = 250,
+        offset: int = 0,
+    ) -> Tuple[dict, str]:
+        """
+        Retrieve variables for a project with pagination
+
+        :param project_id: TestRail project ID
+        :param limit: Maximum number of variables to return (default: 250)
+        :param offset: Offset for pagination (default: 0)
+        :returns: Tuple with (paginated_response_dict, error_message)
+                  Response dict contains: variables, offset, limit, size, _links
+        """
+        # Build query parameters
+        params = []
+        if limit != 250:
+            params.append(f"limit={limit}")
+        if offset > 0:
+            params.append(f"offset={offset}")
+
+        # Build URL
+        query_string = "&".join(params) if params else ""
+        url = f"get_variables/{project_id}"
+        if query_string:
+            url = f"{url}&{query_string}"
+
+        response = self.client.send_get(url)
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""
+
+    def add_variable(
+        self,
+        project_id: int,
+        name: str,
+    ) -> Tuple[Dict[str, Any], str]:
+        """
+        Create a new variable
+
+        :param project_id: TestRail project ID
+        :param name: Name of the variable (required)
+        :returns: Tuple with (created_variable_dict, error_message)
+        """
+        payload = {"name": name}
+
+        response = self.client.send_post(f"add_variable/{project_id}", payload)
+        if response.error_message:
+            return {}, response.error_message
+
+        return response.response_text, ""
+
+    def update_variable(
+        self,
+        variable_id: int,
+        name: str,
+    ) -> Tuple[Dict[str, Any], str]:
+        """
+        Update an existing variable
+
+        :param variable_id: TestRail variable ID
+        :param name: New name for the variable (required)
+        :returns: Tuple with (updated_variable_dict, error_message)
+        """
+        payload = {"name": name}
+
+        response = self.client.send_post(f"update_variable/{variable_id}", payload)
+        if response.error_message:
+            return {}, response.error_message
+
+        return response.response_text, ""
+
+    def delete_variable(
+        self,
+        variable_id: int,
+    ) -> Tuple[dict, str]:
+        """
+        Delete an existing variable
+
+        Note: Deleting a variable also deletes corresponding values from datasets.
+
+        :param variable_id: TestRail variable ID
+        :returns: Tuple with (response_dict, error_message)
+        """
+        response = self.client.send_post(f"delete_variable/{variable_id}", {})
+        if response.error_message:
+            return {}, response.error_message
+
+        return response.response_text, ""

--- a/trcli/commands/cmd_datasets.py
+++ b/trcli/commands/cmd_datasets.py
@@ -1,0 +1,349 @@
+import click
+import json
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def print_config(env: Environment, action: str):
+    env.log(
+        f"Datasets {action} Execution Parameters"
+        f"\n> TestRail instance: {env.host} (user: {env.username})"
+        f"\n> Project: {env.project if env.project else env.project_id}"
+    )
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.pass_context
+@pass_environment
+def cli(environment: Environment, context: click.Context, *args, **kwargs):
+    """Manage test data datasets in TestRail"""
+    environment.cmd = "datasets"
+    environment.set_parameters(context)
+
+
+@cli.command()
+@click.option("--offset", type=int, default=0, metavar="", help="Offset for pagination (default: 0).")
+@click.option("--limit", type=int, default=250, metavar="", help="Limit for pagination (default: 250).")
+@click.option("--json-output", is_flag=True, help="Output datasets as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def list(
+    environment: Environment,
+    context: click.Context,
+    offset: int,
+    limit: int,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """List all datasets for a project"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "List")
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    environment.log(f"Retrieving datasets for project ID {project_client.project.project_id}...")
+
+    # Retrieve datasets
+    response_data, error_message = project_client.api_request_handler.datasets_handler.get_datasets(
+        project_id=project_client.project.project_id,
+        limit=limit,
+        offset=offset,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve datasets: {error_message}")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        print(json.dumps(response_data, indent=2))
+    else:
+        datasets = response_data.get("datasets", [])
+        response_offset = response_data.get("offset", 0)
+        response_size = response_data.get("size", 0)
+        next_link = response_data.get("_links", {}).get("next")
+
+        if not datasets:
+            environment.log("No datasets found.")
+        else:
+            environment.log(
+                f"Found {response_size} dataset(s) (showing {response_offset + 1}-{response_offset + len(datasets)}):"
+            )
+            if next_link:
+                environment.log("  (More results available - use --offset and --limit for pagination)")
+            environment.log("")
+
+            for dataset in datasets:
+                environment.log(f"  Dataset ID: {dataset.get('id', 'N/A')}")
+                environment.log(f"    Name: {dataset.get('name', 'N/A')}")
+                variables = dataset.get("variables", [])
+                environment.log(f"    Variables: {len(variables)} variable(s)")
+                if variables:
+                    # Show first few variables as preview
+                    preview_count = min(3, len(variables))
+                    for i, var in enumerate(variables[:preview_count]):
+                        environment.log(f"      - {var.get('name')}: {var.get('value')}")
+                    if len(variables) > preview_count:
+                        environment.log(f"      ... and {len(variables) - preview_count} more")
+                environment.log("")
+
+
+@cli.command()
+@click.option("--dataset-id", type=click.IntRange(min=1), required=True, metavar="<id>", help="Dataset ID to retrieve.")
+@click.option("--json-output", is_flag=True, help="Output dataset as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def show(
+    environment: Environment,
+    context: click.Context,
+    dataset_id: int,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """View a specific dataset with all variable values"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Show")
+
+    # Create ProjectBasedClient
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    environment.log(f"Retrieving dataset ID {dataset_id}...")
+
+    # Retrieve dataset
+    dataset, error_message = project_client.api_request_handler.datasets_handler.get_dataset(dataset_id=dataset_id)
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve dataset: {error_message}")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        print(json.dumps(dataset, indent=2))
+    else:
+        environment.log("")
+        environment.log(f"Dataset ID: {dataset.get('id', 'N/A')}")
+        environment.log(f"  Name: {dataset.get('name', 'N/A')}")
+
+        variables = dataset.get("variables", [])
+        if variables:
+            environment.log(f"\n  Variables ({len(variables)}):")
+            for variable in variables:
+                environment.log(f"    {variable.get('name', 'N/A')}: {variable.get('value', '')}")
+        else:
+            environment.log("\n  Variables: (none)")
+
+
+@cli.command()
+@click.option("--name", type=str, required=True, metavar="<name>", help="Name of the dataset (required).")
+@click.option(
+    "--variables",
+    type=str,
+    metavar="<json>",
+    help='JSON object of variable_name: value pairs. Example: \'{"browser":"Chrome","version":"1.0"}\'',
+)
+@click.option("--json-output", is_flag=True, help="Output created dataset as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def add(
+    environment: Environment,
+    context: click.Context,
+    name: str,
+    variables: str,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """Create a new dataset"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Add")
+
+    # Parse variables JSON if provided
+    parsed_variables = None
+    if variables:
+        try:
+            parsed_variables = json.loads(variables)
+            if not isinstance(parsed_variables, dict):
+                environment.elog('Error: --variables must be a JSON object (e.g., \'{"var1":"value1"}\')')
+                raise SystemExit(1)
+        except json.JSONDecodeError as e:
+            environment.elog(f"Error: Invalid JSON in --variables: {e}")
+            raise SystemExit(1)
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    environment.log(f"Creating dataset '{name}' in project ID {project_client.project.project_id}...")
+
+    # Create the dataset
+    dataset, error_message = project_client.api_request_handler.datasets_handler.add_dataset(
+        project_id=project_client.project.project_id,
+        name=name,
+        variables=parsed_variables,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to create dataset: {error_message}")
+        raise SystemExit(1)
+
+    if not dataset or not dataset.get("id"):
+        environment.elog("Error: Dataset creation returned unexpected response")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        print(json.dumps(dataset, indent=2))
+    else:
+        environment.log(f"\nDataset created successfully!")
+        environment.log(f"  Dataset ID: {dataset.get('id')}")
+        environment.log(f"  Name: {dataset.get('name')}")
+
+        variables_list = dataset.get("variables", [])
+        if variables_list:
+            environment.log(f"  Variables: {len(variables_list)} variable(s)")
+            for var in variables_list:
+                environment.log(f"    - {var.get('name')}: {var.get('value')}")
+
+
+@cli.command()
+@click.option("--dataset-id", type=click.IntRange(min=1), required=True, metavar="<id>", help="Dataset ID to update.")
+@click.option("--name", type=str, metavar="<name>", help="New name for the dataset.")
+@click.option(
+    "--variables",
+    type=str,
+    metavar="<json>",
+    help='JSON object of variable_name: value pairs to update. Example: \'{"browser":"Firefox"}\'',
+)
+@click.option("--json-output", is_flag=True, help="Output updated dataset as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def update(
+    environment: Environment,
+    context: click.Context,
+    dataset_id: int,
+    name: str,
+    variables: str,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """Update an existing dataset"""
+    environment.check_for_required_parameters()
+
+    # Validate that at least one field is provided
+    if not name and not variables:
+        environment.elog("Error: At least one of --name or --variables must be provided")
+        raise SystemExit(1)
+
+    print_config(environment, "Update")
+
+    # Parse variables JSON if provided
+    parsed_variables = None
+    if variables:
+        try:
+            parsed_variables = json.loads(variables)
+            if not isinstance(parsed_variables, dict):
+                environment.elog('Error: --variables must be a JSON object (e.g., \'{"var1":"value1"}\')')
+                raise SystemExit(1)
+        except json.JSONDecodeError as e:
+            environment.elog(f"Error: Invalid JSON in --variables: {e}")
+            raise SystemExit(1)
+
+    # Create ProjectBasedClient
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    environment.log(f"Updating dataset ID {dataset_id}...")
+
+    # Update the dataset
+    dataset, error_message = project_client.api_request_handler.datasets_handler.update_dataset(
+        dataset_id=dataset_id,
+        name=name,
+        variables=parsed_variables,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to update dataset: {error_message}")
+        raise SystemExit(1)
+
+    if not dataset or not dataset.get("id"):
+        environment.elog("Error: Dataset update returned unexpected response")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        print(json.dumps(dataset, indent=2))
+    else:
+        environment.log(f"\nDataset updated successfully!")
+        environment.log(f"  Dataset ID: {dataset.get('id')}")
+        environment.log(f"  Name: {dataset.get('name')}")
+
+        variables_list = dataset.get("variables", [])
+        if variables_list:
+            environment.log(f"  Variables: {len(variables_list)} variable(s)")
+            for var in variables_list:
+                environment.log(f"    - {var.get('name')}: {var.get('value')}")
+
+
+@cli.command()
+@click.option("--dataset-id", type=click.IntRange(min=1), required=True, metavar="<id>", help="Dataset ID to delete.")
+@click.pass_context
+@pass_environment
+def delete(
+    environment: Environment,
+    context: click.Context,
+    dataset_id: int,
+    *args,
+    **kwargs,
+):
+    """Delete a dataset
+
+    Note: Cannot delete the Default dataset. Deleting a dataset will also remove the dataset's values.
+    """
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Delete")
+
+    # Create ProjectBasedClient
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    environment.log(f"Deleting dataset ID {dataset_id}...")
+
+    # Delete the dataset
+    response, error_message = project_client.api_request_handler.datasets_handler.delete_dataset(
+        dataset_id=dataset_id,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to delete dataset: {error_message}")
+        raise SystemExit(1)
+
+    environment.log(f"\nDataset ID {dataset_id} deleted successfully.")
+    environment.log("Note: The dataset's values have also been removed.")

--- a/trcli/commands/cmd_groups.py
+++ b/trcli/commands/cmd_groups.py
@@ -1,0 +1,150 @@
+import builtins
+import click
+import json
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def print_config(env: Environment, action: str):
+    env.log(f"Groups {action} Execution Parameters" f"\n> TestRail instance: {env.host} (user: {env.username})")
+
+
+def display_group(env: Environment, group: dict):
+    """Helper function to display a single group's information."""
+    env.log(f"Group ID: {group.get('id')}")
+    env.log(f"  Name: {group.get('name', 'N/A')}")
+
+    user_ids = group.get("user_ids", [])
+    if user_ids:
+        env.log(f"  Members: {len(user_ids)} user(s)")
+        env.log(f"  User IDs: {', '.join(str(uid) for uid in user_ids)}")
+    else:
+        env.log(f"  Members: 0 user(s)")
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.pass_context
+@pass_environment
+def cli(environment: Environment, context: click.Context, *args, **kwargs):
+    """Manage groups in TestRail"""
+    environment.cmd = "groups"
+    environment.set_parameters(context)
+
+
+@cli.command()
+@click.option("--group-id", type=int, required=True, metavar="<id>", help="The ID of the group to retrieve.")
+@click.option("--json-output", is_flag=True, help="Output group as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def show(
+    environment: Environment,
+    context: click.Context,
+    group_id: int,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """Get a specific group from TestRail"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Show")
+
+    # Create ProjectBasedClient for consistent API access
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    environment.log(f"Retrieving group with ID {group_id}...")
+    group, error_message = project_client.api_request_handler.groups_handler.get_group(group_id)
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve group: {error_message}")
+        raise SystemExit(1)
+
+    if not group:
+        environment.log("No group found.")
+        return
+
+    if json_output:
+        print(json.dumps(group, indent=2))
+    else:
+        environment.log("")
+        display_group(environment, group)
+        environment.log("")
+
+    environment.log("Group retrieval completed successfully.")
+
+
+@cli.command()
+@click.option("--offset", type=int, default=0, metavar="<offset>", help="Offset for pagination (default: 0).")
+@click.option(
+    "--limit",
+    type=int,
+    default=250,
+    metavar="<limit>",
+    help="Maximum number of groups to return (default: 250).",
+)
+@click.option("--json-output", is_flag=True, help="Output groups as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def list(
+    environment: Environment,
+    context: click.Context,
+    offset: int,
+    limit: int,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """List all groups from TestRail"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "List")
+
+    # Create ProjectBasedClient for consistent API access
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    environment.log(f"Retrieving groups (limit: {limit}, offset: {offset})...")
+    response, error_message = project_client.api_request_handler.groups_handler.get_groups(limit=limit, offset=offset)
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve groups: {error_message}")
+        raise SystemExit(1)
+
+    groups = response.get("groups", [])
+
+    if not groups:
+        environment.log("No groups found.")
+        return
+
+    if json_output:
+        print(json.dumps(response, indent=2))
+    else:
+        environment.log("")
+        environment.log(f"Found {len(groups)} group(s):")
+        environment.log("")
+
+        for group in groups:
+            display_group(environment, group)
+            environment.log("")
+
+        # Display pagination info
+        total_size = response.get("size", len(groups))
+        current_offset = response.get("offset", offset)
+        current_limit = response.get("limit", limit)
+
+        environment.log(f"Showing {len(groups)} of {total_size} group(s)")
+        environment.log(f"Offset: {current_offset}, Limit: {current_limit}")
+
+        # Show pagination hints
+        links = response.get("_links", {})
+        if links.get("next"):
+            environment.log(f"More results available. Use --offset {current_offset + current_limit} to see next page.")
+
+    environment.log("Groups retrieval completed successfully.")

--- a/trcli/commands/cmd_variables.py
+++ b/trcli/commands/cmd_variables.py
@@ -1,0 +1,233 @@
+import click
+import json
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def print_config(env: Environment, action: str):
+    env.log(
+        f"Variables {action} Execution Parameters"
+        f"\n> TestRail instance: {env.host} (user: {env.username})"
+        f"\n> Project: {env.project if env.project else env.project_id}"
+    )
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.pass_context
+@pass_environment
+def cli(environment: Environment, context: click.Context, *args, **kwargs):
+    """Manage test data variables in TestRail"""
+    environment.cmd = "variables"
+    environment.set_parameters(context)
+
+
+@cli.command()
+@click.option("--offset", type=int, default=0, metavar="", help="Offset for pagination (default: 0).")
+@click.option("--limit", type=int, default=250, metavar="", help="Limit for pagination (default: 250).")
+@click.option("--json-output", is_flag=True, help="Output variables as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def list(
+    environment: Environment,
+    context: click.Context,
+    offset: int,
+    limit: int,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """List all variables for a project"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "List")
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    environment.log(f"Retrieving variables for project ID {project_client.project.project_id}...")
+
+    # Retrieve variables
+    response_data, error_message = project_client.api_request_handler.variables_handler.get_variables(
+        project_id=project_client.project.project_id,
+        limit=limit,
+        offset=offset,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve variables: {error_message}")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        print(json.dumps(response_data, indent=2))
+    else:
+        variables = response_data.get("variables", [])
+        response_offset = response_data.get("offset", 0)
+        response_size = response_data.get("size", 0)
+        next_link = response_data.get("_links", {}).get("next")
+
+        if not variables:
+            environment.log("No variables found.")
+        else:
+            environment.log(
+                f"Found {response_size} variable(s) (showing {response_offset + 1}-{response_offset + len(variables)}):"
+            )
+            if next_link:
+                environment.log("  (More results available - use --offset and --limit for pagination)")
+            environment.log("")
+
+            for variable in variables:
+                environment.log(f"  Variable ID: {variable.get('id', 'N/A')}")
+                environment.log(f"    Name: {variable.get('name', 'N/A')}")
+                environment.log("")
+
+
+@cli.command()
+@click.option("--name", type=str, required=True, metavar="<name>", help="Name of the variable (required).")
+@click.option("--json-output", is_flag=True, help="Output created variable as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def add(
+    environment: Environment,
+    context: click.Context,
+    name: str,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """Create a new variable"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Add")
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    environment.log(f"Creating variable '{name}' in project ID {project_client.project.project_id}...")
+
+    # Create the variable
+    variable, error_message = project_client.api_request_handler.variables_handler.add_variable(
+        project_id=project_client.project.project_id,
+        name=name,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to create variable: {error_message}")
+        raise SystemExit(1)
+
+    if not variable or not variable.get("id"):
+        environment.elog("Error: Variable creation returned unexpected response")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        print(json.dumps(variable, indent=2))
+    else:
+        environment.log(f"\nVariable created successfully!")
+        environment.log(f"  Variable ID: {variable.get('id')}")
+        environment.log(f"  Name: {variable.get('name')}")
+
+
+@cli.command()
+@click.option("--variable-id", type=click.IntRange(min=1), required=True, metavar="<id>", help="Variable ID to update.")
+@click.option("--name", type=str, required=True, metavar="<name>", help="New name for the variable (required).")
+@click.option("--json-output", is_flag=True, help="Output updated variable as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def update(
+    environment: Environment,
+    context: click.Context,
+    variable_id: int,
+    name: str,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """Update an existing variable"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Update")
+
+    # Create ProjectBasedClient (needed for environment setup)
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    environment.log(f"Updating variable ID {variable_id}...")
+
+    # Update the variable
+    variable, error_message = project_client.api_request_handler.variables_handler.update_variable(
+        variable_id=variable_id,
+        name=name,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to update variable: {error_message}")
+        raise SystemExit(1)
+
+    if not variable or not variable.get("id"):
+        environment.elog("Error: Variable update returned unexpected response")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        print(json.dumps(variable, indent=2))
+    else:
+        environment.log(f"\nVariable updated successfully!")
+        environment.log(f"  Variable ID: {variable.get('id')}")
+        environment.log(f"  Name: {variable.get('name')}")
+
+
+@cli.command()
+@click.option("--variable-id", type=click.IntRange(min=1), required=True, metavar="<id>", help="Variable ID to delete.")
+@click.pass_context
+@pass_environment
+def delete(
+    environment: Environment,
+    context: click.Context,
+    variable_id: int,
+    *args,
+    **kwargs,
+):
+    """Delete a variable
+
+    Note: Deleting a variable will also delete corresponding values from datasets.
+    """
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Delete")
+
+    # Create ProjectBasedClient (needed for environment setup)
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    environment.log(f"Deleting variable ID {variable_id}...")
+
+    # Delete the variable
+    response, error_message = project_client.api_request_handler.variables_handler.delete_variable(
+        variable_id=variable_id,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to delete variable: {error_message}")
+        raise SystemExit(1)
+
+    environment.log(f"\nVariable ID {variable_id} deleted successfully.")
+    environment.log("Note: Corresponding values from datasets have also been deleted.")

--- a/trcli/constants.py
+++ b/trcli/constants.py
@@ -108,6 +108,7 @@ COMMAND_FAULT_MAPPING = dict(
     tests=dict(**FAULT_MAPPING),
     variables=dict(**FAULT_MAPPING),
     datasets=dict(**FAULT_MAPPING),
+    groups=dict(**FAULT_MAPPING),
 )
 
 PROMPT_MESSAGES = dict(
@@ -152,7 +153,8 @@ TOOL_USAGE = f"""Supported and loaded modules:
     - tests: Query tests (get and list)
     - results: Query and update test results (list, update)
     - variables: Manage test data variables (list, add, update, delete)
-    - datasets: Manage test data datasets (list, show, add, update, delete)"""
+    - datasets: Manage test data datasets (list, show, add, update, delete)
+    - groups: Manage groups (list, show)"""
 
 MISSING_COMMAND_SLOGAN = """Usage: trcli [OPTIONS] COMMAND [ARGS]...\nTry 'trcli --help' for help.
 \nError: Missing command."""

--- a/trcli/constants.py
+++ b/trcli/constants.py
@@ -106,6 +106,8 @@ COMMAND_FAULT_MAPPING = dict(
     projects=dict(**FAULT_MAPPING),
     templates=dict(**FAULT_MAPPING),
     tests=dict(**FAULT_MAPPING),
+    variables=dict(**FAULT_MAPPING),
+    datasets=dict(**FAULT_MAPPING),
 )
 
 PROMPT_MESSAGES = dict(
@@ -148,7 +150,9 @@ TOOL_USAGE = f"""Supported and loaded modules:
     - projects: Query projects (get and list)
     - templates: Query templates (list)
     - tests: Query tests (get and list)
-    - results: Query and update test results (list, update)"""
+    - results: Query and update test results (list, update)
+    - variables: Manage test data variables (list, add, update, delete)
+    - datasets: Manage test data datasets (list, show, add, update, delete)"""
 
 MISSING_COMMAND_SLOGAN = """Usage: trcli [OPTIONS] COMMAND [ARGS]...\nTry 'trcli --help' for help.
 \nError: Missing command."""


### PR DESCRIPTION
### Solution description
Allow users to list down groups and get specific group information from TestRail, with pagination and JSON output option for flexible programmatic format.  

### Changes
Implemented a new command called groups with list and show subcommands for listing groups from an entire project or specifically getting group information.

### Potential impacts
None.

### Steps to test

> #### Reference
> 
> ```shell
> $ trcli groups --help
> 
> Usage: trcli groups [OPTIONS] COMMAND [ARGS]...
>   Manage groups in TestRail
> 
> Options:
>   --help  Show this message and exit.
> 
> Commands:
>   list  List all groups from TestRail
>   show  Get a specific group from TestRail
> ```
> 
> #### Viewing a Specific Group
> 
> The `show` subcommand retrieves detailed information about a single group, including its name and list of member user IDs.
> 
> ```shell
> # Get a specific group by ID
> $ trcli -c config.yml groups show --group-id 1
> 
> # JSON output
> $ trcli -c config.yml groups show --group-id 3 --json-output
> 
> # Without config file (inline credentials)
> $ trcli -h https://yourinstance.testrail.io \
>   -u <your_username> \
>   -p <your_password> \
>   --project "Your Project" \
>   groups show --group-id 5
> ```
> 
> #### Listing Groups
> 
> The `list` subcommand retrieves all available groups in your TestRail instance with pagination support.
> 
> ```shell
> # List all groups
> $ trcli -c config.yml groups list
> 
> # With pagination
> $ trcli -c config.yml groups list --limit 100 --offset 0
> 
> # JSON output
> $ trcli -c config.yml groups list --json-output
> 
> # Without config file (inline credentials)
> $ trcli -h https://yourinstance.testrail.io \
>   -u <your_username> \
>   -p <your_password> \
>   --project "Your Project" \
>   groups list
> ```

### PR Tasks
- [x] PR reference added to issue
- [x] README updated
- [x] Unit tests added/updated
