### PR TITLE
TR-20810: References are added incorrectly after closing test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2618,13 +2618,16 @@ Commands:
 
 ```shell
 # List all priorities
-$ trcli priorities list -h https://yourinstance.testrail.io -u user@example.com -p password
+$ trcli -c config.yml priorities list
 
 # Show all fields including priority order
-$ trcli priorities list -c config.yml --show-all-fields
+$ trcli -c config.yml priorities list --show-all-fields
 
 # JSON output
-$ trcli priorities list -c config.yml --json-output
+$ trcli -c config.yml priorities list --json-output
+
+# Without config file (inline credentials)
+$ trcli -h https://yourinstance.testrail.io -u user@example.com -p password priorities list
 ```
 
 #### Example Output
@@ -2670,13 +2673,13 @@ Commands:
 
 ```shell
 # List all case types
-$ trcli -h https://yourinstance.testrail.io -u user@example.com -p password casetypes list
-
-# With config file
-$ trcli casetypes list -c config.yml
+$ trcli -c config.yml casetypes list
 
 # JSON output
-$ trcli casetypes list -c config.yml --json-output
+$ trcli -c config.yml casetypes list --json-output
+
+# Without config file (inline credentials)
+$ trcli -h https://yourinstance.testrail.io -u user@example.com -p password casetypes list
 ```
 
 #### Example Output
@@ -4056,6 +4059,223 @@ components:
           type: string
           example: Guru
 ```
+
+### Test Data Management using Variables and Datasets (NOTE: Supported for TestRail Enterprise 7.6 or later only)
+
+TestRail Enterprise provides **Test Data Management** functionality that allows you to define variables and datasets for your test cases. TRCLI provides commands to manage both variables and datasets programmatically.
+
+**Key Concepts:**
+- **Variables**: Reusable parameters that can be referenced in test cases (e.g., `browser`, `username`, `api_endpoint`)
+- **Datasets**: Collections of variable values representing different test scenarios (e.g., `Chrome_Dataset`, `Firefox_Dataset`)
+
+#### Naming Conventions and Validation Rules
+
+Both variables and datasets must follow these naming rules:
+
+| Rule | Description |
+|------|-------------|
+| **Characters** | Only letters (A-Z, a-z), numbers (0-9), and underscores (_) |
+| **No Spaces** | Spaces are not allowed in names |
+| **No Special Characters** | Cannot use special characters like -, ., /, %, @, etc. |
+| **Cannot Start with Underscore** | Names cannot begin with an underscore (_) |
+| **Maximum Length** | Maximum 50 characters |
+| **Uniqueness** | Must be unique within a project |
+| **Case-Sensitive** | Names are case-sensitive (e.g., `Chrome` and `chrome` are different) |
+
+#### Variables Command
+
+Manage test data variables for your project.
+
+##### Listing Variables
+
+```bash
+# List all variables for a project
+trcli -c config.yml variables list
+
+# With pagination
+trcli -c config.yml variables list --offset 250 --limit 100
+
+# JSON output for integration
+trcli -c config.yml variables list --json-output
+
+# Without config file (inline credentials)
+trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  variables list
+```
+
+##### Adding a Variable
+
+```bash
+# Create a new variable
+trcli -c config.yml variables add --name "browser"
+
+# JSON output
+trcli -c config.yml variables add --name "test_user" --json-output
+
+# Without config file (inline credentials)
+trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  variables add --name "api_endpoint"
+```
+
+##### Updating a Variable
+
+```bash
+# Update an existing variable
+trcli -c config.yml variables update --variable-id 123 --name "web_browser"
+
+# Without config file (inline credentials)
+trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  variables update --variable-id 456 --name "api_url"
+```
+
+##### Deleting a Variable
+
+```bash
+# Delete a variable (also deletes corresponding values from datasets)
+trcli -c config.yml variables delete --variable-id 123
+
+# Without config file (inline credentials)
+trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  variables delete --variable-id 456
+```
+
+**Note:** Deleting a variable will also delete the corresponding values from all datasets.
+
+#### Datasets Command
+
+Manage test data datasets for your project.
+
+##### Listing Datasets
+
+```bash
+# List all datasets for a project
+trcli -c config.yml datasets list
+
+# With pagination
+trcli -c config.yml datasets list --offset 250 --limit 100
+
+# JSON output
+trcli -c config.yml datasets list --json-output
+
+# Without config file (inline credentials)
+trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  datasets list
+```
+
+##### Viewing a Dataset
+
+```bash
+# Show a specific dataset with all variable values
+trcli -c config.yml datasets show --dataset-id 123
+
+# JSON output
+trcli -c config.yml datasets show --dataset-id 456 --json-output
+
+# Without config file (inline credentials)
+trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  datasets show --dataset-id 789
+```
+
+##### Adding a Dataset
+
+```bash
+# Create a new dataset with variables
+trcli -c config.yml datasets add \
+  --name "Chrome_Dataset" \
+  --variables '{"browser":"Chrome","version":"120.0"}'
+
+# Create a dataset without initial variables
+trcli -c config.yml datasets add --name "Firefox_Dataset"
+
+# JSON output
+trcli -c config.yml datasets add \
+  --name "Edge_Dataset" \
+  --variables '{"browser":"Edge","version":"119.0"}' \
+  --json-output
+
+# Without config file (inline credentials)
+trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  datasets add --name "Safari_Dataset" \
+  --variables '{"browser":"Safari","version":"17.0"}'
+```
+
+**Variables Format:**
+- Must be a JSON object with variable_name: value pairs
+- **Important:** Before adding a dataset with variables, ensure all variable names have been created in the project. If you reference a non-existent variable, the API will return an error.
+- All values must be strings
+- Example: `'{"browser":"Chrome","os":"Windows","version":"1.0"}'`
+
+##### Updating a Dataset
+
+```bash
+# Update dataset name only
+trcli -c config.yml datasets update \
+  --dataset-id 123 \
+  --name "Chrome_Latest"
+
+# Update variables only
+trcli -c config.yml datasets update \
+  --dataset-id 456 \
+  --variables '{"browser":"Chrome","version":"121.0"}'
+
+# Update both name and variables
+trcli -c config.yml datasets update \
+  --dataset-id 789 \
+  --name "Production_Environment" \
+  --variables '{"api_url":"https://api.prod.com","timeout":"30"}'
+
+# JSON output
+trcli -c config.yml datasets update \
+  --dataset-id 123 \
+  --name "Updated_Dataset" \
+  --json-output
+
+# Without config file (inline credentials)
+trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  datasets update --dataset-id 456 --name "New_Dataset_Name"
+```
+
+**Note:** At least one of `--name` or `--variables` must be provided for update.
+
+##### Deleting a Dataset
+
+```bash
+# Delete a dataset (cannot delete "Default" dataset)
+trcli -c config.yml datasets delete --dataset-id 123
+
+# Without config file (inline credentials)
+trcli -h https://yourinstance.testrail.io \
+  -u <your_username> \
+  -p <your_password> \
+  --project "Your Project" \
+  datasets delete --dataset-id 456
+```
+
+**Note:** Cannot delete the "Default" dataset. Deleting a dataset will also remove the dataset's values.
 
 ### Generating test cases
 

--- a/README.md
+++ b/README.md
@@ -4259,7 +4259,9 @@ trcli -h https://yourinstance.testrail.io \
   datasets update --dataset-id 456 --name "New_Dataset_Name"
 ```
 
-**Note:** At least one of `--name` or `--variables` must be provided for update.
+**Note:**
+- At least one of `--name` or `--variables` must be provided for update
+- When updating name only, existing variables are automatically preserved (API requirement)
 
 ##### Deleting a Dataset
 

--- a/README.md
+++ b/README.md
@@ -4202,8 +4202,11 @@ trcli -c config.yml datasets add \
   --name "Chrome_Dataset" \
   --variables '{"browser":"Chrome","version":"120.0"}'
 
-# Create a dataset without initial variables
+# Create a dataset without initial variables (sends empty object {})
 trcli -c config.yml datasets add --name "Firefox_Dataset"
+
+# Create a dataset with explicit empty variables (same as above)
+trcli -c config.yml datasets add --name "Firefox_Dataset" --variables "{}"
 
 # JSON output
 trcli -c config.yml datasets add \
@@ -4229,10 +4232,16 @@ trcli -h https://yourinstance.testrail.io \
 ##### Updating a Dataset
 
 ```bash
-# Update dataset name only
+# Update dataset name only (preserves existing variables)
 trcli -c config.yml datasets update \
   --dataset-id 123 \
   --name "Chrome_Latest"
+
+# Update name with explicit empty variables (also preserves existing variables)
+trcli -c config.yml datasets update \
+  --dataset-id 123 \
+  --name "Chrome_Latest" \
+  --variables "{}"
 
 # Update variables only
 trcli -c config.yml datasets update \
@@ -4261,7 +4270,9 @@ trcli -h https://yourinstance.testrail.io \
 
 **Note:**
 - At least one of `--name` or `--variables` must be provided for update
-- When updating name only, existing variables are automatically preserved (API requirement)
+- When updating name only (without `--variables`), existing variables are automatically preserved
+- Passing `--variables "{}"` (empty object) also preserves existing variables - same behavior as omitting `--variables`
+- To clear all variables from a dataset, you would need to update with explicit empty values for each variable
 
 ##### Deleting a Dataset
 

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,9 @@ setup(
     name="trcli",
     long_description="The TR CLI (trcli) is a command line tool for interacting with TestRail and uploading test automation results.",
     version=__version__,
+    setup_requires=[
+        "setuptools>=83.0.0",  # Updated to address PYSEC-2026-3447 (Unicode normalization bypass on macOS)
+    ],
     packages=[
         "trcli",
         "trcli.commands",
@@ -16,7 +19,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        "click>=8.1.0,<8.2.2",  # Note: click version 8.2.2 is yanked as of Aug 2, 2025!
+        "click>=8.3.3,<9.0.0",
         "pyyaml>=6.0.0,<7.0.0",
         "junitparser>=3.1.0,<4.0.0",
         "pyserde==0.12.*",

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,6 @@ setup(
     name="trcli",
     long_description="The TR CLI (trcli) is a command line tool for interacting with TestRail and uploading test automation results.",
     version=__version__,
-    setup_requires=[
-        "setuptools>=83.0.0",  # Updated to address PYSEC-2026-3447 (Unicode normalization bypass on macOS)
-    ],
     packages=[
         "trcli",
         "trcli.commands",

--- a/tests/requirements-tox.txt
+++ b/tests/requirements-tox.txt
@@ -1,4 +1,4 @@
-pytest==8.0.*
+pytest>=9.0.3
 pytest-md-report
 coverage
 allure-pytest

--- a/tests/test_cmd_datasets.py
+++ b/tests/test_cmd_datasets.py
@@ -1,0 +1,405 @@
+import pytest
+import json
+from unittest import mock
+from unittest.mock import MagicMock, patch
+from click.testing import CliRunner
+
+from trcli.cli import Environment
+from trcli.commands import cmd_datasets
+
+
+class TestCmdDatasets:
+    """Test class for datasets command functionality"""
+
+    def setup_method(self):
+        """Set up test environment"""
+        self.runner = CliRunner()
+        self.environment = Environment(cmd="datasets")
+        self.environment.host = "https://test.testrail.com"
+        self.environment.username = "test@example.com"
+        self.environment.password = "password"
+        self.environment.api_key = None
+        self.environment.project = "Test Project"
+
+    def _setup_project_client_mock(self, mock_project_client):
+        """Helper to setup ProjectBasedClient mock"""
+        mock_client_instance = MagicMock()
+        mock_project_client.return_value = mock_client_instance
+        mock_client_instance.project.project_id = 1
+        return mock_client_instance
+
+    @mock.patch("trcli.commands.cmd_datasets.ProjectBasedClient")
+    def test_list_datasets_success(self, mock_project_client):
+        """Test successful datasets listing"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.datasets_handler.get_datasets.return_value = (
+            {
+                "datasets": [
+                    {
+                        "id": 1,
+                        "name": "Default",
+                        "variables": [
+                            {"name": "browser", "value": "Chrome"},
+                            {"name": "version", "value": "120.0"},
+                        ],
+                    },
+                    {
+                        "id": 2,
+                        "name": "Firefox_Dataset",
+                        "variables": [],
+                    },
+                ],
+                "offset": 0,
+                "limit": 250,
+                "size": 2,
+                "_links": {},
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_datasets.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.datasets_handler.get_datasets.assert_called_once_with(
+                project_id=1, limit=250, offset=0
+            )
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_datasets.ProjectBasedClient")
+    def test_list_datasets_json_output(self, mock_project_client):
+        """Test datasets listing with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        datasets_data = {
+            "datasets": [{"id": 1, "name": "Default", "variables": []}],
+            "offset": 0,
+            "limit": 250,
+            "size": 1,
+            "_links": {},
+        }
+        mock_client.api_request_handler.datasets_handler.get_datasets.return_value = (datasets_data, "")
+
+        with patch.object(self.environment, "log"), patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_datasets.list, ["--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # When --json-output is used, the output should be valid JSON printed to stdout
+            # The runner captures this in result.output, but we need to skip log lines
+            output_lines = result.output.strip().split("\n")
+            # Find the JSON output (should be the last substantial output)
+            json_output = None
+            for line in output_lines:
+                try:
+                    json_output = json.loads(line)
+                    break
+                except json.JSONDecodeError:
+                    continue
+
+            # If JSON wasn't found in individual lines, try the whole output
+            if json_output is None:
+                # Try to extract JSON from mixed output
+                import re
+
+                json_match = re.search(r"\{.*\}", result.output, re.DOTALL)
+                if json_match:
+                    json_output = json.loads(json_match.group(0))
+
+            assert json_output == datasets_data
+
+    @mock.patch("trcli.commands.cmd_datasets.ProjectBasedClient")
+    def test_show_dataset_success(self, mock_project_client):
+        """Test showing a specific dataset"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        dataset_data = {
+            "id": 123,
+            "name": "Chrome_Dataset",
+            "variables": [
+                {"name": "browser", "value": "Chrome"},
+                {"name": "version", "value": "120.0"},
+            ],
+        }
+        mock_client.api_request_handler.datasets_handler.get_dataset.return_value = (dataset_data, "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_datasets.show, ["--dataset-id", "123"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.datasets_handler.get_dataset.assert_called_once_with(dataset_id=123)
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_datasets.ProjectBasedClient")
+    def test_add_dataset_with_variables(self, mock_project_client):
+        """Test adding a dataset with variables"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        created_dataset = {
+            "id": 456,
+            "name": "Chrome_Dataset",
+            "variables": [
+                {"name": "browser", "value": "Chrome"},
+                {"name": "version", "value": "120.0"},
+            ],
+        }
+        mock_client.api_request_handler.datasets_handler.add_dataset.return_value = (created_dataset, "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_datasets.add,
+                ["--name", "Chrome_Dataset", "--variables", '{"browser":"Chrome","version":"120.0"}'],
+                obj=self.environment,
+            )
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.datasets_handler.add_dataset.assert_called_once_with(
+                project_id=1, name="Chrome_Dataset", variables={"browser": "Chrome", "version": "120.0"}
+            )
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_datasets.ProjectBasedClient")
+    def test_add_dataset_without_variables(self, mock_project_client):
+        """Test adding a dataset without variables (should send None)"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        created_dataset = {"id": 456, "name": "Firefox_Dataset", "variables": []}
+        mock_client.api_request_handler.datasets_handler.add_dataset.return_value = (created_dataset, "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_datasets.add, ["--name", "Firefox_Dataset"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.datasets_handler.add_dataset.assert_called_once_with(
+                project_id=1, name="Firefox_Dataset", variables=None
+            )
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_datasets.ProjectBasedClient")
+    def test_add_dataset_with_empty_variables(self, mock_project_client):
+        """Test adding a dataset with explicit empty variables object"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        created_dataset = {"id": 456, "name": "Edge_Dataset", "variables": []}
+        mock_client.api_request_handler.datasets_handler.add_dataset.return_value = (created_dataset, "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_datasets.add, ["--name", "Edge_Dataset", "--variables", "{}"], obj=self.environment
+            )
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.datasets_handler.add_dataset.assert_called_once_with(
+                project_id=1, name="Edge_Dataset", variables={}
+            )
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_datasets.ProjectBasedClient")
+    def test_add_dataset_invalid_json(self, mock_project_client):
+        """Test adding a dataset with invalid JSON variables"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_datasets.add, ["--name", "Test_Dataset", "--variables", "{invalid}"], obj=self.environment
+            )
+
+            assert result.exit_code == 1
+            assert mock_elog.called
+
+    @mock.patch("trcli.commands.cmd_datasets.ProjectBasedClient")
+    def test_update_dataset_name_only(self, mock_project_client):
+        """Test updating dataset name only (should send None for variables)"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        updated_dataset = {
+            "id": 123,
+            "name": "Chrome_Latest",
+            "variables": [{"name": "browser", "value": "Chrome"}],
+        }
+        mock_client.api_request_handler.datasets_handler.update_dataset.return_value = (updated_dataset, "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_datasets.update, ["--dataset-id", "123", "--name", "Chrome_Latest"], obj=self.environment
+            )
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.datasets_handler.update_dataset.assert_called_once_with(
+                dataset_id=123, name="Chrome_Latest", variables=None
+            )
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_datasets.ProjectBasedClient")
+    def test_update_dataset_variables_only(self, mock_project_client):
+        """Test updating dataset variables only"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        updated_dataset = {
+            "id": 456,
+            "name": "Chrome_Dataset",
+            "variables": [
+                {"name": "browser", "value": "Chrome"},
+                {"name": "version", "value": "121.0"},
+            ],
+        }
+        mock_client.api_request_handler.datasets_handler.update_dataset.return_value = (updated_dataset, "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_datasets.update,
+                ["--dataset-id", "456", "--variables", '{"browser":"Chrome","version":"121.0"}'],
+                obj=self.environment,
+            )
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.datasets_handler.update_dataset.assert_called_once_with(
+                dataset_id=456, name=None, variables={"browser": "Chrome", "version": "121.0"}
+            )
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_datasets.ProjectBasedClient")
+    def test_update_dataset_with_empty_variables(self, mock_project_client):
+        """Test updating dataset with explicit empty variables (should preserve existing)"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        updated_dataset = {
+            "id": 123,
+            "name": "Chrome_Latest",
+            "variables": [{"name": "browser", "value": "Chrome"}],
+        }
+        mock_client.api_request_handler.datasets_handler.update_dataset.return_value = (updated_dataset, "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_datasets.update,
+                ["--dataset-id", "123", "--name", "Chrome_Latest", "--variables", "{}"],
+                obj=self.environment,
+            )
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.datasets_handler.update_dataset.assert_called_once_with(
+                dataset_id=123, name="Chrome_Latest", variables={}
+            )
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_datasets.ProjectBasedClient")
+    def test_update_dataset_both_fields(self, mock_project_client):
+        """Test updating both dataset name and variables"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        updated_dataset = {
+            "id": 789,
+            "name": "Production_Environment",
+            "variables": [
+                {"name": "api_url", "value": "https://api.prod.com"},
+                {"name": "timeout", "value": "30"},
+            ],
+        }
+        mock_client.api_request_handler.datasets_handler.update_dataset.return_value = (updated_dataset, "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_datasets.update,
+                [
+                    "--dataset-id",
+                    "789",
+                    "--name",
+                    "Production_Environment",
+                    "--variables",
+                    '{"api_url":"https://api.prod.com","timeout":"30"}',
+                ],
+                obj=self.environment,
+            )
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.datasets_handler.update_dataset.assert_called_once_with(
+                dataset_id=789,
+                name="Production_Environment",
+                variables={"api_url": "https://api.prod.com", "timeout": "30"},
+            )
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_datasets.ProjectBasedClient")
+    def test_update_dataset_no_fields_provided(self, mock_project_client):
+        """Test update with no fields provided (should fail)"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_datasets.update, ["--dataset-id", "123"], obj=self.environment)
+
+            assert result.exit_code == 1
+            assert mock_elog.called
+
+    @mock.patch("trcli.commands.cmd_datasets.ProjectBasedClient")
+    def test_delete_dataset_success(self, mock_project_client):
+        """Test deleting a dataset"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.datasets_handler.delete_dataset.return_value = ({}, "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_datasets.delete, ["--dataset-id", "123"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.datasets_handler.delete_dataset.assert_called_once_with(dataset_id=123)
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_datasets.ProjectBasedClient")
+    def test_add_dataset_api_error(self, mock_project_client):
+        """Test adding a dataset when API returns error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.datasets_handler.add_dataset.return_value = ({}, "API Error occurred")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_datasets.add, ["--name", "Test_Dataset"], obj=self.environment)
+
+            assert result.exit_code == 1
+            assert mock_elog.called
+
+    @mock.patch("trcli.commands.cmd_datasets.ProjectBasedClient")
+    def test_update_dataset_api_error(self, mock_project_client):
+        """Test updating a dataset when API returns error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.datasets_handler.update_dataset.return_value = ({}, "API Error occurred")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_datasets.update, ["--dataset-id", "123", "--name", "New_Name"], obj=self.environment
+            )
+
+            assert result.exit_code == 1
+            assert mock_elog.called
+
+    @mock.patch("trcli.commands.cmd_datasets.ProjectBasedClient")
+    def test_delete_dataset_api_error(self, mock_project_client):
+        """Test deleting a dataset when API returns error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.datasets_handler.delete_dataset.return_value = ({}, "API Error occurred")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_datasets.delete, ["--dataset-id", "123"], obj=self.environment)
+
+            assert result.exit_code == 1
+            assert mock_elog.called

--- a/tests/test_cmd_variables.py
+++ b/tests/test_cmd_variables.py
@@ -1,0 +1,299 @@
+import pytest
+import json
+from unittest import mock
+from unittest.mock import MagicMock, patch
+from click.testing import CliRunner
+
+from trcli.cli import Environment
+from trcli.commands import cmd_variables
+
+
+class TestCmdVariables:
+    """Test class for variables command functionality"""
+
+    def setup_method(self):
+        """Set up test environment"""
+        self.runner = CliRunner()
+        self.environment = Environment(cmd="variables")
+        self.environment.host = "https://test.testrail.com"
+        self.environment.username = "test@example.com"
+        self.environment.password = "password"
+        self.environment.api_key = None
+        self.environment.project = "Test Project"
+
+    def _setup_project_client_mock(self, mock_project_client):
+        """Helper to setup ProjectBasedClient mock"""
+        mock_client_instance = MagicMock()
+        mock_project_client.return_value = mock_client_instance
+        mock_client_instance.project.project_id = 1
+        return mock_client_instance
+
+    @mock.patch("trcli.commands.cmd_variables.ProjectBasedClient")
+    def test_list_variables_success(self, mock_project_client):
+        """Test successful variables listing"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.variables_handler.get_variables.return_value = (
+            {
+                "variables": [
+                    {"id": 1, "name": "browser"},
+                    {"id": 2, "name": "environment"},
+                ],
+                "offset": 0,
+                "limit": 250,
+                "size": 2,
+                "_links": {},
+            },
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_variables.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.variables_handler.get_variables.assert_called_once_with(
+                project_id=1, limit=250, offset=0
+            )
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_variables.ProjectBasedClient")
+    def test_list_variables_with_pagination(self, mock_project_client):
+        """Test variables listing with custom pagination"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.variables_handler.get_variables.return_value = (
+            {"variables": [], "offset": 100, "limit": 50, "size": 0, "_links": {}},
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_variables.list, ["--offset", "100", "--limit", "50"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.variables_handler.get_variables.assert_called_once_with(
+                project_id=1, limit=50, offset=100
+            )
+
+    @mock.patch("trcli.commands.cmd_variables.ProjectBasedClient")
+    def test_list_variables_json_output(self, mock_project_client):
+        """Test variables listing with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        variables_data = {
+            "variables": [{"id": 1, "name": "browser"}],
+            "offset": 0,
+            "limit": 250,
+            "size": 1,
+            "_links": {},
+        }
+        mock_client.api_request_handler.variables_handler.get_variables.return_value = (variables_data, "")
+
+        with patch.object(self.environment, "log"), patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_variables.list, ["--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Try to parse JSON from output
+            output_lines = result.output.strip().split("\n")
+            json_output = None
+            for line in output_lines:
+                try:
+                    json_output = json.loads(line)
+                    break
+                except json.JSONDecodeError:
+                    continue
+
+            if json_output is None:
+                import re
+
+                json_match = re.search(r"\{.*\}", result.output, re.DOTALL)
+                if json_match:
+                    json_output = json.loads(json_match.group(0))
+
+            assert json_output == variables_data
+
+    @mock.patch("trcli.commands.cmd_variables.ProjectBasedClient")
+    def test_list_variables_empty(self, mock_project_client):
+        """Test listing when no variables exist"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.variables_handler.get_variables.return_value = (
+            {"variables": [], "offset": 0, "limit": 250, "size": 0, "_links": {}},
+            "",
+        )
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_variables.list, [], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Check that "No variables found" message was logged
+            log_calls = [str(call) for call in mock_log.call_args_list]
+            assert any("No variables found" in str(call) for call in log_calls)
+
+    @mock.patch("trcli.commands.cmd_variables.ProjectBasedClient")
+    def test_list_variables_api_error(self, mock_project_client):
+        """Test listing variables when API returns error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.variables_handler.get_variables.return_value = ({}, "API Error occurred")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_variables.list, [], obj=self.environment)
+
+            assert result.exit_code == 1
+            assert mock_elog.called
+
+    @mock.patch("trcli.commands.cmd_variables.ProjectBasedClient")
+    def test_add_variable_success(self, mock_project_client):
+        """Test adding a variable"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        created_variable = {"id": 456, "name": "browser"}
+        mock_client.api_request_handler.variables_handler.add_variable.return_value = (created_variable, "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_variables.add, ["--name", "browser"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.variables_handler.add_variable.assert_called_once_with(
+                project_id=1, name="browser"
+            )
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_variables.ProjectBasedClient")
+    def test_add_variable_with_underscore(self, mock_project_client):
+        """Test adding a variable with underscore"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        created_variable = {"id": 457, "name": "api_endpoint"}
+        mock_client.api_request_handler.variables_handler.add_variable.return_value = (created_variable, "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_variables.add, ["--name", "api_endpoint"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.variables_handler.add_variable.assert_called_once_with(
+                project_id=1, name="api_endpoint"
+            )
+
+    @mock.patch("trcli.commands.cmd_variables.ProjectBasedClient")
+    def test_add_variable_json_output(self, mock_project_client):
+        """Test adding a variable with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        created_variable = {"id": 456, "name": "browser"}
+        mock_client.api_request_handler.variables_handler.add_variable.return_value = (created_variable, "")
+
+        with patch.object(self.environment, "log"), patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(cmd_variables.add, ["--name", "browser", "--json-output"], obj=self.environment)
+
+            assert result.exit_code == 0
+            # Verify JSON in output
+            assert '"id": 456' in result.output
+            assert '"name": "browser"' in result.output
+
+    @mock.patch("trcli.commands.cmd_variables.ProjectBasedClient")
+    def test_add_variable_api_error(self, mock_project_client):
+        """Test adding a variable when API returns error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.variables_handler.add_variable.return_value = ({}, "API Error occurred")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_variables.add, ["--name", "test"], obj=self.environment)
+
+            assert result.exit_code == 1
+            assert mock_elog.called
+
+    @mock.patch("trcli.commands.cmd_variables.ProjectBasedClient")
+    def test_update_variable_success(self, mock_project_client):
+        """Test updating a variable"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        updated_variable = {"id": 123, "name": "new_browser"}
+        mock_client.api_request_handler.variables_handler.update_variable.return_value = (updated_variable, "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_variables.update, ["--variable-id", "123", "--name", "new_browser"], obj=self.environment
+            )
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.variables_handler.update_variable.assert_called_once_with(
+                variable_id=123, name="new_browser"
+            )
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_variables.ProjectBasedClient")
+    def test_update_variable_json_output(self, mock_project_client):
+        """Test updating a variable with JSON output"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        updated_variable = {"id": 123, "name": "new_browser"}
+        mock_client.api_request_handler.variables_handler.update_variable.return_value = (updated_variable, "")
+
+        with patch.object(self.environment, "log"), patch.object(self.environment, "set_parameters"), patch.object(
+            self.environment, "check_for_required_parameters"
+        ):
+            result = self.runner.invoke(
+                cmd_variables.update,
+                ["--variable-id", "123", "--name", "new_browser", "--json-output"],
+                obj=self.environment,
+            )
+
+            assert result.exit_code == 0
+            assert '"id": 123' in result.output
+            assert '"name": "new_browser"' in result.output
+
+    @mock.patch("trcli.commands.cmd_variables.ProjectBasedClient")
+    def test_update_variable_api_error(self, mock_project_client):
+        """Test updating a variable when API returns error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.variables_handler.update_variable.return_value = ({}, "Variable not found")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(
+                cmd_variables.update, ["--variable-id", "999", "--name", "new_name"], obj=self.environment
+            )
+
+            assert result.exit_code == 1
+            assert mock_elog.called
+
+    @mock.patch("trcli.commands.cmd_variables.ProjectBasedClient")
+    def test_delete_variable_success(self, mock_project_client):
+        """Test deleting a variable"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.variables_handler.delete_variable.return_value = ({}, "")
+
+        with patch.object(self.environment, "log") as mock_log, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_variables.delete, ["--variable-id", "123"], obj=self.environment)
+
+            assert result.exit_code == 0
+            mock_client.api_request_handler.variables_handler.delete_variable.assert_called_once_with(variable_id=123)
+            assert mock_log.called
+
+    @mock.patch("trcli.commands.cmd_variables.ProjectBasedClient")
+    def test_delete_variable_api_error(self, mock_project_client):
+        """Test deleting a variable when API returns error"""
+        mock_client = self._setup_project_client_mock(mock_project_client)
+        mock_client.api_request_handler.variables_handler.delete_variable.return_value = ({}, "Variable not found")
+
+        with patch.object(self.environment, "elog") as mock_elog, patch.object(
+            self.environment, "set_parameters"
+        ), patch.object(self.environment, "check_for_required_parameters"):
+            result = self.runner.invoke(cmd_variables.delete, ["--variable-id", "999"], obj=self.environment)
+
+            assert result.exit_code == 1
+            assert mock_elog.called

--- a/tests/test_data/cli_test_data.py
+++ b/tests/test_data/cli_test_data.py
@@ -90,6 +90,8 @@ trcli_description = (
     "    - templates: Query templates (list)\n"
     "    - tests: Query tests (get and list)\n"
     "    - results: Query and update test results (list, update)\n"
+    "    - variables: Manage test data variables (list, add, update, delete)\n"
+    "    - datasets: Manage test data datasets (list, show, add, update, delete)\n"
 )
 
 trcli_help_description = "TestRail CLI"

--- a/tests/test_datasets_handler.py
+++ b/tests/test_datasets_handler.py
@@ -1,0 +1,301 @@
+import pytest
+from unittest.mock import MagicMock
+
+from trcli.api.datasets_handler import DatasetsHandler
+from trcli.api.api_client import APIClient
+from trcli.cli import Environment
+
+
+class TestDatasetsHandler:
+    """Test class for DatasetsHandler"""
+
+    def setup_method(self):
+        """Set up test fixtures"""
+        self.mock_client = MagicMock(spec=APIClient)
+        self.environment = Environment()
+        self.environment.host = "https://test.testrail.com"
+        self.handler = DatasetsHandler(client=self.mock_client, environment=self.environment)
+
+    def test_get_dataset_success(self):
+        """Test retrieving a single dataset by ID"""
+        dataset_data = {
+            "id": 123,
+            "name": "Chrome_Dataset",
+            "variables": [
+                {"name": "browser", "value": "Chrome"},
+                {"name": "version", "value": "120.0"},
+            ],
+        }
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = dataset_data
+        self.mock_client.send_get.return_value = mock_response
+
+        result, error = self.handler.get_dataset(dataset_id=123)
+
+        assert result == dataset_data
+        assert error == ""
+        self.mock_client.send_get.assert_called_once_with("get_dataset/123")
+
+    def test_get_dataset_error(self):
+        """Test retrieving a dataset with API error"""
+        mock_response = MagicMock()
+        mock_response.error_message = "Dataset not found"
+        mock_response.response_text = None
+        self.mock_client.send_get.return_value = mock_response
+
+        result, error = self.handler.get_dataset(dataset_id=999)
+
+        assert result == {}
+        assert error == "Dataset not found"
+
+    def test_get_datasets_success(self):
+        """Test retrieving datasets list with default parameters"""
+        datasets_data = {
+            "datasets": [
+                {"id": 1, "name": "Default", "variables": []},
+                {"id": 2, "name": "Test_Dataset", "variables": [{"name": "browser", "value": "Chrome"}]},
+            ],
+            "offset": 0,
+            "limit": 250,
+            "size": 2,
+            "_links": {},
+        }
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = datasets_data
+        self.mock_client.send_get.return_value = mock_response
+
+        result, error = self.handler.get_datasets(project_id=1)
+
+        assert result == datasets_data
+        assert error == ""
+        self.mock_client.send_get.assert_called_once_with("get_datasets/1")
+
+    def test_get_datasets_with_pagination(self):
+        """Test retrieving datasets with custom pagination"""
+        datasets_data = {"datasets": [], "offset": 250, "limit": 100, "size": 0, "_links": {}}
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = datasets_data
+        self.mock_client.send_get.return_value = mock_response
+
+        result, error = self.handler.get_datasets(project_id=1, limit=100, offset=250)
+
+        assert result == datasets_data
+        assert error == ""
+        self.mock_client.send_get.assert_called_once_with("get_datasets/1&limit=100&offset=250")
+
+    def test_get_datasets_error(self):
+        """Test retrieving datasets with API error"""
+        mock_response = MagicMock()
+        mock_response.error_message = "Project not found"
+        mock_response.response_text = None
+        self.mock_client.send_get.return_value = mock_response
+
+        result, error = self.handler.get_datasets(project_id=999)
+
+        assert result == {}
+        assert error == "Project not found"
+
+    def test_add_dataset_with_variables(self):
+        """Test adding a dataset with variables"""
+        variables = {"browser": "Chrome", "version": "120.0"}
+        created_dataset = {
+            "id": 456,
+            "name": "Chrome_Dataset",
+            "variables": [
+                {"name": "browser", "value": "Chrome"},
+                {"name": "version", "value": "120.0"},
+            ],
+        }
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = created_dataset
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.add_dataset(project_id=1, name="Chrome_Dataset", variables=variables)
+
+        assert result == created_dataset
+        assert error == ""
+        self.mock_client.send_post.assert_called_once_with(
+            "add_dataset/1", {"name": "Chrome_Dataset", "variables": variables}
+        )
+
+    def test_add_dataset_without_variables(self):
+        """Test adding a dataset without variables (None should send empty object)"""
+        created_dataset = {"id": 456, "name": "Firefox_Dataset", "variables": []}
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = created_dataset
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.add_dataset(project_id=1, name="Firefox_Dataset", variables=None)
+
+        assert result == created_dataset
+        assert error == ""
+        # Verify that empty object {} is sent when variables=None
+        self.mock_client.send_post.assert_called_once_with(
+            "add_dataset/1", {"name": "Firefox_Dataset", "variables": {}}
+        )
+
+    def test_add_dataset_with_empty_variables_dict(self):
+        """Test adding a dataset with explicit empty variables dict"""
+        created_dataset = {"id": 456, "name": "Edge_Dataset", "variables": []}
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = created_dataset
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.add_dataset(project_id=1, name="Edge_Dataset", variables={})
+
+        assert result == created_dataset
+        assert error == ""
+        # Verify that empty object {} is sent when variables={}
+        self.mock_client.send_post.assert_called_once_with("add_dataset/1", {"name": "Edge_Dataset", "variables": {}})
+
+    def test_add_dataset_error(self):
+        """Test adding a dataset with API error"""
+        mock_response = MagicMock()
+        mock_response.error_message = "Invalid variable name"
+        mock_response.response_text = None
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.add_dataset(project_id=1, name="Test_Dataset", variables={"invalid-var": "value"})
+
+        assert result == {}
+        assert error == "Invalid variable name"
+
+    def test_update_dataset_name_only(self):
+        """Test updating dataset name only (should send empty variables object)"""
+        updated_dataset = {
+            "id": 123,
+            "name": "Chrome_Latest",
+            "variables": [{"name": "browser", "value": "Chrome"}],
+        }
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = updated_dataset
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.update_dataset(dataset_id=123, name="Chrome_Latest", variables=None)
+
+        assert result == updated_dataset
+        assert error == ""
+        # Verify that empty object {} is sent when variables=None
+        self.mock_client.send_post.assert_called_once_with(
+            "update_dataset/123", {"name": "Chrome_Latest", "variables": {}}
+        )
+
+    def test_update_dataset_variables_only(self):
+        """Test updating dataset variables only"""
+        variables = {"browser": "Chrome", "version": "121.0"}
+        updated_dataset = {
+            "id": 456,
+            "name": "Chrome_Dataset",
+            "variables": [
+                {"name": "browser", "value": "Chrome"},
+                {"name": "version", "value": "121.0"},
+            ],
+        }
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = updated_dataset
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.update_dataset(dataset_id=456, name=None, variables=variables)
+
+        assert result == updated_dataset
+        assert error == ""
+        self.mock_client.send_post.assert_called_once_with("update_dataset/456", {"variables": variables})
+
+    def test_update_dataset_with_empty_variables(self):
+        """Test updating dataset with explicit empty variables object"""
+        updated_dataset = {
+            "id": 123,
+            "name": "Chrome_Latest",
+            "variables": [{"name": "browser", "value": "Chrome"}],
+        }
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = updated_dataset
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.update_dataset(dataset_id=123, name="Chrome_Latest", variables={})
+
+        assert result == updated_dataset
+        assert error == ""
+        # Verify that empty object {} is sent when variables={}
+        self.mock_client.send_post.assert_called_once_with(
+            "update_dataset/123", {"name": "Chrome_Latest", "variables": {}}
+        )
+
+    def test_update_dataset_both_fields(self):
+        """Test updating both name and variables"""
+        variables = {"api_url": "https://api.prod.com", "timeout": "30"}
+        updated_dataset = {
+            "id": 789,
+            "name": "Production_Environment",
+            "variables": [
+                {"name": "api_url", "value": "https://api.prod.com"},
+                {"name": "timeout", "value": "30"},
+            ],
+        }
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = updated_dataset
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.update_dataset(dataset_id=789, name="Production_Environment", variables=variables)
+
+        assert result == updated_dataset
+        assert error == ""
+        self.mock_client.send_post.assert_called_once_with(
+            "update_dataset/789", {"name": "Production_Environment", "variables": variables}
+        )
+
+    def test_update_dataset_no_fields(self):
+        """Test updating dataset with no fields provided (should return error)"""
+        result, error = self.handler.update_dataset(dataset_id=123, name=None, variables=None)
+
+        assert result == {}
+        assert "At least one field" in error
+        # Verify no API call was made
+        self.mock_client.send_post.assert_not_called()
+
+    def test_update_dataset_error(self):
+        """Test updating dataset with API error"""
+        mock_response = MagicMock()
+        mock_response.error_message = "Dataset not found"
+        mock_response.response_text = None
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.update_dataset(dataset_id=999, name="New_Name")
+
+        assert result == {}
+        assert error == "Dataset not found"
+
+    def test_delete_dataset_success(self):
+        """Test deleting a dataset"""
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = {}
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.delete_dataset(dataset_id=123)
+
+        assert result == {}
+        assert error == ""
+        self.mock_client.send_post.assert_called_once_with("delete_dataset/123", {})
+
+    def test_delete_dataset_error(self):
+        """Test deleting a dataset with API error"""
+        mock_response = MagicMock()
+        mock_response.error_message = "Cannot delete Default dataset"
+        mock_response.response_text = None
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.delete_dataset(dataset_id=1)
+
+        assert result == {}
+        assert error == "Cannot delete Default dataset"

--- a/tests/test_variables_handler.py
+++ b/tests/test_variables_handler.py
@@ -1,0 +1,236 @@
+import pytest
+from unittest.mock import MagicMock
+
+from trcli.api.variables_handler import VariablesHandler
+from trcli.api.api_client import APIClient
+from trcli.cli import Environment
+
+
+class TestVariablesHandler:
+    """Test class for VariablesHandler"""
+
+    def setup_method(self):
+        """Set up test fixtures"""
+        self.mock_client = MagicMock(spec=APIClient)
+        self.environment = Environment()
+        self.environment.host = "https://test.testrail.com"
+        self.handler = VariablesHandler(client=self.mock_client, environment=self.environment)
+
+    def test_get_variables_success(self):
+        """Test retrieving variables list with default parameters"""
+        variables_data = {
+            "variables": [
+                {"id": 1, "name": "browser"},
+                {"id": 2, "name": "environment"},
+            ],
+            "offset": 0,
+            "limit": 250,
+            "size": 2,
+            "_links": {},
+        }
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = variables_data
+        self.mock_client.send_get.return_value = mock_response
+
+        result, error = self.handler.get_variables(project_id=1)
+
+        assert result == variables_data
+        assert error == ""
+        self.mock_client.send_get.assert_called_once_with("get_variables/1")
+
+    def test_get_variables_with_pagination(self):
+        """Test retrieving variables with custom pagination"""
+        variables_data = {"variables": [], "offset": 250, "limit": 100, "size": 0, "_links": {}}
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = variables_data
+        self.mock_client.send_get.return_value = mock_response
+
+        result, error = self.handler.get_variables(project_id=1, limit=100, offset=250)
+
+        assert result == variables_data
+        assert error == ""
+        self.mock_client.send_get.assert_called_once_with("get_variables/1&limit=100&offset=250")
+
+    def test_get_variables_with_limit_only(self):
+        """Test retrieving variables with custom limit only"""
+        variables_data = {"variables": [], "offset": 0, "limit": 50, "size": 0, "_links": {}}
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = variables_data
+        self.mock_client.send_get.return_value = mock_response
+
+        result, error = self.handler.get_variables(project_id=1, limit=50)
+
+        assert result == variables_data
+        assert error == ""
+        self.mock_client.send_get.assert_called_once_with("get_variables/1&limit=50")
+
+    def test_get_variables_with_offset_only(self):
+        """Test retrieving variables with custom offset only"""
+        variables_data = {"variables": [], "offset": 100, "limit": 250, "size": 0, "_links": {}}
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = variables_data
+        self.mock_client.send_get.return_value = mock_response
+
+        result, error = self.handler.get_variables(project_id=1, offset=100)
+
+        assert result == variables_data
+        assert error == ""
+        self.mock_client.send_get.assert_called_once_with("get_variables/1&offset=100")
+
+    def test_get_variables_error(self):
+        """Test retrieving variables with API error"""
+        mock_response = MagicMock()
+        mock_response.error_message = "Project not found"
+        mock_response.response_text = None
+        self.mock_client.send_get.return_value = mock_response
+
+        result, error = self.handler.get_variables(project_id=999)
+
+        assert result == {}
+        assert error == "Project not found"
+
+    def test_add_variable_success(self):
+        """Test adding a variable"""
+        created_variable = {"id": 456, "name": "browser"}
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = created_variable
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.add_variable(project_id=1, name="browser")
+
+        assert result == created_variable
+        assert error == ""
+        self.mock_client.send_post.assert_called_once_with("add_variable/1", {"name": "browser"})
+
+    def test_add_variable_with_underscore(self):
+        """Test adding a variable with underscore in name"""
+        created_variable = {"id": 457, "name": "api_endpoint"}
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = created_variable
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.add_variable(project_id=1, name="api_endpoint")
+
+        assert result == created_variable
+        assert error == ""
+        self.mock_client.send_post.assert_called_once_with("add_variable/1", {"name": "api_endpoint"})
+
+    def test_add_variable_error(self):
+        """Test adding a variable with API error"""
+        mock_response = MagicMock()
+        mock_response.error_message = "Invalid variable name"
+        mock_response.response_text = None
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.add_variable(project_id=1, name="invalid-name")
+
+        assert result == {}
+        assert error == "Invalid variable name"
+
+    def test_add_variable_duplicate_error(self):
+        """Test adding a duplicate variable"""
+        mock_response = MagicMock()
+        mock_response.error_message = "Variable with this name already exists"
+        mock_response.response_text = None
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.add_variable(project_id=1, name="browser")
+
+        assert result == {}
+        assert error == "Variable with this name already exists"
+
+    def test_update_variable_success(self):
+        """Test updating a variable"""
+        updated_variable = {"id": 123, "name": "new_browser"}
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = updated_variable
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.update_variable(variable_id=123, name="new_browser")
+
+        assert result == updated_variable
+        assert error == ""
+        self.mock_client.send_post.assert_called_once_with("update_variable/123", {"name": "new_browser"})
+
+    def test_update_variable_rename(self):
+        """Test renaming a variable"""
+        updated_variable = {"id": 456, "name": "environment_type"}
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = updated_variable
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.update_variable(variable_id=456, name="environment_type")
+
+        assert result == updated_variable
+        assert error == ""
+        self.mock_client.send_post.assert_called_once_with("update_variable/456", {"name": "environment_type"})
+
+    def test_update_variable_error(self):
+        """Test updating a variable with API error"""
+        mock_response = MagicMock()
+        mock_response.error_message = "Variable not found"
+        mock_response.response_text = None
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.update_variable(variable_id=999, name="new_name")
+
+        assert result == {}
+        assert error == "Variable not found"
+
+    def test_update_variable_duplicate_name_error(self):
+        """Test updating variable to a name that already exists"""
+        mock_response = MagicMock()
+        mock_response.error_message = "Variable with this name already exists"
+        mock_response.response_text = None
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.update_variable(variable_id=123, name="browser")
+
+        assert result == {}
+        assert error == "Variable with this name already exists"
+
+    def test_delete_variable_success(self):
+        """Test deleting a variable"""
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = {}
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.delete_variable(variable_id=123)
+
+        assert result == {}
+        assert error == ""
+        self.mock_client.send_post.assert_called_once_with("delete_variable/123", {})
+
+    def test_delete_variable_error(self):
+        """Test deleting a variable with API error"""
+        mock_response = MagicMock()
+        mock_response.error_message = "Variable not found"
+        mock_response.response_text = None
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.delete_variable(variable_id=999)
+
+        assert result == {}
+        assert error == "Variable not found"
+
+    def test_delete_variable_in_use_warning(self):
+        """Test deleting a variable that's in use (should succeed with warning)"""
+        mock_response = MagicMock()
+        mock_response.error_message = None
+        mock_response.response_text = {}
+        self.mock_client.send_post.return_value = mock_response
+
+        result, error = self.handler.delete_variable(variable_id=123)
+
+        assert result == {}
+        assert error == ""
+        # Note: API handles cascade deletion of values, no error returned

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,30 @@
 [tox]
-env_list = 
-     unit-test, #click-pyyaml{60,latest}-junitparser{31,latest}-pyserde{12,latest}-requests{231,232,latest}-tqdm{465,latest}-humanfriendly{100,latest}-openapi{50,latest}-beartype{17,latest}-prance
+env_list =
+     unit-test, security-audit, #click-pyyaml{60,latest}-junitparser{31,latest}-pyserde{12,latest}-requests{231,232,latest}-tqdm{465,latest}-humanfriendly{100,latest}-openapi{50,latest}-beartype{17,latest}-prance
 
 [testenv:unit-test]
 description = run basic unit test based on latest version of dependencies
-commands = 
+commands =
     pip install -r tests/requirements-tox.txt
     pip install -r tests/requirements-variable-deps.txt
     pip list
     coverage run -m pytest -c tests/pytest.ini -W ignore::pytest.PytestCollectionWarning tests
     coverage report -m
 
-allowlist_externals = 
+allowlist_externals =
     cd
+
+[testenv:security-audit]
+description = run pip-audit to check for known security vulnerabilities in dependencies
+deps =
+    pip>=26.1.2
+    setuptools>=83.0.0
+    pip-audit
+skip_install = false
+commands =
+    pip install --upgrade pip>=26.1.2 setuptools>=83.0.0
+    pip install -e .
+    pip-audit --desc
 
 [testenv]
 description = Run dependencies matrix  + full unit test (NOTE: May take time as different versions of each dependencies are tested against each other!)

--- a/trcli/api/api_request_handler.py
+++ b/trcli/api/api_request_handler.py
@@ -27,6 +27,8 @@ from trcli.api.user_handler import UserHandler
 from trcli.api.project_handler import ProjectHandler
 from trcli.api.template_handler import TemplateHandler
 from trcli.api.test_handler import TestHandler
+from trcli.api.variables_handler import VariablesHandler
+from trcli.api.datasets_handler import DatasetsHandler
 from trcli.cli import Environment
 from trcli.constants import (
     ProjectErrors,
@@ -108,6 +110,8 @@ class ApiRequestHandler:
         self.project_handler = ProjectHandler(api_client)
         self.template_handler = TemplateHandler(api_client)
         self.test_handler = TestHandler(api_client)
+        self.variables_handler = VariablesHandler(api_client, environment)
+        self.datasets_handler = DatasetsHandler(api_client, environment)
 
         # BDD case cache for feature name matching (shared by CucumberParser and JunitParser)
         # Structure: {"{project_id}_{suite_id}": {normalized_name: [case_dict, case_dict, ...]}}

--- a/trcli/api/datasets_handler.py
+++ b/trcli/api/datasets_handler.py
@@ -1,0 +1,153 @@
+"""
+DatasetsHandler - Handles all datasets-related operations for TestRail
+
+It manages all dataset operations including:
+- Retrieving individual datasets
+- Listing all datasets
+- Adding new datasets
+- Updating existing datasets
+- Deleting datasets
+"""
+
+from beartype.typing import Tuple, Optional, Dict, Any
+
+from trcli.api.api_client import APIClient
+from trcli.cli import Environment
+
+
+class DatasetsHandler:
+    """Handles all datasets-related operations for TestRail"""
+
+    def __init__(
+        self,
+        client: APIClient,
+        environment: Environment,
+    ):
+        """
+        Initialize the DatasetsHandler
+
+        :param client: APIClient instance for making API calls
+        :param environment: Environment configuration
+        """
+        self.client = client
+        self.environment = environment
+
+    def get_dataset(self, dataset_id: int) -> Tuple[dict, str]:
+        """
+        Retrieve a single dataset by ID
+
+        :param dataset_id: TestRail dataset ID
+        :returns: Tuple with (dataset_data_dict, error_message)
+        """
+        response = self.client.send_get(f"get_dataset/{dataset_id}")
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""
+
+    def get_datasets(
+        self,
+        project_id: int,
+        limit: int = 250,
+        offset: int = 0,
+    ) -> Tuple[dict, str]:
+        """
+        Retrieve datasets for a project with pagination
+
+        :param project_id: TestRail project ID
+        :param limit: Maximum number of datasets to return (default: 250)
+        :param offset: Offset for pagination (default: 0)
+        :returns: Tuple with (paginated_response_dict, error_message)
+                  Response dict contains: datasets, offset, limit, size, _links
+        """
+        # Build query parameters
+        params = []
+        if limit != 250:
+            params.append(f"limit={limit}")
+        if offset > 0:
+            params.append(f"offset={offset}")
+
+        # Build URL
+        query_string = "&".join(params) if params else ""
+        url = f"get_datasets/{project_id}"
+        if query_string:
+            url = f"{url}&{query_string}"
+
+        response = self.client.send_get(url)
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""
+
+    def add_dataset(
+        self,
+        project_id: int,
+        name: str,
+        variables: Optional[Dict[str, str]] = None,
+    ) -> Tuple[Dict[str, Any], str]:
+        """
+        Create a new dataset
+
+        :param project_id: TestRail project ID
+        :param name: Name of the dataset (required)
+        :param variables: Dictionary of variable_name: value pairs (optional)
+        :returns: Tuple with (created_dataset_dict, error_message)
+        """
+        payload = {"name": name}
+
+        if variables:
+            payload["variables"] = variables
+
+        response = self.client.send_post(f"add_dataset/{project_id}", payload)
+        if response.error_message:
+            return {}, response.error_message
+
+        return response.response_text, ""
+
+    def update_dataset(
+        self,
+        dataset_id: int,
+        name: Optional[str] = None,
+        variables: Optional[Dict[str, str]] = None,
+    ) -> Tuple[Dict[str, Any], str]:
+        """
+        Update an existing dataset
+
+        :param dataset_id: TestRail dataset ID
+        :param name: New name for the dataset (optional)
+        :param variables: Dictionary of variable_name: value pairs (optional)
+        :returns: Tuple with (updated_dataset_dict, error_message)
+        """
+        payload = {}
+
+        if name is not None:
+            payload["name"] = name
+
+        if variables:
+            payload["variables"] = variables
+
+        if not payload:
+            return {}, "Error: At least one field (name or variables) must be provided for update"
+
+        response = self.client.send_post(f"update_dataset/{dataset_id}", payload)
+        if response.error_message:
+            return {}, response.error_message
+
+        return response.response_text, ""
+
+    def delete_dataset(
+        self,
+        dataset_id: int,
+    ) -> Tuple[dict, str]:
+        """
+        Delete an existing dataset
+
+        Note: Cannot delete the Default dataset.
+        Deleting a dataset also removes the dataset's values.
+
+        :param dataset_id: TestRail dataset ID
+        :returns: Tuple with (response_dict, error_message)
+        """
+        response = self.client.send_post(f"delete_dataset/{dataset_id}", {})
+        if response.error_message:
+            return {}, response.error_message
+
+        return response.response_text, ""

--- a/trcli/api/datasets_handler.py
+++ b/trcli/api/datasets_handler.py
@@ -111,21 +111,29 @@ class DatasetsHandler:
         """
         Update an existing dataset
 
+        Note: TestRail API requires the 'variables' field to always be present in update requests.
+        If only name is provided, an empty variables object {} will be sent, which preserves
+        existing variables.
+
         :param dataset_id: TestRail dataset ID
         :param name: New name for the dataset (optional)
         :param variables: Dictionary of variable_name: value pairs (optional)
         :returns: Tuple with (updated_dataset_dict, error_message)
         """
-        payload = {}
+        if name is None and variables is None:
+            return {}, "Error: At least one field (name or variables) must be provided for update"
 
+        # Build payload
+        payload = {}
         if name is not None:
             payload["name"] = name
 
-        if variables:
+        # TestRail API requires 'variables' field to always be present
+        # If variables not provided, send empty dict to preserve existing variables
+        if variables is not None:
             payload["variables"] = variables
-
-        if not payload:
-            return {}, "Error: At least one field (name or variables) must be provided for update"
+        else:
+            payload["variables"] = {}
 
         response = self.client.send_post(f"update_dataset/{dataset_id}", payload)
         if response.error_message:

--- a/trcli/api/datasets_handler.py
+++ b/trcli/api/datasets_handler.py
@@ -89,12 +89,16 @@ class DatasetsHandler:
         :param project_id: TestRail project ID
         :param name: Name of the dataset (required)
         :param variables: Dictionary of variable_name: value pairs (optional)
+                         If None, sends empty dict {}. If empty dict {}, also sends {}.
         :returns: Tuple with (created_dataset_dict, error_message)
         """
         payload = {"name": name}
 
-        if variables:
+        # Always include variables field, use {} if not provided
+        if variables is not None:
             payload["variables"] = variables
+        else:
+            payload["variables"] = {}
 
         response = self.client.send_post(f"add_dataset/{project_id}", payload)
         if response.error_message:

--- a/trcli/api/results_uploader.py
+++ b/trcli/api/results_uploader.py
@@ -14,9 +14,12 @@ class ResultsUploader(ProjectBasedClient):
     Initialized with environment object and result file parser object (any parser derived from FileParser).
     """
 
-    def __init__(self, environment: Environment, suite: TestRailSuite, skip_run: bool = False):
+    def __init__(
+        self, environment: Environment, suite: TestRailSuite, skip_run: bool = False, defer_close_run: bool = False
+    ):
         super().__init__(environment, suite)
         self.skip_run = skip_run
+        self.defer_close_run = defer_close_run
         self.last_run_id = None
         if hasattr(self.environment, "special_parser") and self.environment.special_parser == "saucectl":
             self.run_name += f" ({suite.name})"
@@ -169,12 +172,13 @@ class ResultsUploader(ProjectBasedClient):
             self.environment.log("\n".join(revert_logs))
             exit(1)
 
-        if self.environment.close_run:
+        # Close run only if not deferred (defer_close_run allows caller to close later)
+        if self.environment.close_run and not self.defer_close_run:
             self.environment.log("Closing test run. ", new_line=False)
             response, error_message = self.api_request_handler.close_run(run_id)
-        if error_message:
-            self.environment.elog("\n" + error_message)
-            exit(1)
+            if error_message:
+                self.environment.elog("\n" + error_message)
+                exit(1)
 
         # Terminate upload
         stop = time.time()

--- a/trcli/api/variables_handler.py
+++ b/trcli/api/variables_handler.py
@@ -1,0 +1,123 @@
+"""
+VariablesHandler - Handles all variables-related operations for TestRail
+
+It manages all variable operations including:
+- Retrieving variables
+- Adding new variables
+- Updating existing variables
+- Deleting variables
+"""
+
+from beartype.typing import Tuple, Optional, Dict, Any
+
+from trcli.api.api_client import APIClient
+from trcli.cli import Environment
+
+
+class VariablesHandler:
+    """Handles all variables-related operations for TestRail"""
+
+    def __init__(
+        self,
+        client: APIClient,
+        environment: Environment,
+    ):
+        """
+        Initialize the VariablesHandler
+
+        :param client: APIClient instance for making API calls
+        :param environment: Environment configuration
+        """
+        self.client = client
+        self.environment = environment
+
+    def get_variables(
+        self,
+        project_id: int,
+        limit: int = 250,
+        offset: int = 0,
+    ) -> Tuple[dict, str]:
+        """
+        Retrieve variables for a project with pagination
+
+        :param project_id: TestRail project ID
+        :param limit: Maximum number of variables to return (default: 250)
+        :param offset: Offset for pagination (default: 0)
+        :returns: Tuple with (paginated_response_dict, error_message)
+                  Response dict contains: variables, offset, limit, size, _links
+        """
+        # Build query parameters
+        params = []
+        if limit != 250:
+            params.append(f"limit={limit}")
+        if offset > 0:
+            params.append(f"offset={offset}")
+
+        # Build URL
+        query_string = "&".join(params) if params else ""
+        url = f"get_variables/{project_id}"
+        if query_string:
+            url = f"{url}&{query_string}"
+
+        response = self.client.send_get(url)
+        if response.error_message:
+            return {}, response.error_message
+        return response.response_text, ""
+
+    def add_variable(
+        self,
+        project_id: int,
+        name: str,
+    ) -> Tuple[Dict[str, Any], str]:
+        """
+        Create a new variable
+
+        :param project_id: TestRail project ID
+        :param name: Name of the variable (required)
+        :returns: Tuple with (created_variable_dict, error_message)
+        """
+        payload = {"name": name}
+
+        response = self.client.send_post(f"add_variable/{project_id}", payload)
+        if response.error_message:
+            return {}, response.error_message
+
+        return response.response_text, ""
+
+    def update_variable(
+        self,
+        variable_id: int,
+        name: str,
+    ) -> Tuple[Dict[str, Any], str]:
+        """
+        Update an existing variable
+
+        :param variable_id: TestRail variable ID
+        :param name: New name for the variable (required)
+        :returns: Tuple with (updated_variable_dict, error_message)
+        """
+        payload = {"name": name}
+
+        response = self.client.send_post(f"update_variable/{variable_id}", payload)
+        if response.error_message:
+            return {}, response.error_message
+
+        return response.response_text, ""
+
+    def delete_variable(
+        self,
+        variable_id: int,
+    ) -> Tuple[dict, str]:
+        """
+        Delete an existing variable
+
+        Note: Deleting a variable also deletes corresponding values from datasets.
+
+        :param variable_id: TestRail variable ID
+        :returns: Tuple with (response_dict, error_message)
+        """
+        response = self.client.send_post(f"delete_variable/{variable_id}", {})
+        if response.error_message:
+            return {}, response.error_message
+
+        return response.response_text, ""

--- a/trcli/commands/cmd_datasets.py
+++ b/trcli/commands/cmd_datasets.py
@@ -155,7 +155,7 @@ def show(
     "--variables",
     type=str,
     metavar="<json>",
-    help='JSON object of variable_name: value pairs. Example: \'{"browser":"Chrome","version":"1.0"}\'',
+    help='JSON object of variable_name: value pairs. Example: {"browser":"Chrome","version":"1.0"}',
 )
 @click.option("--json-output", is_flag=True, help="Output created dataset as raw JSON from API.")
 @click.pass_context
@@ -234,7 +234,7 @@ def add(
     "--variables",
     type=str,
     metavar="<json>",
-    help='JSON object of variable_name: value pairs to update. Example: \'{"browser":"Firefox"}\'',
+    help='JSON object of variable_name: value pairs to update. Example: {"browser":"Firefox"}',
 )
 @click.option("--json-output", is_flag=True, help="Output updated dataset as raw JSON from API.")
 @click.pass_context

--- a/trcli/commands/cmd_datasets.py
+++ b/trcli/commands/cmd_datasets.py
@@ -1,0 +1,349 @@
+import click
+import json
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def print_config(env: Environment, action: str):
+    env.log(
+        f"Datasets {action} Execution Parameters"
+        f"\n> TestRail instance: {env.host} (user: {env.username})"
+        f"\n> Project: {env.project if env.project else env.project_id}"
+    )
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.pass_context
+@pass_environment
+def cli(environment: Environment, context: click.Context, *args, **kwargs):
+    """Manage test data datasets in TestRail"""
+    environment.cmd = "datasets"
+    environment.set_parameters(context)
+
+
+@cli.command()
+@click.option("--offset", type=int, default=0, metavar="", help="Offset for pagination (default: 0).")
+@click.option("--limit", type=int, default=250, metavar="", help="Limit for pagination (default: 250).")
+@click.option("--json-output", is_flag=True, help="Output datasets as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def list(
+    environment: Environment,
+    context: click.Context,
+    offset: int,
+    limit: int,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """List all datasets for a project"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "List")
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    environment.log(f"Retrieving datasets for project ID {project_client.project.project_id}...")
+
+    # Retrieve datasets
+    response_data, error_message = project_client.api_request_handler.datasets_handler.get_datasets(
+        project_id=project_client.project.project_id,
+        limit=limit,
+        offset=offset,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve datasets: {error_message}")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        print(json.dumps(response_data, indent=2))
+    else:
+        datasets = response_data.get("datasets", [])
+        response_offset = response_data.get("offset", 0)
+        response_size = response_data.get("size", 0)
+        next_link = response_data.get("_links", {}).get("next")
+
+        if not datasets:
+            environment.log("No datasets found.")
+        else:
+            environment.log(
+                f"Found {response_size} dataset(s) (showing {response_offset + 1}-{response_offset + len(datasets)}):"
+            )
+            if next_link:
+                environment.log("  (More results available - use --offset and --limit for pagination)")
+            environment.log("")
+
+            for dataset in datasets:
+                environment.log(f"  Dataset ID: {dataset.get('id', 'N/A')}")
+                environment.log(f"    Name: {dataset.get('name', 'N/A')}")
+                variables = dataset.get("variables", [])
+                environment.log(f"    Variables: {len(variables)} variable(s)")
+                if variables:
+                    # Show first few variables as preview
+                    preview_count = min(3, len(variables))
+                    for i, var in enumerate(variables[:preview_count]):
+                        environment.log(f"      - {var.get('name')}: {var.get('value')}")
+                    if len(variables) > preview_count:
+                        environment.log(f"      ... and {len(variables) - preview_count} more")
+                environment.log("")
+
+
+@cli.command()
+@click.option("--dataset-id", type=click.IntRange(min=1), required=True, metavar="<id>", help="Dataset ID to retrieve.")
+@click.option("--json-output", is_flag=True, help="Output dataset as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def show(
+    environment: Environment,
+    context: click.Context,
+    dataset_id: int,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """View a specific dataset with all variable values"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Show")
+
+    # Create ProjectBasedClient
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    environment.log(f"Retrieving dataset ID {dataset_id}...")
+
+    # Retrieve dataset
+    dataset, error_message = project_client.api_request_handler.datasets_handler.get_dataset(dataset_id=dataset_id)
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve dataset: {error_message}")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        print(json.dumps(dataset, indent=2))
+    else:
+        environment.log("")
+        environment.log(f"Dataset ID: {dataset.get('id', 'N/A')}")
+        environment.log(f"  Name: {dataset.get('name', 'N/A')}")
+
+        variables = dataset.get("variables", [])
+        if variables:
+            environment.log(f"\n  Variables ({len(variables)}):")
+            for variable in variables:
+                environment.log(f"    {variable.get('name', 'N/A')}: {variable.get('value', '')}")
+        else:
+            environment.log("\n  Variables: (none)")
+
+
+@cli.command()
+@click.option("--name", type=str, required=True, metavar="<name>", help="Name of the dataset (required).")
+@click.option(
+    "--variables",
+    type=str,
+    metavar="<json>",
+    help='JSON object of variable_name: value pairs. Example: \'{"browser":"Chrome","version":"1.0"}\'',
+)
+@click.option("--json-output", is_flag=True, help="Output created dataset as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def add(
+    environment: Environment,
+    context: click.Context,
+    name: str,
+    variables: str,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """Create a new dataset"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Add")
+
+    # Parse variables JSON if provided
+    parsed_variables = None
+    if variables:
+        try:
+            parsed_variables = json.loads(variables)
+            if not isinstance(parsed_variables, dict):
+                environment.elog('Error: --variables must be a JSON object (e.g., \'{"var1":"value1"}\')')
+                raise SystemExit(1)
+        except json.JSONDecodeError as e:
+            environment.elog(f"Error: Invalid JSON in --variables: {e}")
+            raise SystemExit(1)
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    environment.log(f"Creating dataset '{name}' in project ID {project_client.project.project_id}...")
+
+    # Create the dataset
+    dataset, error_message = project_client.api_request_handler.datasets_handler.add_dataset(
+        project_id=project_client.project.project_id,
+        name=name,
+        variables=parsed_variables,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to create dataset: {error_message}")
+        raise SystemExit(1)
+
+    if not dataset or not dataset.get("id"):
+        environment.elog("Error: Dataset creation returned unexpected response")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        print(json.dumps(dataset, indent=2))
+    else:
+        environment.log(f"\nDataset created successfully!")
+        environment.log(f"  Dataset ID: {dataset.get('id')}")
+        environment.log(f"  Name: {dataset.get('name')}")
+
+        variables_list = dataset.get("variables", [])
+        if variables_list:
+            environment.log(f"  Variables: {len(variables_list)} variable(s)")
+            for var in variables_list:
+                environment.log(f"    - {var.get('name')}: {var.get('value')}")
+
+
+@cli.command()
+@click.option("--dataset-id", type=click.IntRange(min=1), required=True, metavar="<id>", help="Dataset ID to update.")
+@click.option("--name", type=str, metavar="<name>", help="New name for the dataset.")
+@click.option(
+    "--variables",
+    type=str,
+    metavar="<json>",
+    help='JSON object of variable_name: value pairs to update. Example: \'{"browser":"Firefox"}\'',
+)
+@click.option("--json-output", is_flag=True, help="Output updated dataset as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def update(
+    environment: Environment,
+    context: click.Context,
+    dataset_id: int,
+    name: str,
+    variables: str,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """Update an existing dataset"""
+    environment.check_for_required_parameters()
+
+    # Validate that at least one field is provided
+    if not name and not variables:
+        environment.elog("Error: At least one of --name or --variables must be provided")
+        raise SystemExit(1)
+
+    print_config(environment, "Update")
+
+    # Parse variables JSON if provided
+    parsed_variables = None
+    if variables:
+        try:
+            parsed_variables = json.loads(variables)
+            if not isinstance(parsed_variables, dict):
+                environment.elog('Error: --variables must be a JSON object (e.g., \'{"var1":"value1"}\')')
+                raise SystemExit(1)
+        except json.JSONDecodeError as e:
+            environment.elog(f"Error: Invalid JSON in --variables: {e}")
+            raise SystemExit(1)
+
+    # Create ProjectBasedClient
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    environment.log(f"Updating dataset ID {dataset_id}...")
+
+    # Update the dataset
+    dataset, error_message = project_client.api_request_handler.datasets_handler.update_dataset(
+        dataset_id=dataset_id,
+        name=name,
+        variables=parsed_variables,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to update dataset: {error_message}")
+        raise SystemExit(1)
+
+    if not dataset or not dataset.get("id"):
+        environment.elog("Error: Dataset update returned unexpected response")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        print(json.dumps(dataset, indent=2))
+    else:
+        environment.log(f"\nDataset updated successfully!")
+        environment.log(f"  Dataset ID: {dataset.get('id')}")
+        environment.log(f"  Name: {dataset.get('name')}")
+
+        variables_list = dataset.get("variables", [])
+        if variables_list:
+            environment.log(f"  Variables: {len(variables_list)} variable(s)")
+            for var in variables_list:
+                environment.log(f"    - {var.get('name')}: {var.get('value')}")
+
+
+@cli.command()
+@click.option("--dataset-id", type=click.IntRange(min=1), required=True, metavar="<id>", help="Dataset ID to delete.")
+@click.pass_context
+@pass_environment
+def delete(
+    environment: Environment,
+    context: click.Context,
+    dataset_id: int,
+    *args,
+    **kwargs,
+):
+    """Delete a dataset
+
+    Note: Cannot delete the Default dataset. Deleting a dataset will also remove the dataset's values.
+    """
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Delete")
+
+    # Create ProjectBasedClient
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    environment.log(f"Deleting dataset ID {dataset_id}...")
+
+    # Delete the dataset
+    response, error_message = project_client.api_request_handler.datasets_handler.delete_dataset(
+        dataset_id=dataset_id,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to delete dataset: {error_message}")
+        raise SystemExit(1)
+
+    environment.log(f"\nDataset ID {dataset_id} deleted successfully.")
+    environment.log("Note: The dataset's values have also been removed.")

--- a/trcli/commands/cmd_datasets.py
+++ b/trcli/commands/cmd_datasets.py
@@ -175,13 +175,15 @@ def add(
     print_config(environment, "Add")
 
     # Parse variables JSON if provided
+    # Note: None means --variables not provided, {} means empty object provided
     parsed_variables = None
     if variables:
         try:
             parsed_variables = json.loads(variables)
             if not isinstance(parsed_variables, dict):
-                environment.elog('Error: --variables must be a JSON object (e.g., \'{"var1":"value1"}\')')
+                environment.elog('Error: --variables must be a JSON object (e.g., {"var1":"value1"})')
                 raise SystemExit(1)
+            # Empty object {} is valid - it creates a dataset with no variables
         except json.JSONDecodeError as e:
             environment.elog(f"Error: Invalid JSON in --variables: {e}")
             raise SystemExit(1)
@@ -260,13 +262,15 @@ def update(
     print_config(environment, "Update")
 
     # Parse variables JSON if provided
+    # Note: None means --variables not provided, {} means empty object provided
     parsed_variables = None
     if variables:
         try:
             parsed_variables = json.loads(variables)
             if not isinstance(parsed_variables, dict):
-                environment.elog('Error: --variables must be a JSON object (e.g., \'{"var1":"value1"}\')')
+                environment.elog('Error: --variables must be a JSON object (e.g., {"var1":"value1"})')
                 raise SystemExit(1)
+            # Empty object {} is valid - it will preserve existing variables (API behavior)
         except json.JSONDecodeError as e:
             environment.elog(f"Error: Invalid JSON in --variables: {e}")
             raise SystemExit(1)

--- a/trcli/commands/cmd_datasets.py
+++ b/trcli/commands/cmd_datasets.py
@@ -41,7 +41,9 @@ def list(
     """List all datasets for a project"""
     environment.check_for_required_parameters()
 
-    print_config(environment, "List")
+    # Skip log output when JSON output is requested (for clean JSON-only output)
+    if not json_output:
+        print_config(environment, "List")
 
     # Create ProjectBasedClient to resolve project
     project_client = ProjectBasedClient(
@@ -52,7 +54,8 @@ def list(
     # Resolve project (converts name to ID if needed)
     project_client.resolve_project()
 
-    environment.log(f"Retrieving datasets for project ID {project_client.project.project_id}...")
+    if not json_output:
+        environment.log(f"Retrieving datasets for project ID {project_client.project.project_id}...")
 
     # Retrieve datasets
     response_data, error_message = project_client.api_request_handler.datasets_handler.get_datasets(
@@ -113,9 +116,12 @@ def show(
     **kwargs,
 ):
     """View a specific dataset with all variable values"""
+    environment.cmd = "datasets_show"  # Use ID-based command (no project required)
     environment.check_for_required_parameters()
 
-    print_config(environment, "Show")
+    # Skip log output when JSON output is requested (for clean JSON-only output)
+    if not json_output:
+        print_config(environment, "Show")
 
     # Create ProjectBasedClient
     project_client = ProjectBasedClient(
@@ -123,7 +129,8 @@ def show(
         suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
     )
 
-    environment.log(f"Retrieving dataset ID {dataset_id}...")
+    if not json_output:
+        environment.log(f"Retrieving dataset ID {dataset_id}...")
 
     # Retrieve dataset
     dataset, error_message = project_client.api_request_handler.datasets_handler.get_dataset(dataset_id=dataset_id)
@@ -172,7 +179,9 @@ def add(
     """Create a new dataset"""
     environment.check_for_required_parameters()
 
-    print_config(environment, "Add")
+    # Skip log output when JSON output is requested (for clean JSON-only output)
+    if not json_output:
+        print_config(environment, "Add")
 
     # Parse variables JSON if provided
     # Note: None means --variables not provided, {} means empty object provided
@@ -197,7 +206,8 @@ def add(
     # Resolve project (converts name to ID if needed)
     project_client.resolve_project()
 
-    environment.log(f"Creating dataset '{name}' in project ID {project_client.project.project_id}...")
+    if not json_output:
+        environment.log(f"Creating dataset '{name}' in project ID {project_client.project.project_id}...")
 
     # Create the dataset
     dataset, error_message = project_client.api_request_handler.datasets_handler.add_dataset(
@@ -252,6 +262,7 @@ def update(
     **kwargs,
 ):
     """Update an existing dataset"""
+    environment.cmd = "datasets_update"  # Use ID-based command (no project required)
     environment.check_for_required_parameters()
 
     # Validate that at least one field is provided
@@ -259,7 +270,9 @@ def update(
         environment.elog("Error: At least one of --name or --variables must be provided")
         raise SystemExit(1)
 
-    print_config(environment, "Update")
+    # Skip log output when JSON output is requested (for clean JSON-only output)
+    if not json_output:
+        print_config(environment, "Update")
 
     # Parse variables JSON if provided
     # Note: None means --variables not provided, {} means empty object provided
@@ -281,7 +294,8 @@ def update(
         suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
     )
 
-    environment.log(f"Updating dataset ID {dataset_id}...")
+    if not json_output:
+        environment.log(f"Updating dataset ID {dataset_id}...")
 
     # Update the dataset
     dataset, error_message = project_client.api_request_handler.datasets_handler.update_dataset(
@@ -328,6 +342,7 @@ def delete(
 
     Note: Cannot delete the Default dataset. Deleting a dataset will also remove the dataset's values.
     """
+    environment.cmd = "datasets_delete"  # Use ID-based command (no project required)
     environment.check_for_required_parameters()
 
     print_config(environment, "Delete")

--- a/trcli/commands/cmd_parse_junit.py
+++ b/trcli/commands/cmd_parse_junit.py
@@ -109,25 +109,33 @@ def cli(environment: Environment, context: click.Context, *args, **kwargs):
             # Normal mode: process each suite separately
             # Defer close_run if test_run_ref is provided to attach references first
             defer_close = environment.test_run_ref is not None
+            run_ids = []  # Track all run IDs created/used
 
             for suite in parsed_suites:
                 result_uploader = ResultsUploader(environment=environment, suite=suite, defer_close_run=defer_close)
                 result_uploader.upload_results()
 
-                if run_id is None and hasattr(result_uploader, "last_run_id"):
-                    run_id = result_uploader.last_run_id
+                # Collect all run IDs (not just the first one)
+                if hasattr(result_uploader, "last_run_id") and result_uploader.last_run_id:
+                    run_ids.append(result_uploader.last_run_id)
+                    # Keep first run_id for backward compatibility
+                    if run_id is None:
+                        run_id = result_uploader.last_run_id
 
                 # Collect case update results
                 if hasattr(result_uploader, "case_update_results"):
                     case_update_results = result_uploader.case_update_results
 
-        # Handle test run references BEFORE closing the run
-        if environment.test_run_ref and run_id:
-            _handle_test_run_references(environment, run_id)
+        # Handle test run references and closing for all runs
+        if environment.test_run_ref and run_ids:
+            # Attach references to all runs
+            for current_run_id in run_ids:
+                _handle_test_run_references(environment, current_run_id)
 
-        # Close run after references are attached (if deferred and close_run flag is set)
-        if environment.close_run and environment.test_run_ref and run_id:
-            _close_test_run(environment, run_id)
+        # Close all runs after references are attached (if deferred and close_run flag is set)
+        if environment.close_run and environment.test_run_ref and run_ids:
+            for current_run_id in run_ids:
+                _close_test_run(environment, current_run_id)
 
         # Handle case update reporting if enabled
         if environment.update_existing_cases == "yes" and case_update_results is not None:

--- a/trcli/commands/cmd_parse_junit.py
+++ b/trcli/commands/cmd_parse_junit.py
@@ -94,6 +94,7 @@ def cli(environment: Environment, context: click.Context, *args, **kwargs):
             exit(1)
 
         run_id = None
+        run_ids = []  # Track all run IDs - hoisted to top-level scope to avoid NameError
         case_update_results = {}
 
         # Multisuite mode: use MultisuiteUploader for cross-suite plans
@@ -103,13 +104,14 @@ def cli(environment: Environment, context: click.Context, *args, **kwargs):
             multisuite_uploader = MultisuiteUploader(environment=environment, suite=parsed_suites[0])
             multisuite_uploader.upload_results()
 
-            # Use plan_id for reference handling
-            run_id = multisuite_uploader.last_plan_id
+            # Use plan_id for reference handling - add to run_ids for unified handling
+            plan_id = multisuite_uploader.last_plan_id
+            run_ids = [plan_id]
+            run_id = plan_id
         else:
             # Normal mode: process each suite separately
             # Defer close_run if test_run_ref is provided to attach references first
             defer_close = environment.test_run_ref is not None
-            run_ids = []  # Track all run IDs created/used
 
             for suite in parsed_suites:
                 result_uploader = ResultsUploader(environment=environment, suite=suite, defer_close_run=defer_close)
@@ -118,7 +120,7 @@ def cli(environment: Environment, context: click.Context, *args, **kwargs):
                 # Collect all run IDs (not just the first one)
                 if hasattr(result_uploader, "last_run_id") and result_uploader.last_run_id:
                     run_ids.append(result_uploader.last_run_id)
-                    # Keep first run_id for backward compatibility
+                    # Store first run_id (may be used elsewhere in future)
                     if run_id is None:
                         run_id = result_uploader.last_run_id
 
@@ -129,8 +131,20 @@ def cli(environment: Environment, context: click.Context, *args, **kwargs):
         # Handle test run references and closing for all runs
         if environment.test_run_ref and run_ids:
             # Attach references to all runs
-            for current_run_id in run_ids:
-                _handle_test_run_references(environment, current_run_id)
+            if environment.json_output and len(run_ids) > 1:
+                # Multiple runs with JSON output: accumulate results into array
+                import json
+
+                all_results = []
+                for current_run_id in run_ids:
+                    result = _handle_test_run_references(environment, current_run_id, return_result=True)
+                    all_results.append(result)
+                # Print single valid JSON array
+                print(json.dumps(all_results, indent=2))
+            else:
+                # Single run or console output: process normally
+                for current_run_id in run_ids:
+                    _handle_test_run_references(environment, current_run_id)
 
         # Close all runs after references are attached (if deferred and close_run flag is set)
         if environment.close_run and environment.test_run_ref and run_ids:
@@ -197,9 +211,17 @@ def _close_test_run(environment: Environment, run_id: int):
         exit(1)
 
 
-def _handle_test_run_references(environment: Environment, run_id: int):
+def _handle_test_run_references(environment: Environment, run_id: int, return_result: bool = False):
     """
     Handle appending references to the test run.
+
+    Args:
+        environment: Environment object
+        run_id: TestRail run ID or plan ID
+        return_result: If True, return result dict instead of printing (for JSON accumulation)
+
+    Returns:
+        dict: Result dictionary if return_result=True, otherwise None
     """
     from trcli.api.project_based_client import ProjectBasedClient
     from trcli.data_classes.dataclass_testrail import TestRailSuite
@@ -210,7 +232,9 @@ def _handle_test_run_references(environment: Environment, run_id: int):
     project_client = ProjectBasedClient(environment=environment, suite=TestRailSuite(name="temp", suite_id=1))
     project_client.resolve_project()
 
-    environment.log(f"Appending references to test run {run_id}...")
+    if not return_result:
+        environment.log(f"Appending references to test run {run_id}...")
+
     run_data, added_refs, skipped_refs, error_message = project_client.api_request_handler.append_run_references(
         run_id, refs
     )
@@ -221,9 +245,14 @@ def _handle_test_run_references(environment: Environment, run_id: int):
 
     final_refs = run_data.get("refs", "") if run_data else ""
 
+    result = {"run_id": run_id, "added": added_refs, "skipped": skipped_refs, "total_references": final_refs}
+
+    # Return result for accumulation (JSON mode with multiple runs)
+    if return_result:
+        return result
+
+    # Print/log result immediately (single run or console mode)
     if environment.json_output:
-        # JSON output
-        result = {"run_id": run_id, "added": added_refs, "skipped": skipped_refs, "total_references": final_refs}
         print(json.dumps(result, indent=2))
     else:
         environment.log(f"References appended successfully:")

--- a/trcli/commands/cmd_parse_junit.py
+++ b/trcli/commands/cmd_parse_junit.py
@@ -107,8 +107,11 @@ def cli(environment: Environment, context: click.Context, *args, **kwargs):
             run_id = multisuite_uploader.last_plan_id
         else:
             # Normal mode: process each suite separately
+            # Defer close_run if test_run_ref is provided to attach references first
+            defer_close = environment.test_run_ref is not None
+
             for suite in parsed_suites:
-                result_uploader = ResultsUploader(environment=environment, suite=suite)
+                result_uploader = ResultsUploader(environment=environment, suite=suite, defer_close_run=defer_close)
                 result_uploader.upload_results()
 
                 if run_id is None and hasattr(result_uploader, "last_run_id"):
@@ -118,8 +121,13 @@ def cli(environment: Environment, context: click.Context, *args, **kwargs):
                 if hasattr(result_uploader, "case_update_results"):
                     case_update_results = result_uploader.case_update_results
 
+        # Handle test run references BEFORE closing the run
         if environment.test_run_ref and run_id:
             _handle_test_run_references(environment, run_id)
+
+        # Close run after references are attached (if deferred and close_run flag is set)
+        if environment.close_run and environment.test_run_ref and run_id:
+            _close_test_run(environment, run_id)
 
         # Handle case update reporting if enabled
         if environment.update_existing_cases == "yes" and case_update_results is not None:
@@ -161,6 +169,24 @@ def _validate_test_run_ref(test_run_ref: str) -> str:
         return f"Error: --test-run-ref exceeds 250 character limit ({len(test_run_ref)} characters)"
 
     return None
+
+
+def _close_test_run(environment: Environment, run_id: int):
+    """
+    Close the test run.
+    """
+    from trcli.api.project_based_client import ProjectBasedClient
+    from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+    project_client = ProjectBasedClient(environment=environment, suite=TestRailSuite(name="temp", suite_id=1))
+    project_client.resolve_project()
+
+    environment.log("Closing test run. ", new_line=False)
+    response, error_message = project_client.api_request_handler.close_run(run_id)
+
+    if error_message:
+        environment.elog("\n" + error_message)
+        exit(1)
 
 
 def _handle_test_run_references(environment: Environment, run_id: int):

--- a/trcli/commands/cmd_results.py
+++ b/trcli/commands/cmd_results.py
@@ -228,7 +228,7 @@ def list(
 @click.option(
     "--custom-fields",
     metavar="",
-    help='Custom field values in JSON format (e.g., \'{"custom_field1": "value1"}\').',
+    help='Custom field values in JSON format (e.g., {"custom_field1": "value1"}).',
 )
 @click.pass_context
 @pass_environment

--- a/trcli/commands/cmd_variables.py
+++ b/trcli/commands/cmd_variables.py
@@ -41,7 +41,9 @@ def list(
     """List all variables for a project"""
     environment.check_for_required_parameters()
 
-    print_config(environment, "List")
+    # Skip log output when JSON output is requested (for clean JSON-only output)
+    if not json_output:
+        print_config(environment, "List")
 
     # Create ProjectBasedClient to resolve project
     project_client = ProjectBasedClient(
@@ -52,7 +54,8 @@ def list(
     # Resolve project (converts name to ID if needed)
     project_client.resolve_project()
 
-    environment.log(f"Retrieving variables for project ID {project_client.project.project_id}...")
+    if not json_output:
+        environment.log(f"Retrieving variables for project ID {project_client.project.project_id}...")
 
     # Retrieve variables
     response_data, error_message = project_client.api_request_handler.variables_handler.get_variables(
@@ -106,7 +109,9 @@ def add(
     """Create a new variable"""
     environment.check_for_required_parameters()
 
-    print_config(environment, "Add")
+    # Skip log output when JSON output is requested (for clean JSON-only output)
+    if not json_output:
+        print_config(environment, "Add")
 
     # Create ProjectBasedClient to resolve project
     project_client = ProjectBasedClient(
@@ -117,7 +122,8 @@ def add(
     # Resolve project (converts name to ID if needed)
     project_client.resolve_project()
 
-    environment.log(f"Creating variable '{name}' in project ID {project_client.project.project_id}...")
+    if not json_output:
+        environment.log(f"Creating variable '{name}' in project ID {project_client.project.project_id}...")
 
     # Create the variable
     variable, error_message = project_client.api_request_handler.variables_handler.add_variable(
@@ -158,9 +164,12 @@ def update(
     **kwargs,
 ):
     """Update an existing variable"""
+    environment.cmd = "variables_update"  # Use ID-based command (no project required)
     environment.check_for_required_parameters()
 
-    print_config(environment, "Update")
+    # Skip log output when JSON output is requested (for clean JSON-only output)
+    if not json_output:
+        print_config(environment, "Update")
 
     # Create ProjectBasedClient (needed for environment setup)
     project_client = ProjectBasedClient(
@@ -168,7 +177,8 @@ def update(
         suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
     )
 
-    environment.log(f"Updating variable ID {variable_id}...")
+    if not json_output:
+        environment.log(f"Updating variable ID {variable_id}...")
 
     # Update the variable
     variable, error_message = project_client.api_request_handler.variables_handler.update_variable(
@@ -208,6 +218,7 @@ def delete(
 
     Note: Deleting a variable will also delete corresponding values from datasets.
     """
+    environment.cmd = "variables_delete"  # Use ID-based command (no project required)
     environment.check_for_required_parameters()
 
     print_config(environment, "Delete")

--- a/trcli/commands/cmd_variables.py
+++ b/trcli/commands/cmd_variables.py
@@ -1,0 +1,233 @@
+import click
+import json
+
+from trcli.api.project_based_client import ProjectBasedClient
+from trcli.cli import pass_environment, CONTEXT_SETTINGS, Environment
+from trcli.data_classes.dataclass_testrail import TestRailSuite
+
+
+def print_config(env: Environment, action: str):
+    env.log(
+        f"Variables {action} Execution Parameters"
+        f"\n> TestRail instance: {env.host} (user: {env.username})"
+        f"\n> Project: {env.project if env.project else env.project_id}"
+    )
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.pass_context
+@pass_environment
+def cli(environment: Environment, context: click.Context, *args, **kwargs):
+    """Manage test data variables in TestRail"""
+    environment.cmd = "variables"
+    environment.set_parameters(context)
+
+
+@cli.command()
+@click.option("--offset", type=int, default=0, metavar="", help="Offset for pagination (default: 0).")
+@click.option("--limit", type=int, default=250, metavar="", help="Limit for pagination (default: 250).")
+@click.option("--json-output", is_flag=True, help="Output variables as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def list(
+    environment: Environment,
+    context: click.Context,
+    offset: int,
+    limit: int,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """List all variables for a project"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "List")
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    environment.log(f"Retrieving variables for project ID {project_client.project.project_id}...")
+
+    # Retrieve variables
+    response_data, error_message = project_client.api_request_handler.variables_handler.get_variables(
+        project_id=project_client.project.project_id,
+        limit=limit,
+        offset=offset,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to retrieve variables: {error_message}")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        print(json.dumps(response_data, indent=2))
+    else:
+        variables = response_data.get("variables", [])
+        response_offset = response_data.get("offset", 0)
+        response_size = response_data.get("size", 0)
+        next_link = response_data.get("_links", {}).get("next")
+
+        if not variables:
+            environment.log("No variables found.")
+        else:
+            environment.log(
+                f"Found {response_size} variable(s) (showing {response_offset + 1}-{response_offset + len(variables)}):"
+            )
+            if next_link:
+                environment.log("  (More results available - use --offset and --limit for pagination)")
+            environment.log("")
+
+            for variable in variables:
+                environment.log(f"  Variable ID: {variable.get('id', 'N/A')}")
+                environment.log(f"    Name: {variable.get('name', 'N/A')}")
+                environment.log("")
+
+
+@cli.command()
+@click.option("--name", type=str, required=True, metavar="<name>", help="Name of the variable (required).")
+@click.option("--json-output", is_flag=True, help="Output created variable as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def add(
+    environment: Environment,
+    context: click.Context,
+    name: str,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """Create a new variable"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Add")
+
+    # Create ProjectBasedClient to resolve project
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    # Resolve project (converts name to ID if needed)
+    project_client.resolve_project()
+
+    environment.log(f"Creating variable '{name}' in project ID {project_client.project.project_id}...")
+
+    # Create the variable
+    variable, error_message = project_client.api_request_handler.variables_handler.add_variable(
+        project_id=project_client.project.project_id,
+        name=name,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to create variable: {error_message}")
+        raise SystemExit(1)
+
+    if not variable or not variable.get("id"):
+        environment.elog("Error: Variable creation returned unexpected response")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        print(json.dumps(variable, indent=2))
+    else:
+        environment.log(f"\nVariable created successfully!")
+        environment.log(f"  Variable ID: {variable.get('id')}")
+        environment.log(f"  Name: {variable.get('name')}")
+
+
+@cli.command()
+@click.option("--variable-id", type=click.IntRange(min=1), required=True, metavar="<id>", help="Variable ID to update.")
+@click.option("--name", type=str, required=True, metavar="<name>", help="New name for the variable (required).")
+@click.option("--json-output", is_flag=True, help="Output updated variable as raw JSON from API.")
+@click.pass_context
+@pass_environment
+def update(
+    environment: Environment,
+    context: click.Context,
+    variable_id: int,
+    name: str,
+    json_output: bool,
+    *args,
+    **kwargs,
+):
+    """Update an existing variable"""
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Update")
+
+    # Create ProjectBasedClient (needed for environment setup)
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    environment.log(f"Updating variable ID {variable_id}...")
+
+    # Update the variable
+    variable, error_message = project_client.api_request_handler.variables_handler.update_variable(
+        variable_id=variable_id,
+        name=name,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to update variable: {error_message}")
+        raise SystemExit(1)
+
+    if not variable or not variable.get("id"):
+        environment.elog("Error: Variable update returned unexpected response")
+        raise SystemExit(1)
+
+    # Handle output format
+    if json_output:
+        print(json.dumps(variable, indent=2))
+    else:
+        environment.log(f"\nVariable updated successfully!")
+        environment.log(f"  Variable ID: {variable.get('id')}")
+        environment.log(f"  Name: {variable.get('name')}")
+
+
+@cli.command()
+@click.option("--variable-id", type=click.IntRange(min=1), required=True, metavar="<id>", help="Variable ID to delete.")
+@click.pass_context
+@pass_environment
+def delete(
+    environment: Environment,
+    context: click.Context,
+    variable_id: int,
+    *args,
+    **kwargs,
+):
+    """Delete a variable
+
+    Note: Deleting a variable will also delete corresponding values from datasets.
+    """
+    environment.check_for_required_parameters()
+
+    print_config(environment, "Delete")
+
+    # Create ProjectBasedClient (needed for environment setup)
+    project_client = ProjectBasedClient(
+        environment=environment,
+        suite=TestRailSuite(name=environment.suite_name, suite_id=environment.suite_id),
+    )
+
+    environment.log(f"Deleting variable ID {variable_id}...")
+
+    # Delete the variable
+    response, error_message = project_client.api_request_handler.variables_handler.delete_variable(
+        variable_id=variable_id,
+    )
+
+    if error_message:
+        environment.elog(f"Error: Failed to delete variable: {error_message}")
+        raise SystemExit(1)
+
+    environment.log(f"\nVariable ID {variable_id} deleted successfully.")
+    environment.log("Note: Corresponding values from datasets have also been deleted.")

--- a/trcli/constants.py
+++ b/trcli/constants.py
@@ -106,6 +106,8 @@ COMMAND_FAULT_MAPPING = dict(
     projects=dict(**FAULT_MAPPING),
     templates=dict(**FAULT_MAPPING),
     tests=dict(**FAULT_MAPPING),
+    variables=dict(**FAULT_MAPPING),
+    datasets=dict(**FAULT_MAPPING),
 )
 
 PROMPT_MESSAGES = dict(
@@ -148,7 +150,9 @@ TOOL_USAGE = f"""Supported and loaded modules:
     - projects: Query projects (get and list)
     - templates: Query templates (list)
     - tests: Query tests (get and list)
-    - results: Query and update test results (list, update)"""
+    - results: Query and update test results (list, update)
+    - variables: Manage test data variables (list, add, update, delete)
+    - datasets: Manage test data datasets (list, show, add, update, delete)"""
 
 MISSING_COMMAND_SLOGAN = """Usage: trcli [OPTIONS] COMMAND [ARGS]...\nTry 'trcli --help' for help.
 \nError: Missing command."""

--- a/trcli/constants.py
+++ b/trcli/constants.py
@@ -108,6 +108,11 @@ COMMAND_FAULT_MAPPING = dict(
     tests=dict(**FAULT_MAPPING),
     variables=dict(**FAULT_MAPPING),
     datasets=dict(**FAULT_MAPPING),
+    variables_update=dict(**{k: v for k, v in FAULT_MAPPING.items() if k != "missing_project"}),
+    variables_delete=dict(**{k: v for k, v in FAULT_MAPPING.items() if k != "missing_project"}),
+    datasets_show=dict(**{k: v for k, v in FAULT_MAPPING.items() if k != "missing_project"}),
+    datasets_update=dict(**{k: v for k, v in FAULT_MAPPING.items() if k != "missing_project"}),
+    datasets_delete=dict(**{k: v for k, v in FAULT_MAPPING.items() if k != "missing_project"}),
 )
 
 PROMPT_MESSAGES = dict(


### PR DESCRIPTION
### Solution description
There is an issue where references are not correctly appended to runs when using --close-run option with --test-run-ref.

### Changes
Defer the close_run operation when --test-run-ref is present, allowing references to be attached first.

### Potential impacts
None

### Steps to test
Parse a sample junit file and use --test-run-ref and --close-run together. There should be no error and references are added to the run correctly.

### PR Tasks
- [ ] PR reference added to issue
- [ ] README updated
- [ ] Unit tests added/updated
